### PR TITLE
Update GH action to use new consolidated repo for integration tests

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -43,17 +43,16 @@ jobs:
       - name: Checkout Integration Test Repo
         uses: actions/checkout@v3
         with:
-          repository: teamforage/forage-android-sdk-QA-automation
+          repository: teamforage/mobile-qa-tests
           ref: main
-          ssh-key: ${{ secrets.ANDROID_QA_CHECKOUT_KEY }}
-          path: 'integration_tests/'
+          ssh-key: ${{ secrets.MOBILE_QA_DEPLOY_KEY }}
+          path: 'mobile-qa-tests/'
 
       - name: Run Integration tests
         run: |
-          cd integration_tests
+          cd mobile-qa-tests
           pip install -r requirements.txt
-          pytest
-          pytest --lf --last-failed-no-failures none  --suppress-no-test-exit-code
+          pytest android/tests/test_basic_flow.py
 
       - name: Upload build outputs (APKs and SDK AARs)
         uses: actions/upload-artifact@v3

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -48,7 +48,7 @@ jobs:
           ssh-key: ${{ secrets.MOBILE_QA_DEPLOY_KEY }}
           path: 'mobile-qa-tests/'
 
-      - name: Run Integration tests
+      - name: Run Integration Tests
         run: |
           cd mobile-qa-tests
           pip install -r requirements.txt


### PR DESCRIPTION
# Description
Updating the Integration Test to refer to the [mobile-qa-tests](https://github.com/teamforage/mobile-qa-tests) repo and run the android sdk qa tests that are found in that repo.

## Tests Added / Updated?
- NO - updating a github action

## Screenshots