### PR TITLE
Fix broken script

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -53,6 +53,7 @@ jobs:
           cd mobile-qa-tests
           pip install -r requirements.txt
           pytest android/tests/test_basic_flow.py
+          pytest --lf --last-failed-no-failures none  --suppress-no-test-exit-code android/tests/test_basic_flow.py
 
       - name: Upload build outputs (APKs and SDK AARs)
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
# Description
The retry logic was removed from the github action that ran QA tests in this repo. These tests aren't the most resilient, so the retry logic is often necessary to get them to complete. I looked through a few of the past failed runs and many of them failed because 1 random test had an issue. This should fix our problems.