### PR TITLE
Danny/fx 252 implement token parser and expect 2 encryption aliases

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
@@ -4,10 +4,10 @@ import com.basistheory.android.service.BasisTheoryElements
 import com.basistheory.android.service.ProxyRequest
 import com.joinforage.forage.android.BuildConfig
 import com.joinforage.forage.android.model.EncryptionKey
+import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.model.ForageApiError
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
-import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.ui.ForagePINEditText
 import org.json.JSONException
 import java.util.*

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
@@ -3,7 +3,7 @@ package com.joinforage.forage.android.collect
 import com.basistheory.android.service.BasisTheoryElements
 import com.basistheory.android.service.ProxyRequest
 import com.joinforage.forage.android.BuildConfig
-import com.joinforage.forage.android.model.EncryptionKey
+import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.model.ForageApiError
 import com.joinforage.forage.android.network.model.ForageApiResponse
@@ -132,7 +132,7 @@ internal class BTPinCollector(
         )
     }
 
-    override fun parseEncryptionKey(encryptionKeys: EncryptionKey): String {
+    override fun parseEncryptionKey(encryptionKeys: EncryptionKeys): String {
         return encryptionKeys.btAlias
     }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/PinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/PinCollector.kt
@@ -1,8 +1,8 @@
 package com.joinforage.forage.android.collect
 
 import com.joinforage.forage.android.model.EncryptionKey
-import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.model.PaymentMethod
+import com.joinforage.forage.android.network.model.ForageApiResponse
 
 internal object CollectorConstants {
     const val TOKEN_DELIMITER = ","

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/PinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/PinCollector.kt
@@ -1,6 +1,6 @@
 package com.joinforage.forage.android.collect
 
-import com.joinforage.forage.android.model.EncryptionKey
+import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.model.ForageApiResponse
 
@@ -22,7 +22,7 @@ internal interface PinCollector {
     ): ForageApiResponse<String>
 
     fun parseEncryptionKey(
-        encryptionKeys: EncryptionKey
+        encryptionKeys: EncryptionKeys
     ): String
 
     fun parseVaultToken(

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/PinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/PinCollector.kt
@@ -1,6 +1,12 @@
 package com.joinforage.forage.android.collect
 
+import com.joinforage.forage.android.model.EncryptionKey
 import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.model.PaymentMethod
+
+internal object CollectorConstants {
+    const val TOKEN_DELIMITER = ","
+}
 
 internal interface PinCollector {
     suspend fun collectPinForBalanceCheck(
@@ -14,4 +20,12 @@ internal interface PinCollector {
         cardToken: String,
         encryptionKey: String
     ): ForageApiResponse<String>
+
+    fun parseEncryptionKey(
+        encryptionKeys: EncryptionKey
+    ): String
+
+    fun parseVaultToken(
+        paymentMethod: PaymentMethod
+    ): String
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
@@ -3,10 +3,10 @@ package com.joinforage.forage.android.collect
 import android.content.Context
 import com.joinforage.forage.android.BuildConfig
 import com.joinforage.forage.android.model.EncryptionKey
+import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.ForageConstants
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
-import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.ui.ForagePINEditText
 import com.verygoodsecurity.vgscollect.VGSCollectLogger
 import com.verygoodsecurity.vgscollect.core.HTTPMethod

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
@@ -2,7 +2,7 @@ package com.joinforage.forage.android.collect
 
 import android.content.Context
 import com.joinforage.forage.android.BuildConfig
-import com.joinforage.forage.android.model.EncryptionKey
+import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.ForageConstants
 import com.joinforage.forage.android.network.model.ForageApiResponse
@@ -123,7 +123,7 @@ internal class VGSPinCollector(
         vgsCollect.asyncSubmit(request)
     }
 
-    override fun parseEncryptionKey(encryptionKeys: EncryptionKey): String {
+    override fun parseEncryptionKey(encryptionKeys: EncryptionKeys): String {
         return encryptionKeys.vgsAlias
     }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
@@ -2,9 +2,11 @@ package com.joinforage.forage.android.collect
 
 import android.content.Context
 import com.joinforage.forage.android.BuildConfig
+import com.joinforage.forage.android.model.EncryptionKey
 import com.joinforage.forage.android.network.ForageConstants
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
+import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.ui.ForagePINEditText
 import com.verygoodsecurity.vgscollect.VGSCollectLogger
 import com.verygoodsecurity.vgscollect.core.HTTPMethod
@@ -119,6 +121,18 @@ internal class VGSPinCollector(
             .build()
 
         vgsCollect.asyncSubmit(request)
+    }
+
+    override fun parseEncryptionKey(encryptionKeys: EncryptionKey): String {
+        return encryptionKeys.vgsAlias
+    }
+
+    override fun parseVaultToken(paymentMethod: PaymentMethod): String {
+        val token = paymentMethod.card.token
+        if (token.contains(CollectorConstants.TOKEN_DELIMITER)) {
+            return token.split(CollectorConstants.TOKEN_DELIMITER)[0]
+        }
+        return token
     }
 
     companion object {

--- a/forage-android/src/main/java/com/joinforage/forage/android/model/EncryptionKey.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/model/EncryptionKey.kt
@@ -3,14 +3,19 @@ package com.joinforage.forage.android.model
 import org.json.JSONObject
 
 internal data class EncryptionKey(
-    val alias: String
+    val vgsAlias: String,
+    val btAlias: String
 ) {
     object ModelMapper {
         fun from(string: String): EncryptionKey {
             val jsonObject = JSONObject(string)
 
-            val alias = jsonObject.getString("alias")
-            return EncryptionKey(alias)
+            val vgsAlias = jsonObject.getString("alias")
+            val btAlias = jsonObject.getString("bt_alias")
+            return EncryptionKey(
+                vgsAlias = vgsAlias,
+                btAlias = btAlias
+            )
         }
     }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/model/EncryptionKeys.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/model/EncryptionKeys.kt
@@ -2,17 +2,17 @@ package com.joinforage.forage.android.model
 
 import org.json.JSONObject
 
-internal data class EncryptionKey(
+internal data class EncryptionKeys(
     val vgsAlias: String,
     val btAlias: String
 ) {
     object ModelMapper {
-        fun from(string: String): EncryptionKey {
+        fun from(string: String): EncryptionKeys {
             val jsonObject = JSONObject(string)
 
             val vgsAlias = jsonObject.getString("alias")
             val btAlias = jsonObject.getString("bt_alias")
-            return EncryptionKey(
+            return EncryptionKeys(
                 vgsAlias = vgsAlias,
                 btAlias = btAlias
             )

--- a/forage-android/src/main/java/com/joinforage/forage/android/model/PaymentMethod.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/model/PaymentMethod.kt
@@ -1,4 +1,4 @@
-package com.joinforage.forage.android.network.model
+package com.joinforage.forage.android.model
 import org.json.JSONObject
 
 internal data class Card(
@@ -35,7 +35,7 @@ internal data class PaymentMethod(
     val type: String,
     val customerId: String,
     val balance: Balance?,
-    val card: Card?
+    val card: Card
 ) {
     object ModelMapper {
         fun from(string: String): PaymentMethod {

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
@@ -2,7 +2,7 @@ package com.joinforage.forage.android.network.data
 
 import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.core.Logger
-import com.joinforage.forage.android.model.EncryptionKey
+import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.model.Payment
 import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.EncryptionKeyService
@@ -27,7 +27,7 @@ internal class CapturePaymentRepository(
             is ForageApiResponse.Success -> getPaymentMethodFromPayment(
                 paymentRef = paymentRef,
                 pinCollector.parseEncryptionKey(
-                    EncryptionKey.ModelMapper.from(response.data)
+                    EncryptionKeys.ModelMapper.from(response.data)
                 )
             )
             else -> response

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
@@ -11,7 +11,7 @@ import com.joinforage.forage.android.network.PaymentService
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.network.model.Message
-import com.joinforage.forage.android.network.model.PaymentMethod
+import com.joinforage.forage.android.model.PaymentMethod
 import kotlinx.coroutines.delay
 
 internal class CapturePaymentRepository(
@@ -26,7 +26,9 @@ internal class CapturePaymentRepository(
         return when (val response = encryptionKeyService.getEncryptionKey()) {
             is ForageApiResponse.Success -> getPaymentMethodFromPayment(
                 paymentRef = paymentRef,
-                EncryptionKey.ModelMapper.from(response.data).alias
+                pinCollector.parseEncryptionKey(
+                    EncryptionKey.ModelMapper.from(response.data)
+                )
             )
             else -> response
         }
@@ -39,7 +41,6 @@ internal class CapturePaymentRepository(
         return when (val response = paymentService.getPayment(paymentRef)) {
             is ForageApiResponse.Success -> getTokenFromPaymentMethod(
                 paymentRef = paymentRef,
-                // TODO: Parse the token to get BT or VGS
                 paymentMethodRef = Payment.ModelMapper.from(response.data).paymentMethod,
                 encryptionKey = encryptionKey
             )
@@ -55,7 +56,7 @@ internal class CapturePaymentRepository(
         return when (val response = paymentMethodService.getPaymentMethod(paymentMethodRef)) {
             is ForageApiResponse.Success -> collectPinToCapturePayment(
                 paymentRef = paymentRef,
-                cardToken = PaymentMethod.ModelMapper.from(response.data).card?.token ?: "",
+                cardToken = pinCollector.parseVaultToken(PaymentMethod.ModelMapper.from(response.data)),
                 encryptionKey = encryptionKey
             )
             else -> response

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
@@ -4,6 +4,7 @@ import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.core.Logger
 import com.joinforage.forage.android.model.EncryptionKey
 import com.joinforage.forage.android.model.Payment
+import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.EncryptionKeyService
 import com.joinforage.forage.android.network.MessageStatusService
 import com.joinforage.forage.android.network.PaymentMethodService
@@ -11,7 +12,6 @@ import com.joinforage.forage.android.network.PaymentService
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.network.model.Message
-import com.joinforage.forage.android.model.PaymentMethod
 import kotlinx.coroutines.delay
 
 internal class CapturePaymentRepository(

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
@@ -3,13 +3,13 @@ package com.joinforage.forage.android.network.data
 import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.core.Logger
 import com.joinforage.forage.android.model.EncryptionKey
+import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.EncryptionKeyService
 import com.joinforage.forage.android.network.MessageStatusService
 import com.joinforage.forage.android.network.PaymentMethodService
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.network.model.Message
-import com.joinforage.forage.android.model.PaymentMethod
 import kotlinx.coroutines.delay
 
 internal class CheckBalanceRepository(

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
@@ -9,7 +9,7 @@ import com.joinforage.forage.android.network.PaymentMethodService
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.network.model.Message
-import com.joinforage.forage.android.network.model.PaymentMethod
+import com.joinforage.forage.android.model.PaymentMethod
 import kotlinx.coroutines.delay
 
 internal class CheckBalanceRepository(
@@ -25,7 +25,9 @@ internal class CheckBalanceRepository(
         return when (val response = encryptionKeyService.getEncryptionKey()) {
             is ForageApiResponse.Success -> getTokenFromPaymentMethod(
                 paymentMethodRef = paymentMethodRef,
-                EncryptionKey.ModelMapper.from(response.data).alias
+                pinCollector.parseEncryptionKey(
+                    EncryptionKey.ModelMapper.from(response.data)
+                )
             )
             else -> response
         }
@@ -38,8 +40,7 @@ internal class CheckBalanceRepository(
         return when (val response = paymentMethodService.getPaymentMethod(paymentMethodRef)) {
             is ForageApiResponse.Success -> collectPinToCheckBalance(
                 paymentMethodRef = paymentMethodRef,
-                // TODO: Parse the token to get BT or VGS
-                cardToken = PaymentMethod.ModelMapper.from(response.data).card?.token ?: "",
+                cardToken = pinCollector.parseVaultToken(PaymentMethod.ModelMapper.from(response.data)),
                 encryptionKey = encryptionKey
             )
             else -> response

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
@@ -2,7 +2,7 @@ package com.joinforage.forage.android.network.data
 
 import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.core.Logger
-import com.joinforage.forage.android.model.EncryptionKey
+import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.EncryptionKeyService
 import com.joinforage.forage.android.network.MessageStatusService
@@ -26,7 +26,7 @@ internal class CheckBalanceRepository(
             is ForageApiResponse.Success -> getTokenFromPaymentMethod(
                 paymentMethodRef = paymentMethodRef,
                 pinCollector.parseEncryptionKey(
-                    EncryptionKey.ModelMapper.from(response.data)
+                    EncryptionKeys.ModelMapper.from(response.data)
                 )
             )
             else -> response

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/EncryptionKeyServiceTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/EncryptionKeyServiceTest.kt
@@ -57,7 +57,7 @@ class EncryptionKeyServiceTest : MockServerSuite() {
             val successResponse = response as ForageApiResponse.Success
 
             val encryptionKey = EncryptionKey.ModelMapper.from(successResponse.data)
-            assertThat(encryptionKey).isEqualTo(EncryptionKey(alias = "tok_sandbox_eZeWfkq1AkqYdiAJC8iweE"))
+            assertThat(encryptionKey).isEqualTo(EncryptionKey(vgsAlias = "tok_sandbox_eZeWfkq1AkqYdiAJC8iweE", btAlias = "fake-bt-alias"))
         }
 
     @Test

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/EncryptionKeyServiceTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/EncryptionKeyServiceTest.kt
@@ -3,7 +3,7 @@ package com.joinforage.forage.android.network
 import com.joinforage.forage.android.fixtures.givenEncryptionKey
 import com.joinforage.forage.android.fixtures.returnsEncryptionKeySuccessfully
 import com.joinforage.forage.android.fixtures.returnsUnauthorizedEncryptionKey
-import com.joinforage.forage.android.model.EncryptionKey
+import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -56,8 +56,8 @@ class EncryptionKeyServiceTest : MockServerSuite() {
             assertThat(response).isExactlyInstanceOf(ForageApiResponse.Success::class.java)
             val successResponse = response as ForageApiResponse.Success
 
-            val encryptionKey = EncryptionKey.ModelMapper.from(successResponse.data)
-            assertThat(encryptionKey).isEqualTo(EncryptionKey(vgsAlias = "tok_sandbox_eZeWfkq1AkqYdiAJC8iweE", btAlias = "fake-bt-alias"))
+            val encryptionKey = EncryptionKeys.ModelMapper.from(successResponse.data)
+            assertThat(encryptionKey).isEqualTo(EncryptionKeys(vgsAlias = "tok_sandbox_eZeWfkq1AkqYdiAJC8iweE", btAlias = "fake-bt-alias"))
         }
 
     @Test

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/TokenizeCardServiceTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/TokenizeCardServiceTest.kt
@@ -4,9 +4,9 @@ import com.joinforage.forage.android.fixtures.givenCardToken
 import com.joinforage.forage.android.fixtures.returnsPaymentMethodFailed
 import com.joinforage.forage.android.fixtures.returnsPaymentMethodSuccessfully
 import com.joinforage.forage.android.model.Card
+import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
-import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.model.PaymentMethodRequestBody
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/TokenizeCardServiceTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/TokenizeCardServiceTest.kt
@@ -3,10 +3,10 @@ package com.joinforage.forage.android.network
 import com.joinforage.forage.android.fixtures.givenCardToken
 import com.joinforage.forage.android.fixtures.returnsPaymentMethodFailed
 import com.joinforage.forage.android.fixtures.returnsPaymentMethodSuccessfully
-import com.joinforage.forage.android.network.model.Card
+import com.joinforage.forage.android.model.Card
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
-import com.joinforage.forage.android.network.model.PaymentMethod
+import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.model.PaymentMethodRequestBody
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/CheckBalanceRepositoryTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/CheckBalanceRepositoryTest.kt
@@ -12,12 +12,12 @@ import com.joinforage.forage.android.fixtures.returnsPaymentMethodWithBalance
 import com.joinforage.forage.android.fixtures.returnsSendToProxy
 import com.joinforage.forage.android.fixtures.returnsUnauthorized
 import com.joinforage.forage.android.fixtures.returnsUnauthorizedEncryptionKey
+import com.joinforage.forage.android.model.Balance
 import com.joinforage.forage.android.model.Message
 import com.joinforage.forage.android.network.EncryptionKeyService
 import com.joinforage.forage.android.network.MessageStatusService
 import com.joinforage.forage.android.network.OkHttpClientBuilder
 import com.joinforage.forage.android.network.PaymentMethodService
-import com.joinforage.forage.android.model.Balance
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/CheckBalanceRepositoryTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/CheckBalanceRepositoryTest.kt
@@ -17,7 +17,7 @@ import com.joinforage.forage.android.network.EncryptionKeyService
 import com.joinforage.forage.android.network.MessageStatusService
 import com.joinforage.forage.android.network.OkHttpClientBuilder
 import com.joinforage.forage.android.network.PaymentMethodService
-import com.joinforage.forage.android.network.model.Balance
+import com.joinforage.forage.android.model.Balance
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/TestPinCollector.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/TestPinCollector.kt
@@ -2,7 +2,7 @@ package com.joinforage.forage.android.network.data
 
 import com.joinforage.forage.android.collect.CollectorConstants
 import com.joinforage.forage.android.collect.PinCollector
-import com.joinforage.forage.android.model.EncryptionKey
+import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
@@ -46,7 +46,7 @@ internal class TestPinCollector : PinCollector {
         )
     }
 
-    override fun parseEncryptionKey(encryptionKeys: EncryptionKey): String {
+    override fun parseEncryptionKey(encryptionKeys: EncryptionKeys): String {
         return encryptionKeys.vgsAlias
     }
 

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/TestPinCollector.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/TestPinCollector.kt
@@ -1,13 +1,16 @@
 package com.joinforage.forage.android.network.data
 
+import com.joinforage.forage.android.collect.CollectorConstants
 import com.joinforage.forage.android.collect.PinCollector
+import com.joinforage.forage.android.model.EncryptionKey
+import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 
 /**
  * Fake test implementation of PinCollector that could be used to replace VGS on tests
  */
-class TestPinCollector : PinCollector {
+internal class TestPinCollector : PinCollector {
     private var collectPinForBalanceCheckResponses =
         HashMap<CheckBalanceWrapper, ForageApiResponse<String>>()
     private var collectPinForCapturePaymentResponses =
@@ -41,6 +44,18 @@ class TestPinCollector : PinCollector {
             ),
             ForageApiResponse.Failure(listOf(ForageError(500, "unknown_server_error", "Unknown Server Error")))
         )
+    }
+
+    override fun parseEncryptionKey(encryptionKeys: EncryptionKey): String {
+        return encryptionKeys.vgsAlias
+    }
+
+    override fun parseVaultToken(paymentMethod: PaymentMethod): String {
+        val token = paymentMethod.card.token
+        if (token.contains(CollectorConstants.TOKEN_DELIMITER)) {
+            return token.split(CollectorConstants.TOKEN_DELIMITER)[0]
+        }
+        return token
     }
 
     fun setCollectPinForBalanceCheckResponse(

--- a/forage-android/src/test/resources/fixtures/encryption/key/successful_get_encryption_key.json
+++ b/forage-android/src/test/resources/fixtures/encryption/key/successful_get_encryption_key.json
@@ -1,3 +1,4 @@
 {
-  "alias": "tok_sandbox_eZeWfkq1AkqYdiAJC8iweE"
+  "alias": "tok_sandbox_eZeWfkq1AkqYdiAJC8iweE",
+  "bt_alias": "fake-bt-alias"
 }


### PR DESCRIPTION
# Description
Dynamically select the correct `encryption_alias` based on the vault provider and include token parser functions that can accept the current token implementation and the new one. The token parser functions are important because in order to release BT, we need to first release the backend changes and all clients should be able to accept the old and new implementations.