### PR TITLE
[FX-268] Add optional reusable param to tokenizeCard

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ The ForageSDK exposes the following function to collect the EBT card number:
     suspend fun tokenizeEBTCard(
         merchantAccount: String,
         bearerToken: String,
-        customerId: String
+        customerId: String,
+        reusable: Boolean = true
     ): ForageApiResponse<String>
 ```
 
@@ -260,6 +261,7 @@ The ForageSDK exposes the following function to collect the EBT card number:
 - `merchantAccount`: A unique seven digit numeric string that [FNS](https://docs.joinforage.app/docs/ebt-online-101#food-and-nutrition-service-fns) issues to authorized EBT merchants.
 - `bearerToken`: A [session token](https://docs.joinforage.app/reference/create-session-token) that authenticates front-end requests to Forage. To create one, send a server-side request from your backend to the `/session_token/` endpoint.
 - `customerId`: A unique ID for the end customer making the payment. If you use your internal customer ID, then we recommend that you hash the value before sending it on the payload.
+- `reusable`: An optional boolean value indicating whether the same card can be used to make multiple payments, set to true by default.
 
 #### Example
 
@@ -274,7 +276,8 @@ This is an example of usage inside an ACC ViewModel:
             bearerToken = bearer,
             // NOTE: The following line is for testing purposes only and should not be used in production.
             // Please replace this line with a real hashed customer ID value.
-            customerId = UUID.randomUUID().toString()
+            customerId = UUID.randomUUID().toString(),
+            reusable = true
         )
 
         when (response) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ForageSDK.kt
@@ -27,7 +27,8 @@ object ForageSDK : ForageSDKApi {
     override suspend fun tokenizeEBTCard(
         merchantAccount: String,
         bearerToken: String,
-        customerId: String
+        customerId: String,
+        reusable: Boolean
     ): ForageApiResponse<String> {
         val currentEntry = panEntry
 
@@ -41,7 +42,8 @@ object ForageSDK : ForageSDKApi {
                 httpUrl = ForageConstants.provideHttpUrl()
             ).tokenizeCard(
                 cardNumber = currentEntry.getPanNumber(),
-                customerId = customerId
+                customerId = customerId,
+                reusable = reusable
             )
             else -> ForageApiResponse.Failure(listOf(ForageError(400, "invalid_input_data", "Invalid PAN entry")))
         }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ForageSDKApi.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ForageSDKApi.kt
@@ -11,7 +11,8 @@ internal interface ForageSDKApi {
     suspend fun tokenizeEBTCard(
         merchantAccount: String,
         bearerToken: String,
-        customerId: String
+        customerId: String,
+        reusable: Boolean = true
     ): ForageApiResponse<String>
 
     suspend fun checkBalance(

--- a/forage-android/src/main/java/com/joinforage/forage/android/model/PaymentMethod.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/model/PaymentMethod.kt
@@ -35,7 +35,8 @@ internal data class PaymentMethod(
     val type: String,
     val customerId: String,
     val balance: Balance?,
-    val card: Card
+    val card: Card,
+    val reusable: Boolean?
 ) {
     object ModelMapper {
         fun from(string: String): PaymentMethod {
@@ -59,6 +60,11 @@ internal data class PaymentMethod(
             val last4 = card.getString("last_4")
             val token = card.getString("token")
 
+            var reusable: Boolean? = true
+            if (!jsonObject.isNull("reusable")) {
+                reusable = jsonObject.getBoolean("reusable")
+            }
+
             return PaymentMethod(
                 ref = ref,
                 type = type,
@@ -68,7 +74,8 @@ internal data class PaymentMethod(
                     type = "",
                     token = token
                 ),
-                customerId = customerId
+                customerId = customerId,
+                reusable = reusable
             )
         }
     }

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/TokenizeCardService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/TokenizeCardService.kt
@@ -16,17 +16,17 @@ internal class TokenizeCardService(
     private val httpUrl: HttpUrl,
     okHttpClient: OkHttpClient
 ) : NetworkService(okHttpClient) {
-    suspend fun tokenizeCard(cardNumber: String, customerId: String): ForageApiResponse<String> = try {
-        tokenizeCardCoroutine(cardNumber, customerId)
+    suspend fun tokenizeCard(cardNumber: String, customerId: String, reusable: Boolean = true): ForageApiResponse<String> = try {
+        tokenizeCardCoroutine(cardNumber, customerId, reusable)
     } catch (ex: IOException) {
         ForageApiResponse.Failure(listOf(ForageError(500, "unknown_server_error", ex.message.orEmpty())))
     }
 
-    private suspend fun tokenizeCardCoroutine(cardNumber: String, customerId: String): ForageApiResponse<String> {
+    private suspend fun tokenizeCardCoroutine(cardNumber: String, customerId: String, reusable: Boolean): ForageApiResponse<String> {
         val url = getTokenizeCardUrl()
 
         val requestBody =
-            PaymentMethodRequestBody(cardNumber = cardNumber, customerId = customerId).toJSONObject().toString()
+            PaymentMethodRequestBody(cardNumber = cardNumber, customerId = customerId, reusable = reusable).toJSONObject().toString()
 
         val body: RequestBody =
             requestBody.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())

--- a/forage-android/src/test/java/com/joinforage/forage/android/fixtures/CreatePaymentMethodFixtures.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/fixtures/CreatePaymentMethodFixtures.kt
@@ -9,12 +9,12 @@ import me.jorgecastillo.hiroaki.models.success
 import me.jorgecastillo.hiroaki.whenever
 import okhttp3.mockwebserver.MockWebServer
 
-fun MockWebServer.givenCardToken(cardNumber: String, customerId: String) = whenever(
+fun MockWebServer.givenCardToken(cardNumber: String, customerId: String, reusable: Boolean = true) = whenever(
     method = Method.POST,
     sentToPath = "api/payment_methods/",
     jsonBody = json {
         "type" / "ebt"
-        "reusable" / true
+        "reusable" / reusable
         "card" / json {
             "number" / cardNumber
         }
@@ -26,6 +26,14 @@ fun PotentialRequestChain.returnsPaymentMethodSuccessfully() = thenRespond(
     success(
         jsonBody = fileBody(
             "fixtures/payment/methods/successful_create_payment_method.json"
+        )
+    )
+)
+
+fun PotentialRequestChain.returnsNonReusablePaymentMethodSuccessfully() = thenRespond(
+    success(
+        jsonBody = fileBody(
+            "fixtures/payment/methods/successful_create_nonreusable_payment_method.json"
         )
     )
 )

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/TokenizeCardServiceTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/TokenizeCardServiceTest.kt
@@ -1,6 +1,7 @@
 package com.joinforage.forage.android.network
 
 import com.joinforage.forage.android.fixtures.givenCardToken
+import com.joinforage.forage.android.fixtures.returnsNonReusablePaymentMethodSuccessfully
 import com.joinforage.forage.android.fixtures.returnsPaymentMethodFailed
 import com.joinforage.forage.android.fixtures.returnsPaymentMethodSuccessfully
 import com.joinforage.forage.android.model.Card
@@ -78,9 +79,45 @@ class TokenizeCardServiceTest : MockServerSuite() {
                     last4 = "7845",
                     token = "tok_sandbox_sYiPe9Q249qQ5wQyUPP5f7"
                 ),
-                customerId = "test-android-customer-id"
+                customerId = "test-android-customer-id",
+                reusable = true
             )
         )
+    }
+
+    @Test
+    fun `it should handle the reusable parameter when provided`() = runTest {
+        val testCustomerId = UUID.randomUUID().toString()
+        val reusable = false
+        server.givenCardToken(testData.cardNumber, testCustomerId, reusable).returnsNonReusablePaymentMethodSuccessfully()
+
+        val paymentMethodResponse = tokenizeCardService.tokenizeCard(testData.cardNumber, testCustomerId, reusable)
+        assertThat(paymentMethodResponse).isExactlyInstanceOf(ForageApiResponse.Success::class.java)
+
+        val response =
+            PaymentMethod.ModelMapper.from((paymentMethodResponse as ForageApiResponse.Success).data)
+        assertThat(response).isEqualTo(
+            PaymentMethod(
+                ref = "1f148fe399",
+                type = "ebt",
+                balance = null,
+                card = Card(
+                    last4 = "7845",
+                    token = "tok_sandbox_sYiPe9Q249qQ5wQyUPP5f7"
+                ),
+                customerId = "test-android-customer-id",
+                reusable = false
+            )
+        )
+    }
+
+    @Test
+    fun `it should handle the absence of reusable parameter`() = runTest {
+        val testCustomerId = UUID.randomUUID().toString()
+        server.givenCardToken(testData.cardNumber, testCustomerId).returnsPaymentMethodSuccessfully()
+
+        val paymentMethodResponse = tokenizeCardService.tokenizeCard(testData.cardNumber, testCustomerId)
+        assertThat(paymentMethodResponse).isExactlyInstanceOf(ForageApiResponse.Success::class.java)
     }
 
     @Test
@@ -101,6 +138,7 @@ class TokenizeCardServiceTest : MockServerSuite() {
         val bearerToken: String = "AbCaccesstokenXyz",
         val cardNumber: String = "5076801234567845",
         val customerId: String = "test-android-customer-id",
+        val reusable: Boolean = false,
         val paymentMethodRequestBody: PaymentMethodRequestBody = PaymentMethodRequestBody(cardNumber = cardNumber, customerId = customerId)
     )
 }

--- a/forage-android/src/test/resources/fixtures/payment/methods/successful_create_nonreusable_payment_method.json
+++ b/forage-android/src/test/resources/fixtures/payment/methods/successful_create_nonreusable_payment_method.json
@@ -9,5 +9,5 @@
     "state": "PA"
   },
   "customer_id": "test-android-customer-id",
-  "reusable": true
+  "reusable": false
 }


### PR DESCRIPTION
As described in [this](https://linear.app/joinforage/issue/FX-268/android-add-the-reusable-flag-to-post-payment-method-endpoint) ticket, adding optional reusable param to tokenizeCard calls. Reusable will be set to true by default, maintaining the current behavior.

## Tests Added / Updated
Added test to validate successful response with or without param

NOTE: Calls to tokenize card should now be returning `reusable` as well (see [here](https://linear.app/joinforage/issue/COR-341/include-reusable-in-response-from-createpaymentmethod-view)), so we should update `PaymentMethod` as well as all the fixtures to include that param, but not sure if that falls within the scope of this diff:
```
val response =
            PaymentMethod.ModelMapper.from((paymentMethodResponse as ForageApiResponse.Success).data)
        assertThat(response).isEqualTo(
            PaymentMethod(
                ref = "1f148fe399",
                type = "ebt",
                balance = null,
                card = Card(
                    last4 = "7845",
                    token = "tok_sandbox_sYiPe9Q249qQ5wQyUPP5f7"
                ),
                customerId = "test-android-customer-id",
               // SHOULD HAVE reusable
            )
        )
```


## Screenshots