### PR TITLE
Expose focus method on ForagePINEditText

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
@@ -104,4 +104,8 @@ internal class BTVaultWrapper @JvmOverloads constructor(
     override fun setHintTextColor(hintTextColor: Int) {
         _internalTextElement.hintTextColor = hintTextColor
     }
+
+    override fun focus() {
+        _internalTextElement.requestFocus()
+    }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -75,4 +75,9 @@ class ForagePINEditText @JvmOverloads constructor(
     override fun setHintTextColor(hintTextColor: Int) {
         vault?.setHintTextColor(hintTextColor)
     }
+
+    fun focus() {
+        vault?.focus()
+    }
+
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
@@ -117,4 +117,8 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
     override fun setHintTextColor(hintTextColor: Int) {
         _internalEditText.setHintTextColor(hintTextColor)
     }
+
+    override fun focus() {
+        _internalEditText.requestFocus()
+    }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
@@ -26,6 +26,8 @@ abstract class VaultWrapper @JvmOverloads constructor(
     abstract fun getVGSEditText(): VGSEditText
     abstract fun getTextElement(): TextElement
 
+    abstract fun focus()
+
     fun getThemeAccentColor(context: Context): Int {
         val outValue = TypedValue()
         context.theme.resolveAttribute(android.R.attr.colorAccent, outValue, true)


### PR DESCRIPTION
# Description
The fastest way I could think of to expose focus functionality on Android SDK.

## Next Steps for this PR
- [ ] Fix linting errors
- [ ] Test out this functionality manually on local machine
- [ ] Investigate if possible to call method [`requestFocus` like we discussed](https://www.notion.so/joinforage/Android-SDK-Listening-to-Observing-Input-Element-Design-Proposal-33db09c439ba4db0ac76231caaba418b?pvs=4#b8cc348dd83c4d4a9d492f84fd3cf0c6) instead of `focus`.
- [ ] change this to implement ForageElement...stub out all the nonsense you don't need for the focus stuff
- [ ] (ideally) write a unit test for this to confirm it works as expected


## Tests Added / Updated?
- YES or NO. If not, why?

## Screenshots