### PR TITLE
Implement `.isFocused` observable state in PIN

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
@@ -104,4 +104,6 @@ internal class BTVaultWrapper @JvmOverloads constructor(
     override fun setHintTextColor(hintTextColor: Int) {
         _internalTextElement.hintTextColor = hintTextColor
     }
+
+    override val hasFocus: Boolean = _internalTextElement.hasFocus()
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -61,6 +61,8 @@ class ForagePINEditText @JvmOverloads constructor(
 
     override var isValid: Boolean = vault?.isValid ?: false
     override var isEmpty: Boolean = vault?.isEmpty ?: true
+    override val isFocused: Boolean = vault?.hasFocus ?: false
+
     override fun setTextColor(textColor: Int) {
         vault?.setTextColor(textColor)
     }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
@@ -117,4 +117,6 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
     override fun setHintTextColor(hintTextColor: Int) {
         _internalEditText.setHintTextColor(hintTextColor)
     }
+
+    override val hasFocus: Boolean = _internalEditText.hasFocus()
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
@@ -26,6 +26,8 @@ abstract class VaultWrapper @JvmOverloads constructor(
     abstract fun getVGSEditText(): VGSEditText
     abstract fun getTextElement(): TextElement
 
+    abstract val hasFocus: Boolean
+
     fun getThemeAccentColor(context: Context): Int {
         val outValue = TypedValue()
         context.theme.resolveAttribute(android.R.attr.colorAccent, outValue, true)


### PR DESCRIPTION
# Description
Adds the `.isFocused` attribute to `ForagePINEditText`.

## Also
- Add any other relevant change made on this PR.

## Notes
- Describe your changes

## Tests Added / Updated?
- YES or NO. If not, why?

## Screenshots