### PR TITLE
Make vault field non-null

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
@@ -97,12 +97,6 @@ internal class BTVaultWrapper @JvmOverloads constructor(
         return _internalTextElement
     }
 
-    override var isValid: Boolean = false
-        get() = _internalTextElement.isValid
-
-    override var isEmpty: Boolean = false
-        get() = _internalTextElement.isEmpty
-
     override var typeface: Typeface?
         get() = _internalTextElement.typeface
         set(value) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -36,8 +36,8 @@ class ForagePANEditText @JvmOverloads constructor(
     private val textInputEditText: TextInputEditText
     private val textInputLayout: TextInputLayout
     private val manager: PanElementStateManager = PanElementStateManager.forEmptyInput()
-    override var isValid: Boolean = manager.getState().isEmpty
-        get() = manager.getState().isEmpty
+    override var isValid: Boolean = manager.getState().isValid
+        get() = manager.getState().isValid
     override var isEmpty: Boolean = manager.getState().isEmpty
         get() = manager.getState().isEmpty
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -27,7 +27,7 @@ class ForagePANEditText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.foragePanEditTextStyle
-) : LinearLayout(context, attrs, defStyleAttr), TextWatcher, ActionMode.Callback {
+) : ForageUI, LinearLayout(context, attrs, defStyleAttr), TextWatcher, ActionMode.Callback {
     private val textInputEditText: TextInputEditText
     private val textInputLayout: TextInputLayout
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -36,10 +36,6 @@ class ForagePANEditText @JvmOverloads constructor(
     private val textInputEditText: TextInputEditText
     private val textInputLayout: TextInputLayout
     private val manager: PanElementStateManager = PanElementStateManager.forEmptyInput()
-    override var isValid: Boolean = manager.getState().isValid
-        get() = manager.getState().isValid
-    override var isEmpty: Boolean = manager.getState().isEmpty
-        get() = manager.getState().isEmpty
 
     override var typeface: Typeface? = null
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -36,6 +36,10 @@ class ForagePANEditText @JvmOverloads constructor(
     private val textInputEditText: TextInputEditText
     private val textInputLayout: TextInputLayout
     private val manager: PanElementStateManager = PanElementStateManager.forEmptyInput()
+    override var isValid: Boolean = manager.getState().isEmpty
+        get() = manager.getState().isEmpty
+    override var isEmpty: Boolean = manager.getState().isEmpty
+        get() = manager.getState().isEmpty
 
     override var typeface: Typeface? = null
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -2,6 +2,7 @@ package com.joinforage.forage.android.ui
 
 import android.content.Context
 import android.graphics.Color
+import android.graphics.Typeface
 import android.text.Editable
 import android.text.InputFilter
 import android.text.InputType
@@ -17,6 +18,10 @@ import com.google.android.material.textfield.TextInputLayout
 import com.joinforage.forage.android.ForageSDK
 import com.joinforage.forage.android.R
 import com.joinforage.forage.android.core.Log
+import com.joinforage.forage.android.core.element.SimpleElementListener
+import com.joinforage.forage.android.core.element.StatefulElementListener
+import com.joinforage.forage.android.core.element.state.ElementState
+import com.joinforage.forage.android.core.element.state.PanElementStateManager
 import com.joinforage.forage.android.model.PanEntry
 import com.joinforage.forage.android.model.StateIIN
 
@@ -30,6 +35,9 @@ class ForagePANEditText @JvmOverloads constructor(
 ) : ForageUI, LinearLayout(context, attrs, defStyleAttr), TextWatcher, ActionMode.Callback {
     private val textInputEditText: TextInputEditText
     private val textInputLayout: TextInputLayout
+    private val manager: PanElementStateManager = PanElementStateManager.forEmptyInput()
+
+    override var typeface: Typeface? = null
 
     init {
         // Must initialize DD at the beginning of each render function. DD requires the context,
@@ -81,6 +89,9 @@ class ForagePANEditText @JvmOverloads constructor(
         disableCopyCardNumber()
 
         textInputEditText.addTextChangedListener(this)
+        textInputEditText.setOnFocusChangeListener { _, hasFocus ->
+            manager.changeFocus(hasFocus)
+        }
 
         textInputLayout.addView(textInputEditText)
         textInputLayout.isErrorEnabled = true
@@ -88,6 +99,40 @@ class ForagePANEditText @JvmOverloads constructor(
 
         addView(getLogoImageViewLayout(context))
         logger.i("ForagePANEditText successfully rendered")
+    }
+
+    // While the events that ForageElements expose mirrors the
+    // blur, focus, change etc events of an Android view,
+    // they represent different abstractions. Our users need to
+    // interact with the ForageElement abstraction and not the
+    // implementation details of which Android view we use.
+    // Therefore we expose novel set listener methods instead of
+    // overriding the convention setOn*Listener
+    override fun setOnFocusEventListener(l: SimpleElementListener) {
+        manager.setOnFocusEventListener(l)
+    }
+    override fun setOnBlurEventListener(l: SimpleElementListener) {
+        manager.setOnBlurEventListener(l)
+    }
+    override fun setOnChangeEventListener(l: StatefulElementListener) {
+        manager.setOnChangeEventListener(l)
+    }
+
+    override fun getElementState(): ElementState {
+        return manager.getState()
+    }
+
+    override fun setTextColor(textColor: Int) {
+        // no-ops for now
+    }
+    override fun setTextSize(textSize: Float) {
+        // no-ops for now
+    }
+    override fun setHint(hint: String) {
+        // no-ops for now
+    }
+    override fun setHintTextColor(hintTextColor: Int) {
+        // no-ops for now
     }
 
     private fun disableCopyCardNumber() {
@@ -98,7 +143,8 @@ class ForagePANEditText @JvmOverloads constructor(
     override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
     }
 
-    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+    override fun onTextChanged(cardNumber: CharSequence?, start: Int, before: Int, count: Int) {
+        manager.handleChangeEvent(cardNumber.toString())
     }
 
     override fun afterTextChanged(s: Editable?) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -15,8 +15,8 @@ import com.joinforage.forage.android.collect.VGSPinCollector
 import com.joinforage.forage.android.core.Log
 import com.joinforage.forage.android.core.element.SimpleElementListener
 import com.joinforage.forage.android.core.element.StatefulElementListener
-import com.verygoodsecurity.vgscollect.widget.VGSEditText
 import com.joinforage.forage.android.core.element.state.ElementState
+import com.verygoodsecurity.vgscollect.widget.VGSEditText
 
 class ForagePINEditText @JvmOverloads constructor(
     context: Context,

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -16,6 +16,7 @@ import com.joinforage.forage.android.core.Log
 import com.joinforage.forage.android.core.element.SimpleElementListener
 import com.joinforage.forage.android.core.element.StatefulElementListener
 import com.verygoodsecurity.vgscollect.widget.VGSEditText
+import com.joinforage.forage.android.core.element.state.ElementState
 
 class ForagePINEditText @JvmOverloads constructor(
     context: Context,
@@ -62,8 +63,8 @@ class ForagePINEditText @JvmOverloads constructor(
         vault.setOnChangeEventListener(l)
     }
 
-    fun getElementState(): ElementState {
-        return ElementState(isFocused = vault?.elementHasFocus ?: false)
+    override fun getElementState(): ElementState {
+        return vault.manager.getState()
     }
 
     internal fun getCollector(

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -13,6 +13,8 @@ import com.joinforage.forage.android.collect.BTPinCollector
 import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.collect.VGSPinCollector
 import com.joinforage.forage.android.core.Log
+import com.joinforage.forage.android.core.element.SimpleElementListener
+import com.joinforage.forage.android.core.element.StatefulElementListener
 import com.verygoodsecurity.vgscollect.widget.VGSEditText
 
 class ForagePINEditText @JvmOverloads constructor(
@@ -50,11 +52,14 @@ class ForagePINEditText @JvmOverloads constructor(
     // implementation details of which Android view we use.
     // Therefore we expose novel set listener methods instead of
     // overriding the convention setOn*Listener
-    fun setOnFocusEventListener(l: ForageElementFocusListener) {
-        vault?.setOnFocusEventListener(l)
+    override fun setOnFocusEventListener(l: SimpleElementListener) {
+        vault.setOnFocusEventListener(l)
     }
-    fun setOnBlurEventListener(l: ForageElementBlurListener) {
-        vault?.setOnBlurEventListener(l)
+    override fun setOnBlurEventListener(l: SimpleElementListener) {
+        vault.setOnBlurEventListener(l)
+    }
+    override fun setOnChangeEventListener(l: StatefulElementListener) {
+        vault.setOnChangeEventListener(l)
     }
 
     fun getElementState(): ElementState {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -20,7 +20,7 @@ class ForagePINEditText @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.foragePanEditTextStyle
 ) : ForageUI, LinearLayout(context, attrs, defStyleAttr) {
-    private var vault: VaultWrapper?
+    private var vault: VaultWrapper
 
     init {
         // Must initialize DD at the beginning of each render function. DD requires the context,
@@ -32,13 +32,13 @@ class ForagePINEditText @JvmOverloads constructor(
         setWillNotDraw(false)
         orientation = VERTICAL
 
-        var vaultType = LDManager.getVaultProvider(context.applicationContext as Application, logger)
+        val vaultType = LDManager.getVaultProvider(context.applicationContext as Application, logger)
         vault = if (vaultType == VaultConstants.BT_VAULT_TYPE) {
             BTVaultWrapper(context, attrs, defStyleAttr)
         } else {
             VGSVaultWrapper(context, attrs, defStyleAttr)
         }
-        addView(vault!!.getUnderlying())
+        addView(vault.getUnderlying())
         addView(getLogoImageViewLayout(context))
         logger.i("ForagePINEditText successfully rendered")
     }
@@ -78,27 +78,27 @@ class ForagePINEditText @JvmOverloads constructor(
     }
 
     internal fun getTextInputEditText(): VGSEditText {
-        return vault?.getVGSEditText()!!
+        return vault.getVGSEditText()
     }
 
     internal fun getTextElement(): TextElement {
-        return vault?.getTextElement()!!
+        return vault.getTextElement()
     }
 
     override var isValid: Boolean = vault?.isValid ?: false
     override var isEmpty: Boolean = vault?.isEmpty ?: true
     override fun setTextColor(textColor: Int) {
-        vault?.setTextColor(textColor)
+        vault.setTextColor(textColor)
     }
     override fun setTextSize(textSize: Float) {
-        vault?.setTextSize(textSize)
+        vault.setTextSize(textSize)
     }
 
-    override var typeface: Typeface? = vault?.typeface
+    override var typeface: Typeface? = vault.typeface
     override fun setHint(hint: String) {
-        vault?.setHint(hint)
+        vault.setHint(hint)
     }
     override fun setHintTextColor(hintTextColor: Int) {
-        vault?.setHintTextColor(hintTextColor)
+        vault.setHintTextColor(hintTextColor)
     }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -24,10 +24,6 @@ class ForagePINEditText @JvmOverloads constructor(
     defStyleAttr: Int = R.attr.foragePanEditTextStyle
 ) : ForageUI, LinearLayout(context, attrs, defStyleAttr) {
     private var vault: VaultWrapper
-    override var isValid: Boolean = false
-        get() = vault.manager.getState().isValid
-    override var isEmpty: Boolean = true
-        get() = vault.manager.getState().isEmpty
 
     init {
         // Must initialize DD at the beginning of each render function. DD requires the context,

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -24,6 +24,10 @@ class ForagePINEditText @JvmOverloads constructor(
     defStyleAttr: Int = R.attr.foragePanEditTextStyle
 ) : ForageUI, LinearLayout(context, attrs, defStyleAttr) {
     private var vault: VaultWrapper
+    override var isValid: Boolean = false
+        get() = vault.manager.getState().isEmpty
+    override var isEmpty: Boolean = true
+        get() = vault.manager.getState().isEmpty
 
     init {
         // Must initialize DD at the beginning of each render function. DD requires the context,
@@ -91,8 +95,6 @@ class ForagePINEditText @JvmOverloads constructor(
         return vault.getTextElement()
     }
 
-    override var isValid: Boolean = vault?.isValid ?: false
-    override var isEmpty: Boolean = vault?.isEmpty ?: true
     override fun setTextColor(textColor: Int) {
         vault.setTextColor(textColor)
     }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -25,7 +25,7 @@ class ForagePINEditText @JvmOverloads constructor(
 ) : ForageUI, LinearLayout(context, attrs, defStyleAttr) {
     private var vault: VaultWrapper
     override var isValid: Boolean = false
-        get() = vault.manager.getState().isEmpty
+        get() = vault.manager.getState().isValid
     override var isEmpty: Boolean = true
         get() = vault.manager.getState().isEmpty
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageUI.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageUI.kt
@@ -5,16 +5,12 @@ import com.joinforage.forage.android.core.element.SimpleElementListener
 import com.joinforage.forage.android.core.element.StatefulElementListener
 import com.joinforage.forage.android.core.element.state.ElementState
 
-
 // an interface that represents that abstract state of
 // a ForageElement.
 // NOTE: isValid is true when validationError = null
 
-
-
 // Minimalist event signatures where the only information
 // conveyed is whether or not a specific event has occurred
-
 
 interface ForageUI {
     var isValid: Boolean

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageUI.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageUI.kt
@@ -13,8 +13,6 @@ import com.joinforage.forage.android.core.element.state.ElementState
 // conveyed is whether or not a specific event has occurred
 
 interface ForageUI {
-    var isValid: Boolean
-    var isEmpty: Boolean
     var typeface: Typeface?
     fun setTextColor(textColor: Int)
     fun setTextSize(textSize: Float)

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageUI.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageUI.kt
@@ -1,15 +1,20 @@
 package com.joinforage.forage.android.ui
 
 import android.graphics.Typeface
+import com.joinforage.forage.android.core.element.SimpleElementListener
+import com.joinforage.forage.android.core.element.StatefulElementListener
+import com.joinforage.forage.android.core.element.state.ElementState
+
 
 // an interface that represents that abstract state of
 // a ForageElement.
-data class ElementState(val isFocused: Boolean)
+// NOTE: isValid is true when validationError = null
+
+
 
 // Minimalist event signatures where the only information
 // conveyed is whether or not a specific event has occurred
-typealias ForageElementFocusListener = () -> Unit
-typealias ForageElementBlurListener = () -> Unit
+
 
 interface ForageUI {
     var isValid: Boolean
@@ -19,4 +24,9 @@ interface ForageUI {
     fun setTextSize(textSize: Float)
     fun setHint(hint: String)
     fun setHintTextColor(hintTextColor: Int)
+
+    fun getElementState(): ElementState
+    fun setOnFocusEventListener(l: SimpleElementListener)
+    fun setOnBlurEventListener(l: SimpleElementListener)
+    fun setOnChangeEventListener(l: StatefulElementListener)
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
@@ -119,12 +119,6 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
         return _internalEditText
     }
 
-    override var isValid: Boolean = false
-        get() = _internalEditText.getState()?.isValid == true
-
-    override var isEmpty: Boolean = false
-        get() = _internalEditText.getState()?.isEmpty == true
-
     override var typeface: Typeface?
         get() = _internalEditText.getTypeface()
         set(value) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
@@ -76,9 +76,10 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
                         setPadding(20, 20, 20, 20)
                     }
                     // enforce that PINs must be 4 digits to be vali
-                    _internalEditText.appendRule(VGSInfoRule.ValidationBuilder()
-                        .setRegex("\\d{4}")
-                        .build()
+                    _internalEditText.appendRule(
+                        VGSInfoRule.ValidationBuilder()
+                            .setRegex("\\d{4}")
+                            .build()
                     )
 
                     // VGS works with the conventional setOnFocusChangeListener
@@ -91,7 +92,7 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
                     _internalEditText.setOnFocusChangeListener { _, hasFocus ->
                         manager.changeFocus(hasFocus)
                     }
-                    _internalEditText.setOnFieldStateChangeListener(object: OnFieldStateChangeListener {
+                    _internalEditText.setOnFieldStateChangeListener(object : OnFieldStateChangeListener {
                         override fun onStateChange(state: FieldState) {
                             // map VGS's event representation to Forage's
                             manager.handleChangeEvent(
@@ -100,7 +101,6 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
                             )
                         }
                     })
-
                 } finally {
                     recycle()
                 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
@@ -8,6 +8,9 @@ import android.util.TypedValue
 import android.view.View
 import android.widget.FrameLayout
 import com.basistheory.android.view.TextElement
+import com.joinforage.forage.android.core.element.SimpleElementListener
+import com.joinforage.forage.android.core.element.StatefulElementListener
+import com.joinforage.forage.android.core.element.state.PinElementStateManager
 import com.verygoodsecurity.vgscollect.widget.VGSEditText
 
 abstract class VaultWrapper @JvmOverloads constructor(
@@ -18,16 +21,13 @@ abstract class VaultWrapper @JvmOverloads constructor(
     abstract var isValid: Boolean
     abstract var isEmpty: Boolean
     abstract var typeface: Typeface?
-    abstract val elementHasFocus: Boolean
-
     // mutable references to event listeners. We use mutable
     // references because the implementations of our vaults
     // require that we are only able to ever pass a single
     // monolithic event within init call. This is mutability
     // allows us simulate setting and overwriting a listener
     // with every set call
-    internal var onFocusEventListener: MutableRef<ForageElementFocusListener> = MutableRef()
-    internal var onBlurEventListener: MutableRef<ForageElementBlurListener> = MutableRef()
+    internal abstract val manager: PinElementStateManager
 
     abstract fun setTextColor(textColor: Int)
     abstract fun setTextSize(textSize: Float)
@@ -67,11 +67,15 @@ abstract class VaultWrapper @JvmOverloads constructor(
         return if (boxCornerRadiusTopStart == 0f) boxCornerRadius else boxCornerRadiusTopStart
     }
 
-    fun setOnFocusEventListener(l: ForageElementFocusListener) {
-        onFocusEventListener?.current = l
+    fun setOnFocusEventListener(l: SimpleElementListener) {
+        manager.setOnFocusEventListener(l)
     }
 
-    fun setOnBlurEventListener(l: ForageElementFocusListener) {
-        onBlurEventListener?.current = l
+    fun setOnBlurEventListener(l: SimpleElementListener) {
+        manager.setOnBlurEventListener(l)
+    }
+
+    fun setOnChangeEventListener(l: StatefulElementListener) {
+        manager.setOnChangeEventListener(l)
     }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
@@ -18,8 +18,6 @@ abstract class VaultWrapper @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr) {
-    abstract var isValid: Boolean
-    abstract var isEmpty: Boolean
     abstract var typeface: Typeface?
 
     // mutable references to event listeners. We use mutable

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
@@ -21,6 +21,7 @@ abstract class VaultWrapper @JvmOverloads constructor(
     abstract var isValid: Boolean
     abstract var isEmpty: Boolean
     abstract var typeface: Typeface?
+
     // mutable references to event listeners. We use mutable
     // references because the implementations of our vaults
     // require that we are only able to ever pass a single


### PR DESCRIPTION
# Description
Within the init method we use an if-else so vault is
guaranteed to point to either VGS or BT. By making `vault`
non-null we can clean up the file and make it easier to read