### PR TITLE
BREAKING: remove isValid, isEmpty from ForageUI

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
@@ -97,12 +97,6 @@ internal class BTVaultWrapper @JvmOverloads constructor(
         return _internalTextElement
     }
 
-    override var isValid: Boolean = false
-        get() = _internalTextElement.isValid
-
-    override var isEmpty: Boolean = false
-        get() = _internalTextElement.isEmpty
-
     override var typeface: Typeface?
         get() = _internalTextElement.typeface
         set(value) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -36,10 +36,6 @@ class ForagePANEditText @JvmOverloads constructor(
     private val textInputEditText: TextInputEditText
     private val textInputLayout: TextInputLayout
     private val manager: PanElementStateManager = PanElementStateManager.forEmptyInput()
-    override var isValid: Boolean = manager.getState().isValid
-        get() = manager.getState().isValid
-    override var isEmpty: Boolean = manager.getState().isEmpty
-        get() = manager.getState().isEmpty
 
     override var typeface: Typeface? = null
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -24,10 +24,6 @@ class ForagePINEditText @JvmOverloads constructor(
     defStyleAttr: Int = R.attr.foragePanEditTextStyle
 ) : ForageUI, LinearLayout(context, attrs, defStyleAttr) {
     private var vault: VaultWrapper
-    override var isValid: Boolean = false
-        get() = vault.manager.getState().isValid
-    override var isEmpty: Boolean = true
-        get() = vault.manager.getState().isEmpty
 
     init {
         // Must initialize DD at the beginning of each render function. DD requires the context,

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageUI.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageUI.kt
@@ -13,8 +13,6 @@ import com.joinforage.forage.android.core.element.state.ElementState
 // conveyed is whether or not a specific event has occurred
 
 interface ForageUI {
-    var isValid: Boolean
-    var isEmpty: Boolean
     var typeface: Typeface?
     fun setTextColor(textColor: Int)
     fun setTextSize(textSize: Float)

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
@@ -119,12 +119,6 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
         return _internalEditText
     }
 
-    override var isValid: Boolean = false
-        get() = _internalEditText.getState()?.isValid == true
-
-    override var isEmpty: Boolean = false
-        get() = _internalEditText.getState()?.isEmpty == true
-
     override var typeface: Typeface?
         get() = _internalEditText.getTypeface()
         set(value) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
@@ -18,8 +18,6 @@ abstract class VaultWrapper @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr) {
-    abstract var isValid: Boolean
-    abstract var isEmpty: Boolean
     abstract var typeface: Typeface?
 
     // mutable references to event listeners. We use mutable


### PR DESCRIPTION
# Description
The recommended way of accessing observable state on
Forage Elements (e.g. PAN/PIN) is via `.getElementState()`.

We don't want to add surface-level attributes to ForageElements
because they inherit from so many other Android View's and there
is a strong chance of name collisions; promoting
`.getElementState()` gives us our own namespace and distinct
abstraction

## Tests Added / Updated?
- NO. Does not affect any functionality. This PR eliminates two fields for reading state