### PR TITLE
Get rid of `TextInputLayout` related error visuals

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -94,7 +94,6 @@ class ForagePANEditText @JvmOverloads constructor(
         }
 
         textInputLayout.addView(textInputEditText)
-        textInputLayout.isErrorEnabled = true
         addView(textInputLayout)
 
         addView(getLogoImageViewLayout(context))
@@ -154,14 +153,11 @@ class ForagePANEditText @JvmOverloads constructor(
                 .find { input.startsWith(it.iin) && input.length == it.panLength }
 
             if (stateInnOrNull == null) {
-                textInputLayout.error = context.getString(R.string.ebt_card_validation_error)
                 ForageSDK.storeEntry(PanEntry.Invalid(input))
             } else {
-                textInputLayout.error = null
                 ForageSDK.storeEntry(PanEntry.Valid(input))
             }
         } else {
-            textInputLayout.error = context.getString(R.string.ebt_card_validation_error)
             ForageSDK.storeEntry(PanEntry.Invalid(input))
         }
     }


### PR DESCRIPTION
# Description
Get rid of `TextInputLayout related` error visuals


## Also
The visuals were driven by the setting of `textInputLayout.error` in the
`afterTextChanged` method. However, since we are no longer setting the
`.error` attribute, it would follow that we should remove the
`textInputLayoutErrorEnabled` in the `init{ ... }` method since GoPuff
should still be able to set that if they so choose

## Release Plan
We don't need to release the second PR in this stack (#61), since that PR can be merged independently at a later point.

## Tests Added / Updated?
- NO - still don't support `espresso` QA-tests so now way to do automated QA tests on Android

## Screenshots
The screenshot below demonstrates `ForagePANEditText` have a non-null `validationError` and the red error text present under the input field, which indicates the successful removal of the errors.
![image](https://github.com/teamforage/forage-android-sdk/assets/12377418/80105857-a511-49b5-848d-468cfab31d6b)
