### PR TITLE
[BREAKING] `tokenizeEBTCard` on `ForageSDK` accepts `ForagePANEditText` as arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ The ForageSDK exposes the following function to collect the EBT card number:
 ```kotlin
     suspend fun tokenizeEBTCard(
         merchantAccount: String,
+        panForageEditText: ForagePANEditText,
         bearerToken: String,
         customerId: String,
         reusable: Boolean = true
@@ -259,6 +260,7 @@ The ForageSDK exposes the following function to collect the EBT card number:
 #### Parameter definitions
 
 - `merchantAccount`: A unique seven digit numeric string that [FNS](https://docs.joinforage.app/docs/ebt-online-101#food-and-nutrition-service-fns) issues to authorized EBT merchants.
+- `panForageEditText`: A reference to the the `ForagePANEditText` that you added to your view. This is needed to extract the card number text.
 - `bearerToken`: A [session token](https://docs.joinforage.app/reference/create-session-token) that authenticates front-end requests to Forage. To create one, send a server-side request from your backend to the `/session_token/` endpoint.
 - `customerId`: A unique ID for the end customer making the payment. If you use your internal customer ID, then we recommend that you hash the value before sending it on the payload.
 - `reusable`: An optional boolean value indicating whether the same card can be used to make multiple payments, set to true by default.
@@ -268,11 +270,12 @@ The ForageSDK exposes the following function to collect the EBT card number:
 This is an example of usage inside an ACC ViewModel:
 
 ```kotlin
-    fun onSubmit() = viewModelScope.launch {
+    fun onSubmit(panForageEditText: ForagePANEditText) = viewModelScope.launch {
         _isLoading.value = true
 
         val response = ForageSDK.tokenizeEBTCard(
             merchantAccount = merchantAccount,
+            panForageEditText = ForagePANEditText,
             bearerToken = bearer,
             // NOTE: The following line is for testing purposes only and should not be used in production.
             // Please replace this line with a real hashed customer ID value.

--- a/forage-android/src/main/java/com/joinforage/forage/android/ForageSDKApi.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ForageSDKApi.kt
@@ -2,6 +2,7 @@ package com.joinforage.forage.android
 
 import android.content.Context
 import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.ui.ForagePANEditText
 import com.joinforage.forage.android.ui.ForagePINEditText
 
 /**
@@ -10,6 +11,7 @@ import com.joinforage.forage.android.ui.ForagePINEditText
 internal interface ForageSDKApi {
     suspend fun tokenizeEBTCard(
         merchantAccount: String,
+        panForageEditText: ForagePANEditText,
         bearerToken: String,
         customerId: String,
         reusable: Boolean = true

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/element/state/PanElementStateManager.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/element/state/PanElementStateManager.kt
@@ -74,6 +74,10 @@ class PanElementStateManager(state: ElementState) : ElementStateManager(state) {
         onChangeEventListener?.invoke(getState())
     }
 
+    fun canTokenizePanElementValue(alwaysAllow: Boolean = false) : Boolean {
+        return getState().isComplete || alwaysAllow;
+    }
+
     companion object {
         fun forEmptyInput(): PanElementStateManager {
             return PanElementStateManager(INITIAL_ELEMENT_STATE)

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -193,4 +193,11 @@ class ForagePANEditText @JvmOverloads constructor(
     }
 
     private fun isNumeric(input: String) = input.matches("[0-9]+".toRegex())
+
+    internal fun shouldTokenize() : Boolean {
+        return manager.canTokenizePanElementValue(BuildConfig.DEBUG)
+    }
+    internal fun getPanNumber() : String {
+        return textInputEditText.text.toString();
+    }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -15,15 +15,13 @@ import android.view.MenuItem
 import android.widget.LinearLayout
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
-import com.joinforage.forage.android.ForageSDK
+import com.joinforage.forage.android.BuildConfig
 import com.joinforage.forage.android.R
 import com.joinforage.forage.android.core.Log
 import com.joinforage.forage.android.core.element.SimpleElementListener
 import com.joinforage.forage.android.core.element.StatefulElementListener
 import com.joinforage.forage.android.core.element.state.ElementState
 import com.joinforage.forage.android.core.element.state.PanElementStateManager
-import com.joinforage.forage.android.model.PanEntry
-import com.joinforage.forage.android.model.StateIIN
 
 /**
  * Material Design component with a TextInputEditText to collect the EBT card number
@@ -162,19 +160,6 @@ class ForagePANEditText @JvmOverloads constructor(
     }
 
     override fun afterTextChanged(s: Editable?) {
-        val input = s.toString()
-        if (isNumeric(input)) {
-            val stateInnOrNull = StateIIN.values()
-                .find { input.startsWith(it.iin) && input.length == it.panLength }
-
-            if (stateInnOrNull == null) {
-                ForageSDK.storeEntry(PanEntry.Invalid(input))
-            } else {
-                ForageSDK.storeEntry(PanEntry.Valid(input))
-            }
-        } else {
-            ForageSDK.storeEntry(PanEntry.Invalid(input))
-        }
     }
 
     override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
@@ -191,8 +176,6 @@ class ForagePANEditText @JvmOverloads constructor(
 
     override fun onDestroyActionMode(mode: ActionMode?) {
     }
-
-    private fun isNumeric(input: String) = input.matches("[0-9]+".toRegex())
 
     internal fun shouldTokenize() : Boolean {
         return manager.canTokenizePanElementValue(BuildConfig.DEBUG)

--- a/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/PanElementStateManagerTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/PanElementStateManagerTest.kt
@@ -236,3 +236,50 @@ class PanHandleChangeEventTest {
         assertThat(callbackBInvoked).isTrue
     }
 }
+
+class CanTokenizePanElementValueTest {
+    @Test
+    fun `alwaysAllow = true trumps complete = false`() {
+        val notCompleteElementState = ElementState(
+            isFocused = false,
+            isEmpty = false,
+            isBlurred = false,
+            isValid = false,
+            validationError = null,
+            isComplete = false
+        )
+        val manager = PanElementStateManager(notCompleteElementState)
+        val canTokenize = manager.canTokenizePanElementValue(alwaysAllow = true)
+        assertThat(canTokenize).isTrue
+    }
+
+    @Test
+    fun `can tokenize when complete = true && alwaysAllow = false`() {
+        val completeElementState = ElementState(
+            isFocused = false,
+            isEmpty = false,
+            isBlurred = false,
+            isValid = false,
+            validationError = null,
+            isComplete = true
+        )
+        val manager = PanElementStateManager(completeElementState)
+        val canTokenize = manager.canTokenizePanElementValue(alwaysAllow = false)
+        assertThat(canTokenize).isTrue
+    }
+
+    @Test
+    fun `canNOT tokenize when complete = false && alwaysAllow = false`() {
+        val notCompleteElementState = ElementState(
+            isFocused = false,
+            isEmpty = false,
+            isBlurred = false,
+            isValid = false,
+            validationError = null,
+            isComplete = false
+        )
+        val manager = PanElementStateManager(notCompleteElementState)
+        val canTokenize = manager.canTokenizePanElementValue(alwaysAllow = false)
+        assertThat(canTokenize).isFalse
+    }
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeFragment.kt
@@ -32,7 +32,9 @@ class FlowTokenizeFragment : Fragment() {
 
         binding.submitButton.apply {
             setOnClickListener {
-                viewModel.onSubmit()
+                viewModel.onSubmit(
+                    panForageEditText = binding.tokenizeForagePanEditText
+                )
                 it.context.hideKeyboard(it)
             }
         }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.joinforage.android.example.network.model.tokenize.PaymentMethod
 import com.joinforage.forage.android.ForageSDK
 import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.ui.ForagePANEditText
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -45,13 +46,14 @@ class FlowTokenizeViewModel @Inject constructor(
 
     val error: LiveData<String?> = _error
 
-    fun onSubmit() = viewModelScope.launch {
+    fun onSubmit(panForageEditText: ForagePANEditText) = viewModelScope.launch {
         _isLoading.value = true
 
         val response = ForageSDK.tokenizeEBTCard(
             merchantAccount = merchantAccount,
             bearerToken = bearer,
-            customerId = "android-test-customer-id"
+            customerId = "android-test-customer-id",
+            panForageEditText = panForageEditText
         )
 
         when (response) {


### PR DESCRIPTION
I accidentally closed #61. This is a duplicate if you are experiencing dejavu

# Description
Previously `tokenizeEBTCard`'s implementation relied on
the sharing of `panEntry` within the `ForageSDK` singleton
object. Sharing state is generally considered bad practice
because it does not scale to multiple parallel consumptions
well.

This commit decouples (and deletes) the shared state. Now,
`tokenizeEBTCard` accepts a ForagePANEditText as an argument
and has no reliance on shared state. The end result is:
* easier to test the `shouldTokenize` logic since it can be
  extract to a service and not live in the view layer near the
  shared state
* no shared state means multiple instances of ForagePANEditText
  can co-exist without issue

# Also
- [x] update the Sample App to pass the `ForagePANEditText` element. Will do that in a subsequent commit
- [x] update the README.md to describe new usage of `ForageSDK.tokenizeEBTCard`
- [ ] Add video recording showcasing flow still works as expected

## Tests Added / Updated?
- YES - this PR adds service layer tests for the guard logic of whether to tokenize an EBT card
- NO - we still don't have espresso enabled so no end-2-end tests to validate new view logic. Instead I'll provide screenshots

## Screenshots