### PR TITLE
[FX-443] Expose version in build config and add to logs

### DIFF
--- a/forage-android/build.gradle
+++ b/forage-android/build.gradle
@@ -52,6 +52,7 @@ android {
             buildConfigField "String", "BASE_URL", '"https://api.dev.joinforage.app/"'
             buildConfigField "String", "LD_MOBILE_KEY", '"mob-03e025cb-5b4e-4d97-8685-39a22316d601"'
             buildConfigField "String", "DD_CLIENT_TOKEN", '"pubf13cedf24ba2ad50d4b9cb0b0100bd4a"'
+            buildConfigField "String", "VERSION", "$publishVersion"
         }
         staging {
             buildConfigField "String", "BT_PROXY_ID", '"ScWvAUkp53xz7muae7fW5p"'
@@ -61,6 +62,7 @@ android {
             buildConfigField "String", "BASE_URL", '"https://api.staging.joinforage.app/"'
             buildConfigField "String", "LD_MOBILE_KEY", '"mob-a9903698-759b-48e2-86e1-c551e2b69118"'
             buildConfigField "String", "DD_CLIENT_TOKEN", '"pubf13cedf24ba2ad50d4b9cb0b0100bd4a"'
+            buildConfigField "String", "VERSION", "$publishVersion"
         }
         sandbox {
             buildConfigField "String", "BT_PROXY_ID", '"R1CNiogSdhnHeNq6ZFWrG1"'
@@ -70,6 +72,7 @@ android {
             buildConfigField "String", "BASE_URL", '"https://api.sandbox.joinforage.app/"'
             buildConfigField "String", "LD_MOBILE_KEY", '"mob-22024b85-05b7-4e24-b290-a071310dfc3d"'
             buildConfigField "String", "DD_CLIENT_TOKEN", '"pubf13cedf24ba2ad50d4b9cb0b0100bd4a"'
+            buildConfigField "String", "VERSION", "$publishVersion"
         }
         cert {
             buildConfigField "String", "BT_PROXY_ID", '"AFSMtyyTGLKgmdWwrLCENX"'
@@ -79,6 +82,7 @@ android {
             buildConfigField "String", "BASE_URL", '"https://api.cert.joinforage.app/"'
             buildConfigField "String", "LD_MOBILE_KEY", '"mob-d2261a08-784b-4300-a45f-ce0e46324d66"'
             buildConfigField "String", "DD_CLIENT_TOKEN", '"pubf13cedf24ba2ad50d4b9cb0b0100bd4a"'
+            buildConfigField "String", "VERSION", "$publishVersion"
         }
         prod {
             buildConfigField "String", "BT_PROXY_ID", '"UxbU4Jn2RmvCovABjwCwsa"'
@@ -88,6 +92,7 @@ android {
             buildConfigField "String", "BASE_URL", '"https://api.joinforage.app/"'
             buildConfigField "String", "LD_MOBILE_KEY", '"mob-5c3dfa7a-fa6d-4cdf-93e8-d28ef8080696"'
             buildConfigField "String", "DD_CLIENT_TOKEN", '"pubf13cedf24ba2ad50d4b9cb0b0100bd4a"'
+            buildConfigField "String", "VERSION", "$publishVersion"
         }
     }
 
@@ -139,7 +144,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'com.joinforage'
-    PUBLISH_VERSION = '2.0.2'
+    PUBLISH_VERSION = publishVersion
     PUBLISH_ARTIFACT_ID = 'forage-android'
     PUBLISH_DESCRIPTION = 'Forage Android SDK'
     PUBLISH_URL = 'https://github.com/teamforage/forage-android-sdk'

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/Log.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/Log.kt
@@ -54,7 +54,8 @@ internal interface Log {
                     .setLoggerName(LOGGER_NAME)
                     .build()
 
-                logger?.addAttribute("version", BuildConfig.VERSION)
+                logger?.addAttribute("version_code", BuildConfig.VERSION)
+                logger?.addTag("version_code", BuildConfig.VERSION)
             }
 
             override fun d(msg: String, attributes: Map<String, Any?>) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/Log.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/Log.kt
@@ -53,6 +53,8 @@ internal interface Log {
                     .setBundleWithTraceEnabled(true)
                     .setLoggerName(LOGGER_NAME)
                     .build()
+
+                logger?.addAttribute("version", BuildConfig.VERSION)
             }
 
             override fun d(msg: String, attributes: Map<String, Any?>) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-publishVersion="2.0.2"
+publishVersion="2.0.3"

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+publishVersion="2.0.2"


### PR DESCRIPTION
# Description
Add the Forage SDK version to the build config and append it to all logs.

<img width="273" alt="Screenshot 2023-08-14 at 7 55 15 PM" src="https://github.com/teamforage/forage-android-sdk/assets/89605898/5a42484a-764a-4c75-85ee-517594bc564b">
