### PR TITLE
Make long-clickable & stop implementing ActionMode.Callback

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -192,5 +192,4 @@ class ForagePANEditText @JvmOverloads constructor(
         val digitsOnly = s.toString().filter { it.isDigit() }
         ForageSDK.storeEntry(digitsOnly)
     }
-
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -9,9 +9,6 @@ import android.text.TextWatcher
 import android.text.method.DigitsKeyListener
 import android.util.AttributeSet
 import android.util.TypedValue
-import android.view.ActionMode
-import android.view.Menu
-import android.view.MenuItem
 import android.widget.LinearLayout
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
@@ -31,7 +28,7 @@ class ForagePANEditText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.foragePanEditTextStyle
-) : ForageElement, LinearLayout(context, attrs, defStyleAttr), TextWatcher, ActionMode.Callback {
+) : ForageElement, LinearLayout(context, attrs, defStyleAttr), TextWatcher {
     private val textInputEditText: TextInputEditText
     private val textInputLayout: TextInputLayout
     private val manager: PanElementStateManager = if (BuildConfig.FLAVOR == "prod") {
@@ -97,8 +94,6 @@ class ForagePANEditText @JvmOverloads constructor(
                     recycle()
                 }
             }
-
-        disableCopyCardNumber()
 
         // Register the afterTextChanged method on this class
         // so that we store the updated PAN on each input change
@@ -182,11 +177,6 @@ class ForagePANEditText @JvmOverloads constructor(
         // no-ops for now
     }
 
-    private fun disableCopyCardNumber() {
-        textInputEditText.isLongClickable = false
-        textInputEditText.customSelectionActionModeCallback = this
-    }
-
     override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
         // no-op
     }
@@ -203,18 +193,4 @@ class ForagePANEditText @JvmOverloads constructor(
         ForageSDK.storeEntry(digitsOnly)
     }
 
-    override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
-        return false
-    }
-
-    override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean {
-        return false
-    }
-
-    override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
-        return false
-    }
-
-    override fun onDestroyActionMode(mode: ActionMode?) {
-    }
 }


### PR DESCRIPTION
# Description
Allow the `ForagePANEditText` to support users copy/pasting their PAN numbers.

## Also
I [verified with Ygor](https://joinforage.slack.com/archives/C056QGRF6S3/p1692652253893609) that by having the `ForagePANEditText` stop implementing the `ActionMode.Callback` interface, that the input would start supporting the copy/paste menu after a longpress. Previously, this was expressly disabled.

## Tests Added / Updated?
No tests because this is entirely in the view-layer and we don't have tests for that yet

## Screenshots
- [x] create a video demo of copy/paste working

https://github.com/teamforage/forage-android-sdk/assets/12377418/2bbc8227-8892-4bf2-a21c-61337fc0dc1d

