### PR TITLE
[FX-404] Support dynamic PAN masking based on StateIIN

### DIFF
--- a/forage-android/build.gradle
+++ b/forage-android/build.gradle
@@ -126,6 +126,7 @@ dependencies {
     implementation "javax.ws.rs:javax.ws.rs-api:2.1@jar"
 
     implementation "com.datadoghq:dd-sdk-android:1.19.2"
+    implementation 'androidx.test:core-ktx:1.5.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'

--- a/forage-android/build.gradle
+++ b/forage-android/build.gradle
@@ -126,7 +126,7 @@ dependencies {
     implementation "javax.ws.rs:javax.ws.rs-api:2.1@jar"
 
     implementation "com.datadoghq:dd-sdk-android:1.19.2"
-    implementation 'androidx.test:core-ktx:1.5.0'
+    testImplementation 'androidx.test:core-ktx:1.5.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/element/state/PanElementStateManager.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/element/state/PanElementStateManager.kt
@@ -4,32 +4,15 @@ import com.joinforage.forage.android.core.element.ElementValidationError
 import com.joinforage.forage.android.core.element.IncompleteEbtPanError
 import com.joinforage.forage.android.core.element.InvalidEbtPanError
 import com.joinforage.forage.android.core.element.TooLongEbtPanError
-import com.joinforage.forage.android.model.STATE_INN_LENGTH
-import com.joinforage.forage.android.model.StateIIN
+import com.joinforage.forage.android.model.hasInvalidStateIIN
+import com.joinforage.forage.android.model.isCorrectLength
+import com.joinforage.forage.android.model.missingStateIIN
+import com.joinforage.forage.android.model.tooLongForStateIIN
+import com.joinforage.forage.android.model.tooShortForStateIIN
 
 const val MIN_CARD_LENGTH = 16
 const val MAX_CARD_LENGTH = 19
 
-private fun missingStateIIN(cardNumber: String): Boolean {
-    return cardNumber.length < STATE_INN_LENGTH
-}
-private fun queryForStateIIN(cardNumber: String): StateIIN? {
-    return StateIIN.values().find { cardNumber.startsWith(it.iin) }
-}
-private fun hasInvalidStateIIN(cardNumber: String): Boolean {
-    return queryForStateIIN(cardNumber) == null
-}
-private fun tooShortForStateIIN(cardNumber: String): Boolean {
-    val iin = queryForStateIIN(cardNumber) ?: return false
-    return cardNumber.length < iin.panLength
-}
-private fun tooLongForStateIIN(cardNumber: String): Boolean {
-    val iin = queryForStateIIN(cardNumber) ?: return false
-    return cardNumber.length > iin.panLength
-}
-private fun isCorrectLength(cardNumber: String): Boolean {
-    return !tooShortForStateIIN(cardNumber) && !tooLongForStateIIN(cardNumber)
-}
 private fun failsValidation(cardNumber: String): Boolean {
     return missingStateIIN(cardNumber) ||
         hasInvalidStateIIN(cardNumber) ||

--- a/forage-android/src/main/java/com/joinforage/forage/android/model/StateIIN.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/model/StateIIN.kt
@@ -60,3 +60,24 @@ internal enum class StateIIN(
     WISCONSIN("507708", 16),
     WYOMING("505349", 16)
 }
+
+internal fun missingStateIIN(cardNumber: String): Boolean {
+    return cardNumber.length < STATE_INN_LENGTH
+}
+internal fun queryForStateIIN(cardNumber: String): StateIIN? {
+    return StateIIN.values().find { cardNumber.startsWith(it.iin) }
+}
+internal fun hasInvalidStateIIN(cardNumber: String): Boolean {
+    return queryForStateIIN(cardNumber) == null
+}
+internal fun tooShortForStateIIN(cardNumber: String): Boolean {
+    val iin = queryForStateIIN(cardNumber) ?: return false
+    return cardNumber.length < iin.panLength
+}
+internal fun tooLongForStateIIN(cardNumber: String): Boolean {
+    val iin = queryForStateIIN(cardNumber) ?: return false
+    return cardNumber.length > iin.panLength
+}
+internal fun isCorrectLength(cardNumber: String): Boolean {
+    return !tooShortForStateIIN(cardNumber) && !tooLongForStateIIN(cardNumber)
+}

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
 import android.text.Editable
-import android.text.InputFilter
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.util.TypedValue
@@ -186,6 +185,4 @@ class ForagePANEditText @JvmOverloads constructor(
 
     override fun onDestroyActionMode(mode: ActionMode?) {
     }
-
-    private fun isNumeric(input: String) = input.matches("[0-9]+".toRegex())
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -5,7 +5,6 @@ import android.graphics.Color
 import android.graphics.Typeface
 import android.text.Editable
 import android.text.InputFilter
-import android.text.InputType
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.util.TypedValue
@@ -74,7 +73,6 @@ class ForagePANEditText @JvmOverloads constructor(
                         layoutParams =
                             LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
                         setTextIsSelectable(false)
-                        inputType = InputType.TYPE_CLASS_NUMBER
                         isSingleLine = true
                         filters += InputFilter.LengthFilter(19)
 
@@ -94,6 +92,7 @@ class ForagePANEditText @JvmOverloads constructor(
         disableCopyCardNumber()
 
         textInputEditText.addTextChangedListener(this)
+        textInputEditText.addTextChangedListener(FormatPanTextWatcher(textInputEditText))
 
         textInputLayout.addView(textInputEditText)
         addView(textInputLayout)

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -74,7 +74,6 @@ class ForagePANEditText @JvmOverloads constructor(
                             LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
                         setTextIsSelectable(false)
                         isSingleLine = true
-                        filters += InputFilter.LengthFilter(19)
 
                         if (textColor != Color.BLACK) {
                             setTextColor(textColor)

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/FormatPanTextWatcher.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/FormatPanTextWatcher.kt
@@ -1,0 +1,129 @@
+package com.joinforage.forage.android.ui
+
+import android.text.Editable
+import android.text.TextWatcher
+import android.widget.EditText
+import com.joinforage.forage.android.model.queryForStateIIN
+
+fun expandDigitsToFormat(pattern: String): (String) -> String {
+    val targetCharGroupSizes = pattern.split(" ").map { it.length }
+    return { input: String ->
+        val acc = listOf<String>() to 0
+        val inputEnd = input.length
+        val (finalGroups, _) = targetCharGroupSizes.fold(acc) { (groupsAcc, i), groupSize ->
+            // don't start group beyond input size
+            val start = minOf(i, inputEnd)
+
+            // don't end group beyond input size
+            val end = minOf(i + groupSize, inputEnd)
+
+            // create char group of [start, end]
+            val charGroup = input.substring(start, end)
+
+            // update accumulator for next iteration
+            val newGroupsAcc = groupsAcc + charGroup
+            val newIndex = i + groupSize
+            newGroupsAcc to newIndex
+        }
+
+        // Groups are separated visually with a single " " character
+        finalGroups.joinToString(" ").trim()
+    }
+}
+
+const val MAX_PAN_LENGTH = 19
+val space16DigitPAN = expandDigitsToFormat("#### #### #### ####")
+val space18DigitPAN = expandDigitsToFormat("###### #### ##### ## #")
+val space19DigitPAN = expandDigitsToFormat("###### #### #### ### ##")
+val noTransform = expandDigitsToFormat("#".repeat(MAX_PAN_LENGTH))
+
+fun stripNonDigits(input: String): String {
+    return input.replace(Regex("\\D"), "")
+}
+
+internal fun truncateDigitsByStateIIN(digits: String): String {
+    val stateIIN = queryForStateIIN(digits)
+    val targetLength = stateIIN?.panLength ?: MAX_PAN_LENGTH
+    return digits.take(targetLength)
+}
+
+fun formatDigitsByStateIIN(digits: String): String {
+    val stateIIN = queryForStateIIN(digits)
+    val transform = when (stateIIN?.panLength) {
+        16 -> space16DigitPAN
+        18 -> space18DigitPAN
+        19 -> space19DigitPAN
+        else -> noTransform
+    }
+    return transform(digits)
+}
+
+fun countSpacesBeforePos(pos: Int, str: String): Int {
+    // protect against boundary cases
+    val end = minOf(pos, str.length)
+
+    // do the logic we actually care about
+    return str.substring(0, end).count { it == ' ' }
+}
+fun getTransformedPosition(pos: Int, oldPrettyText: String, newPrettyText: String): Int {
+    // formatted digits include spaces which change  on inserts,
+    // copy/paste, etc. We need to ensure we factor any space
+    // additions or removals into the cursor's position so the
+    // cursor behaves intuitively to users
+    val prevSpacesBeforePos = countSpacesBeforePos(pos, oldPrettyText)
+    val newSpacesBeforePos = countSpacesBeforePos(pos, newPrettyText)
+    val spacesShift = newSpacesBeforePos - prevSpacesBeforePos
+
+    // ensure we are within the newPrettyText's bounds
+    val shiftedPos = pos + spacesShift
+    return minOf(shiftedPos, newPrettyText.length)
+}
+
+class FormatPanTextWatcher(
+    private val editText: EditText
+) : TextWatcher {
+    private var isProgrammaticChange: Boolean = false
+
+    private fun runWithLock(block: () -> Unit) {
+        if (isProgrammaticChange) return
+        isProgrammaticChange = true
+        block()
+        isProgrammaticChange = false
+    }
+
+    override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+        // a no-op for now
+    }
+
+    override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+        // a no-op for now
+    }
+
+    override fun afterTextChanged(editable: Editable) {
+        // within this method we programmatically change
+        // the EditText's text. To avoid an infinite loop
+        // we use a lock
+        runWithLock {
+            // save the cursor's end position for later
+            val end = editText.selectionEnd
+
+            // save for frequent reuse
+            val rawInput = editable.toString()
+
+            // the TextEdit's content have just been changed and need
+            // to be reformatted. Let's do that now
+            val onlyDigits = stripNonDigits(rawInput)
+            val truncatedDigits = truncateDigitsByStateIIN(onlyDigits)
+            val newText = formatDigitsByStateIIN(truncatedDigits)
+
+            // replace the current (unformatted) content of the
+            // TextEdit with properly formatted content
+            editable.replace(0, rawInput.length, newText)
+
+            // adjust the cursor's position to make sure it moves
+            // intuitively for users
+            val newEnd = getTransformedPosition(end, rawInput, newText)
+            editText.setSelection(newEnd)
+        }
+    }
+}

--- a/forage-android/src/test/java/com/joinforage/forage/android/ui/FormatPanTextWatcherTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/ui/FormatPanTextWatcherTest.kt
@@ -1,0 +1,557 @@
+package com.joinforage.forage.android.ui
+
+import android.widget.EditText
+import androidx.test.core.app.ApplicationProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class InputSanitizationTest {
+    @Test
+    fun `static - non-whitespace, non-digit characters get stripped`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+        editText.setText("!@#$%^&*()_+1234567890-=")
+        assertThat(editText.text.toString()).isEqualTo("1234567890")
+    }
+
+    @Test
+    fun `dynamic - can enter a digit`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+        editText.setText("123")
+        editText.text.insert(1, "7")
+        assertThat(editText.text.toString()).isEqualTo("1723")
+    }
+
+    @Test
+    fun `dynamic - cannot enter whitespace`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+        editText.setText("123")
+        editText.text.insert(1, " ")
+        assertThat(editText.text.toString()).isEqualTo("123")
+    }
+
+    @Test
+    fun `dynamic - cannot enter non-digits`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+        editText.setText("123")
+        editText.text.insert(1, "a")
+        assertThat(editText.text.toString()).isEqualTo("123")
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+class StaticPANFormattingTest {
+    @Test
+    fun `empty input maps to empty output`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+        editText.setText("")
+        assertThat(editText.text.toString()).isEqualTo("")
+    }
+
+    @Test
+    fun `16 digit PAN gets formatted correctly`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+        editText.setText("5053490000000000")
+        assertThat(editText.text.toString()).isEqualTo("5053 4900 0000 0000")
+    }
+
+    @Test
+    fun `18 digit PAN gets formatted correctly`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+        editText.setText("6008900000000000000")
+        assertThat(editText.text.toString()).isEqualTo("600890 0000 00000 00 0")
+    }
+
+    @Test
+    fun `19 digit PAN gets formatted correctly`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+        editText.setText("6274850000000000000")
+        assertThat(editText.text.toString()).isEqualTo("627485 0000 0000 000 00")
+    }
+
+    @Test
+    fun `input with invalid StateIIN does not get transformed`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+        editText.setText("420420000000")
+        assertThat(editText.text.toString()).isEqualTo("420420000000")
+    }
+}
+
+class ExpandDigitsToFormatTest {
+    @Test
+    fun `digits beyond pattern length get dropped`() {
+        val testFormat = expandDigitsToFormat("## #")
+        val formattedText = testFormat("1234")
+        assertThat(formattedText).isEqualTo("12 3") // 4 is dropped
+    }
+
+    @Test
+    fun `incomplete - start of number group`() {
+        val testFormat = expandDigitsToFormat("## #")
+        val formattedText = testFormat("1")
+        assertThat(formattedText).isEqualTo("1")
+    }
+
+    @Test
+    fun `incomplete - within number group`() {
+        val testFormat = expandDigitsToFormat("### #")
+        val formattedText = testFormat("12")
+        assertThat(formattedText).isEqualTo("12")
+    }
+
+    @Test
+    fun `incomplete - end of number group`() {
+        val testFormat = expandDigitsToFormat("## #")
+        val formattedText = testFormat("12")
+        assertThat(formattedText).isEqualTo("12")
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+class TypingCharactersTest {
+    @Test
+    fun `input is max-length - typing at start of string`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204204204204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204 2042 042 04") // to help us visualize
+
+        // simulate typing a "1" at start of input
+        editText.setSelection(0)
+        editText.text.insert(0, "1")
+
+        // 1 gets inserted and trailing 4 gets dropped.
+        // NOTE: that this becomes an invalid StateIIN so the format is lost too
+        assertThat(editText.text.toString()).isEqualTo("1627485420420420420")
+
+        // a standard insert should move the cursor to the next position
+        assertThat(editText.selectionStart).isEqualTo(1)
+        assertThat(editText.selectionEnd).isEqualTo(1)
+    }
+
+    @Test
+    fun `input is max-length - typing before delimiter`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204204204204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204 2042 042 04") // to help us visualize
+
+        // simulate typing a "1" between "85" and " 42"
+        editText.setSelection(6)
+        editText.text.insert(editText.selectionStart, "1")
+
+        // 1 gets inserted and trailing 4 gets dropped.
+        assertThat(editText.text.toString()).isEqualTo("627485 1420 4204 204 20")
+
+        // inserting before a delimiter means the cursor needs
+        // to jump across the delimiter to be after the next number
+        assertThat(editText.selectionStart).isEqualTo(8)
+        assertThat(editText.selectionEnd).isEqualTo(8)
+    }
+
+    @Test
+    fun `input is max-length - typing after delimiter`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204204204204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204 2042 042 04") // to help us visualize
+
+        // simulate typing a "1" between "85 " and "42"
+        editText.setSelection(7)
+        editText.text.insert(editText.selectionStart, "1")
+
+        // 1 gets inserted and trailing 4 gets dropped.
+        assertThat(editText.text.toString()).isEqualTo("627485 1420 4204 204 20")
+
+        // a standard insert should move the cursor to the next position
+        assertThat(editText.selectionStart).isEqualTo(8)
+        assertThat(editText.selectionEnd).isEqualTo(8)
+    }
+
+    @Test
+    fun `input is max-length - typing at end of string`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204204204204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204 2042 042 04") // to help us visualize
+
+        // simulate typing a "1" after trailing "04"
+        editText.setSelection(23)
+        editText.text.insert(editText.selectionStart, "1")
+
+        // no-op. Can't add more characters at the end of the string
+        assertThat(editText.text.toString()).isEqualTo("627485 4204 2042 042 04")
+
+        // the cursor should remain at the end of the string
+        assertThat(editText.selectionStart).isEqualTo(23)
+        assertThat(editText.selectionEnd).isEqualTo(23)
+    }
+
+    @Test
+    fun `input NOT max-length - typing at start of string`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204") // to help us visualize
+
+        // simulate typing a "1" at beginning of string
+        editText.setSelection(0)
+        editText.text.insert(editText.selectionStart, "1")
+
+        // "1" gets inserted. everything else gets pushed
+        // NOTE: this breaks the StateIIN so format collapses
+        assertThat(editText.text.toString()).isEqualTo("16274854204")
+
+        // the cursor should remain at the end of the string
+        assertThat(editText.selectionStart).isEqualTo(1)
+        assertThat(editText.selectionEnd).isEqualTo(1)
+    }
+
+    @Test
+    fun `input NOT max-length - typing before delimiter`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204") // to help us visualize
+
+        // simulate typing a "1" between "85" and " 42"
+        editText.setSelection(6)
+        editText.text.insert(editText.selectionStart, "1")
+
+        // 1 gets inserted and spill into new group
+        assertThat(editText.text.toString()).isEqualTo("627485 1420 4")
+
+        // inserting before a delimiter means the cursor needs
+        // to jump across the delimiter to be after the next number
+        assertThat(editText.selectionStart).isEqualTo(8)
+        assertThat(editText.selectionEnd).isEqualTo(8)
+    }
+
+    @Test
+    fun `input NOT max-length - typing after delimiter`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204") // to help us visualize
+
+        // simulate typing a "1" between "85 " and "42"
+        editText.setSelection(7)
+        editText.text.insert(editText.selectionStart, "1")
+
+        // 1 gets inserted and spill into new group
+        assertThat(editText.text.toString()).isEqualTo("627485 1420 4")
+
+        // a standard insert should move the cursor to the next position
+        assertThat(editText.selectionStart).isEqualTo(8)
+        assertThat(editText.selectionEnd).isEqualTo(8)
+    }
+
+    @Test
+    fun `input NOT max-length - typing at end of string`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204") // to help us visualize
+
+        // simulate typing a "1" after trailing "04"
+        editText.setSelection(11)
+        editText.text.insert(editText.selectionStart, "1")
+
+        // 1 gets inserted and spill into new group
+        assertThat(editText.text.toString()).isEqualTo("627485 4204 1")
+
+        // inserting before a delimiter means the cursor needs
+        // to jump across the delimiter to be after the next number
+        assertThat(editText.selectionStart).isEqualTo(13)
+        assertThat(editText.selectionEnd).isEqualTo(13)
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+class PastingOverSelectionsTest {
+    @Test
+    fun `pasting into empty input`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("") // to help us visualize
+
+        // simulate pasting a "1" in empty input
+        editText.setSelection(0)
+        editText.text.replace(editText.selectionStart, editText.selectionEnd, "1")
+
+        // 1 gets inserted
+        assertThat(editText.text.toString()).isEqualTo("1")
+
+        // pasting in this way should move the cursor to the next position
+        assertThat(editText.selectionStart).isEqualTo(1)
+        assertThat(editText.selectionEnd).isEqualTo(1)
+    }
+
+    @Test
+    fun `pasting over entire input`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204204204204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204 2042 042 04") // to help us visualize
+
+        // simulate pasting a "627485 4204" across whole input
+        editText.setSelection(0, formattedText.length)
+        editText.text.replace(editText.selectionStart, editText.selectionEnd, "6274854204")
+
+        // "627485 4204" gets inserted
+        assertThat(editText.text.toString()).isEqualTo("627485 4204")
+
+        // pasting in this way should move the cursor to the next position
+        assertThat(editText.selectionStart).isEqualTo(11)
+        assertThat(editText.selectionEnd).isEqualTo(11)
+    }
+
+    @Test
+    fun `pasting across group boundaries`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204204204204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204 2042 042 04") // to help us visualize
+
+        // simulate pasting across "204 204"
+        editText.setSelection(8, 15)
+        editText.text.replace(editText.selectionStart, editText.selectionEnd, "6274854204")
+
+        // "627485 4204" gets inserted
+        assertThat(editText.text.toString()).isEqualTo("627485 4627 4854 204 20")
+
+        // pasting in this way should move the cursor to the next position
+        assertThat(editText.selectionStart).isEqualTo(20)
+        assertThat(editText.selectionEnd).isEqualTo(20)
+    }
+
+    @Test
+    fun `pasting before group delimiter`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204204204204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204 2042 042 04") // to help us visualize
+
+        // simulate pasting across "4204" and " 2042"
+        editText.setSelection(11)
+        editText.text.replace(editText.selectionStart, editText.selectionEnd, "77")
+
+        // "77" gets inserted and pushes text back
+        assertThat(editText.text.toString()).isEqualTo("627485 4204 7720 420 42")
+
+        // pasting moves the cursor to the end of the pasted text
+        assertThat(editText.selectionStart).isEqualTo(14)
+        assertThat(editText.selectionEnd).isEqualTo(14)
+    }
+
+    @Test
+    fun `pasting after group delimiter`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204204204204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204 2042 042 04") // to help us visualize
+
+        // simulate pasting between "4204 " and "2042"
+        editText.setSelection(12)
+        editText.text.replace(editText.selectionStart, editText.selectionEnd, "77")
+
+        // "77" gets inserted and pushes text back
+        assertThat(editText.text.toString()).isEqualTo("627485 4204 7720 420 42")
+
+        // pasting moves the cursor to the end of the pasted text
+        assertThat(editText.selectionStart).isEqualTo(14)
+        assertThat(editText.selectionEnd).isEqualTo(14)
+    }
+
+    @Test
+    fun `pasting at start of input`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("627485420")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 420") // to help us visualize
+
+        // simulate pasting at start of input
+        editText.setSelection(0)
+        editText.text.replace(editText.selectionStart, editText.selectionEnd, "77")
+
+        // "77" gets inserted and pushes text back
+        // NOTE: that format is lost since StateIIN becomes invalid
+        assertThat(editText.text.toString()).isEqualTo("77627485420")
+
+        // pasting moves the cursor to the end of the pasted text
+        assertThat(editText.selectionStart).isEqualTo(2)
+        assertThat(editText.selectionEnd).isEqualTo(2)
+    }
+
+    @Test
+    fun `pasting at end of input`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("6274854204204204")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("627485 4204 2042 04") // to help us visualize
+
+        // simulate pasting "7777" at end of the input
+        editText.setSelection(formattedText.length)
+        editText.text.replace(editText.selectionStart, editText.selectionEnd, "7777")
+
+        // "77" gets inserted, correctly grouped and the last "7" gets dropped
+        assertThat(editText.text.toString()).isEqualTo("627485 4204 2042 047 77")
+
+        // pasting moves the cursor to the end of the pasted text
+        // which in this case is the end of the input
+        assertThat(editText.selectionStart).isEqualTo(23)
+        assertThat(editText.selectionEnd).isEqualTo(23)
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+class BackspaceInteractionsTest {
+    @Test
+    fun `backspace on whitespace delimiter does not affect text but moves cursor left`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("505349012")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("5053 4901 2") // to help us visualize
+
+        // simulate backspace on trailing " " before the 2
+        editText.setSelection(editText.text.length - 1)
+        val cursorPos = editText.selectionStart
+        editText.text.delete(cursorPos - 1, cursorPos)
+
+        // trying to delete a whitespace should not affect text content
+        assertThat(editText.text.toString()).isEqualTo("5053 4901 2")
+
+        // trying to delete a whitespace should move cursor
+        // to left, placing it between 1 and " "
+        assertThat(editText.selectionStart).isEqualTo(editText.text.length - 2)
+        assertThat(editText.selectionEnd).isEqualTo(editText.text.length - 2)
+    }
+
+    @Test
+    fun `backspace on only digit in group deletes digit and cursor stays at end`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("505349012")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("5053 4901 2") // to help us visualize
+
+        // simulate backspace on trailing 2
+        editText.setSelection(editText.text.length)
+        val cursorPos = editText.selectionStart
+        editText.text.delete(cursorPos - 1, cursorPos)
+
+        // deleting the trailing two should also delete the whitespace
+        assertThat(editText.text.toString()).isEqualTo("5053 4901")
+
+        // cursor should remain at end of string
+        assertThat(editText.selectionStart).isEqualTo(editText.text.length)
+        assertThat(editText.selectionEnd).isEqualTo(editText.text.length)
+    }
+
+    @Test
+    fun `backspace on last digit in group deletes digit and collapses group`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("505349012")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("5053 4901 2") // to help us visualize
+
+        // simulate backspace on the 1
+        editText.setSelection(editText.text.length - 2)
+        val cursorPos = editText.selectionStart
+        editText.text.delete(cursorPos - 1, cursorPos)
+
+        // deleting the trailing 1 should collapse into two groups
+        assertThat(editText.text.toString()).isEqualTo("5053 4902")
+
+        // cursor should remain at end of string
+        assertThat(editText.selectionStart).isEqualTo(editText.text.length - 1)
+        assertThat(editText.selectionEnd).isEqualTo(editText.text.length - 1)
+    }
+
+    @Test
+    fun `backspace on span across groups deletes digits and preserves groups`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        editText.addTextChangedListener(FormatPanTextWatcher(editText))
+
+        // initialize editText
+        editText.setText("505349012345")
+        val formattedText = editText.text.toString()
+        assertThat(formattedText).isEqualTo("5053 4901 2345") // to help us visualize
+
+        // simulate backspace on the "1 2"
+        editText.setSelection(8, 11)
+        editText.text.delete(editText.selectionStart, editText.selectionEnd)
+
+        // make sure groups are still preserved
+        assertThat(editText.text.toString()).isEqualTo("5053 4903 45")
+
+        // cursor should lie between "03" and " 45"
+        assertThat(editText.selectionStart).isEqualTo(8)
+        assertThat(editText.selectionEnd).isEqualTo(8)
+    }
+}


### PR DESCRIPTION
# Description
1. Introduces the `FormatPanTextWatcher` 
2. Updates the `ForagePANEditText` to use the `ForagePanTextWatcher` to format its input

## Also
- [x] ☠️  I need to update `ForagePANEditText.afterTextChanged` only to use the raw digits from the input. Since all cardNumbers are formatted, they include whitespace so they will always be marked as `Invalid` which will break things.

## Notes
- See [linear ticket](https://linear.app/joinforage/issue/FX-404/android-support-dynamically-updating-the-mask-of-ebt-card-numbers)
- ⚠️  Currently, formatting the PAN text makes the `ForagePANEditText` no longer a Numbers-only input, so adding formatting results in the regular keyboard popping up instead of the numbers-only keyboard that was showing up before.

## Tests Added / Updated?
- YES - this PR added ~30 unit tests to ensure that formatting works in many different scenarios

## Screenshots
Demo showing:
1. 4{14} white listed cards are Valid
2. 5{14} white listed cards are Valid
3. 9{4} white listed cards are Valid
4. 654321 white listed cards are Valid
5. State IIN Validation 
6. 16 PAN formatting for validate State IIN
7. 18 PAN formatting for validate State IIN
8. 19 PAN formatting for validate State IIN


https://github.com/teamforage/forage-android-sdk/assets/12377418/0bb57ee7-7fec-417d-8b3b-24b3a02b3164



