### PR TITLE
[FX-456] Support Whitelisted PAN Cards in Non-Prod environments

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/element/state/PanElementStateManager.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/element/state/PanElementStateManager.kt
@@ -7,6 +7,7 @@ import com.joinforage.forage.android.core.element.TooLongEbtPanError
 import com.joinforage.forage.android.model.STATE_INN_LENGTH
 import com.joinforage.forage.android.model.StateIIN
 
+const val MIN_CARD_LENGTH = 16
 const val MAX_CARD_LENGTH = 19
 
 private fun missingStateIIN(cardNumber: String): Boolean {
@@ -82,7 +83,7 @@ open class WhitelistedCards(
     }
 
     override fun checkIfComplete(cardNumber: String): Boolean {
-        return checkIfValid(cardNumber) && cardNumber.length == MAX_CARD_LENGTH
+        return checkIfValid(cardNumber) && cardNumber.length in MIN_CARD_LENGTH..MAX_CARD_LENGTH
     }
 
     override fun checkForValidationError(cardNumber: String): ElementValidationError? {

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/element/state/PanElementStateManager.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/element/state/PanElementStateManager.kt
@@ -1,13 +1,10 @@
 package com.joinforage.forage.android.core.element.state
 
-import com.joinforage.forage.android.BuildConfig
 import com.joinforage.forage.android.core.element.IncompleteEbtPanError
 import com.joinforage.forage.android.core.element.InvalidEbtPanError
 import com.joinforage.forage.android.core.element.TooLongEbtPanError
 import com.joinforage.forage.android.model.STATE_INN_LENGTH
 import com.joinforage.forage.android.model.StateIIN
-
-const val PROD = "prod"
 
 private fun missingStateIIN(cardNumber: String): Boolean {
     return cardNumber.length < STATE_INN_LENGTH
@@ -39,28 +36,13 @@ private fun passesValidation(cardNumber: String): Boolean {
 }
 
 class PanElementStateManager(state: ElementState) : ElementStateManager(state) {
-    private val errorCardPaymentCapture = Regex("^4{14}.*")
-    private val errorCardBalanceCheck = Regex("^5{14}.*")
-    private val nonProdValidEbtCards = Regex("^9{4}.*")
-
-    private fun overrideNonProdCheck(cardNumber: String): Boolean {
-        return cardNumber.matches(errorCardPaymentCapture) ||
-            cardNumber.matches(errorCardBalanceCheck) ||
-            cardNumber.matches(nonProdValidEbtCards)
-    }
 
     private fun setIsValid(cardNumber: String) {
-        var overrideValidCheck = false
-        if (BuildConfig.FLAVOR != PROD) {
-            overrideValidCheck = overrideNonProdCheck(cardNumber) || cardNumber.length < 6
-        }
-        isValid = cardNumber.isEmpty() || passesValidation(cardNumber) || overrideValidCheck
+        isValid = cardNumber.isEmpty() || passesValidation(cardNumber)
     }
 
     private fun setValidationError(cardNumber: String) {
         validationError = if (cardNumber.isEmpty()) {
-            null
-        } else if (BuildConfig.FLAVOR != PROD && overrideNonProdCheck(cardNumber)) {
             null
         } else if (missingStateIIN(cardNumber)) {
             IncompleteEbtPanError
@@ -76,12 +58,8 @@ class PanElementStateManager(state: ElementState) : ElementStateManager(state) {
     }
 
     private fun setIsComplete(cardNumber: String) {
-        isComplete = if (BuildConfig.FLAVOR != PROD && overrideNonProdCheck(cardNumber)) {
-            cardNumber.length in 16..19
-        } else {
-            passesValidation(cardNumber) &&
-                isCorrectLength(cardNumber)
-        }
+        isComplete = passesValidation(cardNumber) &&
+            isCorrectLength(cardNumber)
     }
 
     private fun setIsEmpty(cardNumber: String) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/element/state/PanElementStateManager.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/element/state/PanElementStateManager.kt
@@ -1,10 +1,13 @@
 package com.joinforage.forage.android.core.element.state
 
+import com.joinforage.forage.android.core.element.ElementValidationError
 import com.joinforage.forage.android.core.element.IncompleteEbtPanError
 import com.joinforage.forage.android.core.element.InvalidEbtPanError
 import com.joinforage.forage.android.core.element.TooLongEbtPanError
 import com.joinforage.forage.android.model.STATE_INN_LENGTH
 import com.joinforage.forage.android.model.StateIIN
+
+const val MAX_CARD_LENGTH = 19
 
 private fun missingStateIIN(cardNumber: String): Boolean {
     return cardNumber.length < STATE_INN_LENGTH
@@ -35,14 +38,23 @@ private fun passesValidation(cardNumber: String): Boolean {
     return !failsValidation(cardNumber)
 }
 
-class PanElementStateManager(state: ElementState) : ElementStateManager(state) {
+interface PanValidator {
+    fun checkIfValid(cardNumber: String): Boolean
+    fun checkIfComplete(cardNumber: String): Boolean
+    fun checkForValidationError(cardNumber: String): ElementValidationError?
+}
 
-    private fun setIsValid(cardNumber: String) {
-        isValid = cardNumber.isEmpty() || passesValidation(cardNumber)
+class StrictEbtValidator : PanValidator {
+    override fun checkIfValid(cardNumber: String): Boolean {
+        return cardNumber.isEmpty() || passesValidation(cardNumber)
     }
 
-    private fun setValidationError(cardNumber: String) {
-        validationError = if (cardNumber.isEmpty()) {
+    override fun checkIfComplete(cardNumber: String): Boolean {
+        return passesValidation(cardNumber) && isCorrectLength(cardNumber)
+    }
+
+    override fun checkForValidationError(cardNumber: String): ElementValidationError? {
+        return if (cardNumber.isEmpty()) {
             null
         } else if (missingStateIIN(cardNumber)) {
             IncompleteEbtPanError
@@ -56,27 +68,84 @@ class PanElementStateManager(state: ElementState) : ElementStateManager(state) {
             null
         }
     }
+}
 
-    private fun setIsComplete(cardNumber: String) {
-        isComplete = passesValidation(cardNumber) &&
-            isCorrectLength(cardNumber)
+open class WhitelistedCards(
+    private val prefix: String,
+    private val repeatCount: Int = 1
+) : PanValidator {
+    override fun checkIfValid(cardNumber: String): Boolean {
+        // for example 444444 4444 4444 *** **
+        // maps to 44444444444444*****, which could be
+        // a whitelisted pattern
+        return cardNumber.startsWith(prefix.repeat(repeatCount))
     }
 
-    private fun setIsEmpty(cardNumber: String) {
-        this.isEmpty = cardNumber.isEmpty()
+    override fun checkIfComplete(cardNumber: String): Boolean {
+        return checkIfValid(cardNumber) && cardNumber.length == MAX_CARD_LENGTH
     }
 
-    fun handleChangeEvent(newCardNumber: String) {
-        setIsValid(newCardNumber)
-        setValidationError(newCardNumber)
-        setIsComplete(newCardNumber)
-        setIsEmpty(newCardNumber)
+    override fun checkForValidationError(cardNumber: String): ElementValidationError? {
+        // this is a developer-only validator and should remain
+        // quiet by not returning a validationError
+        return null
+    }
+}
+
+class PaymentCaptureErrorCard : WhitelistedCards("4", 14)
+class BalanceCheckErrorCard : WhitelistedCards("5", 14)
+class NonProdValidEbtCard : WhitelistedCards("9", 4)
+class EmptyEbtCashBalanceCard : WhitelistedCards("654321")
+
+class PanElementStateManager(state: ElementState, private val validators: Array<PanValidator>) : ElementStateManager(state) {
+
+    private fun checkIsValid(cardNumber: String): Boolean {
+        return validators.any { it.checkIfValid(cardNumber) }
+    }
+    private fun checkIfComplete(cardNumber: String): Boolean {
+        return validators.any { it.checkIfComplete(cardNumber) }
+    }
+    private fun checkForValidationError(cardNumber: String): ElementValidationError? {
+        return validators
+            .map { it.checkForValidationError(cardNumber) }
+            .firstOrNull { it != null }
+    }
+
+    fun handleChangeEvent(rawInput: String) {
+        // because the input may be formatted, we need to
+        // strip everything but digits
+        val newCardNumber = rawInput.filter { it.isDigit() }
+
+        // check to see if any of the validators believe the
+        // card to be valid
+        this.isValid = checkIsValid(newCardNumber)
+        this.isComplete = checkIfComplete(newCardNumber)
+        this.validationError = checkForValidationError(newCardNumber)
+        this.isEmpty = newCardNumber.isEmpty()
+
+        // invoke the registered listener with the updated state
         onChangeEventListener?.invoke(getState())
     }
 
     companion object {
         fun forEmptyInput(): PanElementStateManager {
-            return PanElementStateManager(INITIAL_ELEMENT_STATE)
+            return PanElementStateManager(
+                INITIAL_ELEMENT_STATE,
+                arrayOf(StrictEbtValidator())
+            )
+        }
+
+        fun DEV_ONLY_forEmptyInput(): PanElementStateManager {
+            return PanElementStateManager(
+                INITIAL_ELEMENT_STATE,
+                arrayOf(
+                    StrictEbtValidator(),
+                    PaymentCaptureErrorCard(),
+                    BalanceCheckErrorCard(),
+                    NonProdValidEbtCard(),
+                    EmptyEbtCashBalanceCard()
+                )
+            )
         }
     }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -24,7 +24,6 @@ import com.joinforage.forage.android.core.element.StatefulElementListener
 import com.joinforage.forage.android.core.element.state.ElementState
 import com.joinforage.forage.android.core.element.state.PanElementStateManager
 import com.joinforage.forage.android.model.PanEntry
-import com.joinforage.forage.android.model.StateIIN
 
 /**
  * Material Design component with a TextInputEditText to collect the EBT card number

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -15,6 +15,7 @@ import android.view.MenuItem
 import android.widget.LinearLayout
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
+import com.joinforage.forage.android.BuildConfig
 import com.joinforage.forage.android.ForageSDK
 import com.joinforage.forage.android.R
 import com.joinforage.forage.android.core.Log
@@ -35,7 +36,13 @@ class ForagePANEditText @JvmOverloads constructor(
 ) : ForageUI, LinearLayout(context, attrs, defStyleAttr), TextWatcher, ActionMode.Callback {
     private val textInputEditText: TextInputEditText
     private val textInputLayout: TextInputLayout
-    private val manager: PanElementStateManager = PanElementStateManager.forEmptyInput()
+    private val manager: PanElementStateManager = if (BuildConfig.FLAVOR == "prod") {
+        // strictly support only valid Ebt PAN numbers
+        PanElementStateManager.forEmptyInput()
+    } else {
+        // allows whitelist of special Ebt PAN numbers
+        PanElementStateManager.DEV_ONLY_forEmptyInput()
+    }
 
     override var typeface: Typeface? = null
 
@@ -162,18 +169,18 @@ class ForagePANEditText @JvmOverloads constructor(
     }
 
     override fun afterTextChanged(s: Editable?) {
-        val input = s.toString()
-        if (isNumeric(input)) {
-            val stateInnOrNull = StateIIN.values()
-                .find { input.startsWith(it.iin) && input.length == it.panLength }
+        // PANs will be formatted to include spaces. We want to strip
+        // those spaces so downstream services only work with the raw
+        // digits
+        val digitsOnly = s.toString().filter { it.isDigit() }
 
-            if (stateInnOrNull == null) {
-                ForageSDK.storeEntry(PanEntry.Invalid(input))
-            } else {
-                ForageSDK.storeEntry(PanEntry.Valid(input))
-            }
+        // the manager houses the logic of knowing whether an entered
+        // PAN is OK to be submitted so we use this to determine if
+        // we should store as PanEntry.Valid vs PanEntry.Invalid
+        if (manager.getState().isComplete) {
+            ForageSDK.storeEntry(PanEntry.Valid(digitsOnly))
         } else {
-            ForageSDK.storeEntry(PanEntry.Invalid(input))
+            ForageSDK.storeEntry(PanEntry.Invalid(digitsOnly))
         }
     }
 

--- a/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/PanElementStateManagerTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/PanElementStateManagerTest.kt
@@ -18,12 +18,12 @@ class PanSetIsValidTest {
     }
 
     @Test
-    fun `cardNumber too short to contain IIN`() {
+    fun `cardNumber too short to contain  IIN`() {
         val tooShortNoIIN: String = "420"
         val manager = PanElementStateManager.forEmptyInput()
         manager.handleChangeEvent(tooShortNoIIN)
         val state = manager.getState()
-        assertThat(state.isValid).isTrue
+        assertThat(state.isValid).isFalse
     }
 
     @Test
@@ -63,78 +63,6 @@ class PanSetIsValidTest {
         manager.handleChangeEvent(longMaineNumber)
         val state = manager.getState()
         assertThat(state.isValid).isFalse
-    }
-
-    @Test
-    fun `cardNumber is not special balance card`() {
-        val balanceErrorCard: String = "5555555555"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(balanceErrorCard)
-        val state = manager.getState()
-        assertThat(state.isValid).isFalse
-    }
-
-    @Test
-    fun `cardNumber is special card that causes balance errors short`() {
-        val balanceErrorCard: String = "55555555555555"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(balanceErrorCard)
-        val state = manager.getState()
-        assertThat(state.isValid).isTrue
-    }
-
-    @Test
-    fun `cardNumber is special card that causes balance errors with error code`() {
-        val balanceErrorCard: String = "5555555555555551"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(balanceErrorCard)
-        val state = manager.getState()
-        assertThat(state.isValid).isTrue
-    }
-
-    @Test
-    fun `cardNumber is not special checkout error yet`() {
-        val paymentErrorCard: String = "4444444444"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(paymentErrorCard)
-        val state = manager.getState()
-        assertThat(state.isValid).isFalse
-    }
-
-    @Test
-    fun `cardNumber is special card that causes checkout errors short`() {
-        val paymentErrorCard: String = "44444444444444"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(paymentErrorCard)
-        val state = manager.getState()
-        assertThat(state.isValid).isTrue
-    }
-
-    @Test
-    fun `cardNumber is special card that causes checkout errors with error code`() {
-        val paymentErrorCard: String = "4444444444444451"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(paymentErrorCard)
-        val state = manager.getState()
-        assertThat(state.isValid).isTrue
-    }
-
-    @Test
-    fun `cardNumber is special card that passes validation short`() {
-        val specialSuccessCard: String = "9999"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(specialSuccessCard)
-        val state = manager.getState()
-        assertThat(state.isValid).isTrue
-    }
-
-    @Test
-    fun `cardNumber is special card that passes validation long`() {
-        val specialSuccessCard: String = "9999123456789012345"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(specialSuccessCard)
-        val state = manager.getState()
-        assertThat(state.isValid).isTrue
     }
 }
 
@@ -194,60 +122,6 @@ class PanSetIsCompleteTest {
         val state = manager.getState()
         assertThat(state.isComplete).isFalse
     }
-
-    @Test
-    fun `cardNumber is special balance card length 16`() {
-        val balanceErrorCard: String = "5555555555555551"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(balanceErrorCard)
-        val state = manager.getState()
-        assertThat(state.isComplete).isTrue
-    }
-
-    @Test
-    fun `cardNumber is special balance card length 19`() {
-        val balanceErrorCard: String = "5555555555555551123"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(balanceErrorCard)
-        val state = manager.getState()
-        assertThat(state.isComplete).isTrue
-    }
-
-    @Test
-    fun `cardNumber is special capture card length 16`() {
-        val captureErrorCard: String = "4444444444444451"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(captureErrorCard)
-        val state = manager.getState()
-        assertThat(state.isComplete).isTrue
-    }
-
-    @Test
-    fun `cardNumber is special capture card length 19`() {
-        val captureErrorCard: String = "4444444444444451123"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(captureErrorCard)
-        val state = manager.getState()
-        assertThat(state.isComplete).isTrue
-    }
-
-    @Test
-    fun `cardNumber is special success card length 16`() {
-        val successCard: String = "9999123412341234"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(successCard)
-        val state = manager.getState()
-        assertThat(state.isComplete).isTrue
-    }
-
-    @Test
-    fun `cardNumber is special success card length 19`() {
-        val successCard: String = "9999123412341234123"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(successCard)
-        val state = manager.getState()
-        assertThat(state.isComplete).isTrue
-    }
 }
 
 class PanSetValidationErrorTest {
@@ -255,33 +129,6 @@ class PanSetValidationErrorTest {
     fun `cardNumber as empty string`() {
         val manager = PanElementStateManager.forEmptyInput()
         manager.handleChangeEvent("")
-        val state = manager.getState()
-        assertThat(state.validationError).isNull()
-    }
-
-    @Test
-    fun `cardNumber as special balance card`() {
-        val balanceErrorCard: String = "5555555555555551"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(balanceErrorCard)
-        val state = manager.getState()
-        assertThat(state.validationError).isNull()
-    }
-
-    @Test
-    fun `cardNumber as special capture card`() {
-        val captureErrorCard: String = "4444444444444451"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(captureErrorCard)
-        val state = manager.getState()
-        assertThat(state.validationError).isNull()
-    }
-
-    @Test
-    fun `cardNumber as special success card`() {
-        val captureErrorCard: String = "9999123412341234"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(captureErrorCard)
         val state = manager.getState()
         assertThat(state.validationError).isNull()
     }

--- a/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/PanElementStateManagerTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/PanElementStateManagerTest.kt
@@ -173,15 +173,30 @@ class TestWhitelistedCards {
     }
 
     @Test
-    fun `complete requires length 19 card number`() {
+    fun `complete accepts length 16 card number`() {
         val whitelistValidator = WhitelistedCards("hello", 2)
+        val completeStr = "hellohello******"
+        assertThat(whitelistValidator.checkIfComplete(completeStr)).isTrue
+    }
 
-        val incompleteStr = "hellohello"
-        assertThat(whitelistValidator.checkIfValid(incompleteStr)).isTrue
-        assertThat(whitelistValidator.checkIfComplete(incompleteStr)).isFalse
-
+    @Test
+    fun `complete accepts length 19 card number`() {
+        val whitelistValidator = WhitelistedCards("hello", 2)
         val completeStr = "hellohello*********"
         assertThat(whitelistValidator.checkIfComplete(completeStr)).isTrue
+    }
+
+    @Test
+    fun `complete rejects too short and too long numbers`() {
+        val whitelistValidator = WhitelistedCards("hello", 2)
+
+        val tooShort = "hellohello"
+        assertThat(whitelistValidator.checkIfValid(tooShort)).isTrue
+        assertThat(whitelistValidator.checkIfComplete(tooShort)).isFalse
+
+        val tooLong = "hellohello****************"
+        assertThat(whitelistValidator.checkIfValid(tooLong)).isTrue
+        assertThat(whitelistValidator.checkIfComplete(tooLong)).isFalse
     }
 
     @Test

--- a/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/PanElementStateManagerTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/PanElementStateManagerTest.kt
@@ -7,129 +7,16 @@ import com.joinforage.forage.android.core.element.TooLongEbtPanError
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
-class PanSetIsValidTest {
+class StrictForEmptyInputTest {
 
     @Test
     fun `cardNumber as empty string`() {
         val manager = PanElementStateManager.forEmptyInput()
         manager.handleChangeEvent("")
         val state = manager.getState()
+
         assertThat(state.isValid).isTrue
-    }
-
-    @Test
-    fun `cardNumber too short to contain  IIN`() {
-        val tooShortNoIIN: String = "420"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(tooShortNoIIN)
-        val state = manager.getState()
-        assertThat(state.isValid).isFalse
-    }
-
-    @Test
-    fun `cardNumber has non-existent IIN`() {
-        val invalidIIN: String = "420420420"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(invalidIIN)
-        val state = manager.getState()
-        assertThat(state.isValid).isFalse
-    }
-
-    @Test
-    fun `cardNumber has valid state IIN but is shorter than expected length`() {
-        val tooShortMaineNumber: String = "507703111" // Maine is 507703
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(tooShortMaineNumber)
-        val state = manager.getState()
-        assertThat(state.isValid).isTrue
-    }
-
-    @Test
-    fun `cardNumber has valid state IIN and is correct length`() {
-        val okMaineNumber: String = "5077031111111111111" // Maine is 507703
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(okMaineNumber)
-        val state = manager.getState()
-        assertThat(state.isValid).isTrue
-    }
-
-    @Test
-    fun `cardNumber has valid state IIN and is too long`() {
-        // NOTE: we expect the view to enforce max length based on IIN
-        // but for good measure we'll make sure validation knows to handle
-        // this case
-        val longMaineNumber: String = "50770311111111111110" // Maine is 507703
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(longMaineNumber)
-        val state = manager.getState()
-        assertThat(state.isValid).isFalse
-    }
-}
-
-class PanSetIsCompleteTest {
-    @Test
-    fun `cardNumber as empty string`() {
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent("")
-        val state = manager.getState()
         assertThat(state.isComplete).isFalse
-    }
-
-    @Test
-    fun `cardNumber too short to contain  IIN`() {
-        val tooShortNoIIN: String = "420"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(tooShortNoIIN)
-        val state = manager.getState()
-        assertThat(state.isComplete).isFalse
-    }
-
-    @Test
-    fun `cardNumber has non-existent IIN`() {
-        val invalidIIN: String = "420420420"
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(invalidIIN)
-        val state = manager.getState()
-        assertThat(state.isComplete).isFalse
-    }
-
-    @Test
-    fun `cardNumber has valid state IIN but is shorter than expected length`() {
-        val tooShortMaineNumber: String = "507703111" // Maine is 507703
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(tooShortMaineNumber)
-        val state = manager.getState()
-        assertThat(state.isComplete).isFalse
-    }
-
-    @Test
-    fun `cardNumber has valid state IIN and is correct length`() {
-        val okMaineNumber: String = "5077031111111111111" // Maine is 507703
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(okMaineNumber)
-        val state = manager.getState()
-        assertThat(state.isComplete).isTrue
-    }
-
-    @Test
-    fun `cardNumber has valid state IIN and is too long`() {
-        // NOTE: we expect the view to enforce max length based on IIN
-        // but for good measure we'll make sure validation knows to handle
-        // this case
-        val longMaineNumber: String = "50770311111111111110" // Maine is 507703
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent(longMaineNumber)
-        val state = manager.getState()
-        assertThat(state.isComplete).isFalse
-    }
-}
-
-class PanSetValidationErrorTest {
-    @Test
-    fun `cardNumber as empty string`() {
-        val manager = PanElementStateManager.forEmptyInput()
-        manager.handleChangeEvent("")
-        val state = manager.getState()
         assertThat(state.validationError).isNull()
     }
 
@@ -139,6 +26,9 @@ class PanSetValidationErrorTest {
         val manager = PanElementStateManager.forEmptyInput()
         manager.handleChangeEvent(tooShortNoIIN)
         val state = manager.getState()
+
+        assertThat(state.isValid).isFalse
+        assertThat(state.isComplete).isFalse
         assertThat(state.validationError).isEqualTo(IncompleteEbtPanError)
     }
 
@@ -148,6 +38,9 @@ class PanSetValidationErrorTest {
         val manager = PanElementStateManager.forEmptyInput()
         manager.handleChangeEvent(invalidIIN)
         val state = manager.getState()
+
+        assertThat(state.isValid).isFalse
+        assertThat(state.isComplete).isFalse
         assertThat(state.validationError).isEqualTo(InvalidEbtPanError)
     }
 
@@ -157,6 +50,9 @@ class PanSetValidationErrorTest {
         val manager = PanElementStateManager.forEmptyInput()
         manager.handleChangeEvent(tooShortMaineNumber)
         val state = manager.getState()
+
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isFalse
         assertThat(state.validationError).isEqualTo(IncompleteEbtPanError)
     }
 
@@ -166,6 +62,9 @@ class PanSetValidationErrorTest {
         val manager = PanElementStateManager.forEmptyInput()
         manager.handleChangeEvent(okMaineNumber)
         val state = manager.getState()
+
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isTrue
         assertThat(state.validationError).isNull()
     }
 
@@ -178,11 +77,148 @@ class PanSetValidationErrorTest {
         val manager = PanElementStateManager.forEmptyInput()
         manager.handleChangeEvent(longMaineNumber)
         val state = manager.getState()
+
+        assertThat(state.isValid).isFalse
+        assertThat(state.isComplete).isFalse
         assertThat(state.validationError).isEqualTo(TooLongEbtPanError)
     }
 }
 
-class PanSetIsEmptyTest {
+class DEV_ONLY_IntegrationTests {
+    @Test
+    fun `StrictEbtValidator - correctly flags valid`() {
+        val okMaineNumber: String = "5077031111111111111" // Maine is 507703
+        val manager = PanElementStateManager.DEV_ONLY_forEmptyInput()
+        manager.handleChangeEvent(okMaineNumber)
+        val state = manager.getState()
+
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isTrue
+        assertThat(state.validationError).isNull()
+    }
+
+    @Test
+    fun `PaymentCaptureErrorCard - correctly flags valid`() {
+        val whitelistedPAN: String = "4444444444444412345"
+        val manager = PanElementStateManager.DEV_ONLY_forEmptyInput()
+        manager.handleChangeEvent(whitelistedPAN)
+        val state = manager.getState()
+
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isTrue
+    }
+
+    @Test
+    fun `BalanceCheckErrorCard - correctly flags valid`() {
+        val whitelistedPAN: String = "5555555555555512345"
+        val manager = PanElementStateManager.DEV_ONLY_forEmptyInput()
+        manager.handleChangeEvent(whitelistedPAN)
+        val state = manager.getState()
+
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isTrue
+    }
+
+    @Test
+    fun `NonProdValidEbtCard - correctly flags valid`() {
+        val whitelistedPAN: String = "9999420420420420420"
+        val manager = PanElementStateManager.DEV_ONLY_forEmptyInput()
+        manager.handleChangeEvent(whitelistedPAN)
+        val state = manager.getState()
+
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isTrue
+    }
+
+    @Test
+    fun `EmptyEbtCashBalanceCard - correctly flags valid`() {
+        val whitelistedPAN: String = "6543210000000000000"
+        val manager = PanElementStateManager.DEV_ONLY_forEmptyInput()
+        manager.handleChangeEvent(whitelistedPAN)
+        val state = manager.getState()
+
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isTrue
+    }
+
+    @Test
+    fun `empty string is valid`() {
+        val manager = PanElementStateManager.DEV_ONLY_forEmptyInput()
+        manager.handleChangeEvent("")
+        val state = manager.getState()
+
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isFalse
+        assertThat(state.validationError).isNull()
+    }
+
+    @Test
+    fun `non-whitelisted invalid Ebt Pan should be invalid`() {
+        val manager = PanElementStateManager.DEV_ONLY_forEmptyInput()
+        manager.handleChangeEvent("4204204204204204204")
+        val state = manager.getState()
+
+        assertThat(state.isValid).isFalse
+        assertThat(state.isComplete).isFalse
+        assertThat(state.validationError).isEqualTo(InvalidEbtPanError)
+    }
+}
+
+class TestWhitelistedCards {
+    @Test
+    fun `prefix can be repeated arbitrary times`() {
+        val whitelistValidator = WhitelistedCards("hello", 2)
+        val validStr = "hellohello"
+        assertThat(whitelistValidator.checkIfValid(validStr)).isTrue
+    }
+
+    @Test
+    fun `complete requires length 19 card number`() {
+        val whitelistValidator = WhitelistedCards("hello", 2)
+
+        val incompleteStr = "hellohello"
+        assertThat(whitelistValidator.checkIfValid(incompleteStr)).isTrue
+        assertThat(whitelistValidator.checkIfComplete(incompleteStr)).isFalse
+
+        val completeStr = "hellohello*********"
+        assertThat(whitelistValidator.checkIfComplete(completeStr)).isTrue
+    }
+
+    @Test
+    fun `complete and valid require matching prefix`() {
+        val whitelistValidator = WhitelistedCards("hello", 2)
+
+        val invalidCompleteStr = "hello12345*********"
+        assertThat(whitelistValidator.checkIfValid(invalidCompleteStr)).isFalse
+        assertThat(whitelistValidator.checkIfComplete(invalidCompleteStr)).isFalse
+
+        val completeStr = "hellohello*********"
+        assertThat(whitelistValidator.checkIfValid(completeStr)).isTrue
+        assertThat(whitelistValidator.checkIfComplete(completeStr)).isTrue
+    }
+
+    @Test
+    fun `validationError is always null`() {
+        val whitelistValidator = WhitelistedCards("hello", 2)
+
+        val emptyStr = ""
+        assertThat(whitelistValidator.checkForValidationError(emptyStr)).isNull()
+
+        val shortAndDoesNotMatchPrefixStr = "hello12345"
+        assertThat(whitelistValidator.checkForValidationError(shortAndDoesNotMatchPrefixStr)).isNull()
+
+        val correctLengthAndDoesNotMatchPrefixStr = "hello12345*********"
+        assertThat(whitelistValidator.checkForValidationError(correctLengthAndDoesNotMatchPrefixStr)).isNull()
+
+        val validIncompleteStr = "hellohello"
+        assertThat(whitelistValidator.checkForValidationError(validIncompleteStr)).isNull()
+
+        val completeStr = "hellohello*********"
+        assertThat(whitelistValidator.checkForValidationError(completeStr)).isNull()
+    }
+}
+
+class PanIsEmptyTest {
     @Test
     fun `cardNumber is length 0`() {
         val manager = PanElementStateManager.forEmptyInput()
@@ -234,5 +270,21 @@ class PanHandleChangeEventTest {
         // only the current callback should be invoked
         assertThat(callbackAInvoked).isFalse
         assertThat(callbackBInvoked).isTrue
+    }
+
+    @Test
+    fun `strips all non-digit characters before processing`() {
+        val manager = PanElementStateManager.forEmptyInput()
+        var state: ElementState = manager.getState()
+        val callback: StatefulElementListener = { newState -> state = newState }
+
+        val validStringContaminatedByOtherChars = "!@# $%^ &*()_+<>? abcd5076807890123456"
+        manager.setOnChangeEventListener(callback)
+        manager.handleChangeEvent(validStringContaminatedByOtherChars)
+
+        assertThat(state.isEmpty).isFalse
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isTrue
+        assertThat(state.validationError).isNull()
     }
 }


### PR DESCRIPTION
# Description
1. Reverted the changes done in #65 
2. Adds support for whitelisted EBT PANs for `ForagePANEditText` when environment is not "prod"

## Also
The commits are very detailed so read one by one for more context.

## Tests Added / Updated?
- YES - adds many dozens of unit tests to verify the whitelisting and Strict IIN validation logic

## Screenshots
Video demo of the whitelisted cards and StateIIN cards being accepted as valid

https://github.com/teamforage/forage-android-sdk/assets/12377418/53eed848-b377-4120-aff8-36a67460d662

