### PR TITLE
Make sure that onChangeEventHandler gets fired once

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -104,7 +104,7 @@ class ForagePANEditText @JvmOverloads constructor(
         // for reformatting purposes, we'll let the FormatPanTextWatcher
         // decide when its appropriate to invoke the user-registered callback
         formatTextWatcher = FormatPanTextWatcher(textInputEditText)
-        formatTextWatcher.onFormattedChangeEvent {formattedCardNumber ->
+        formatTextWatcher.onFormattedChangeEvent { formattedCardNumber ->
             manager.handleChangeEvent(formattedCardNumber)
         }
         textInputEditText.addTextChangedListener(formatTextWatcher)

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/FormatPanTextWatcher.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/FormatPanTextWatcher.kt
@@ -80,15 +80,20 @@ fun getTransformedPosition(pos: Int, oldPrettyText: String, newPrettyText: Strin
 }
 
 class FormatPanTextWatcher(
-    private val editText: EditText
+    private val editText: EditText,
 ) : TextWatcher {
     private var isProgrammaticChange: Boolean = false
+    private var onFormattedChangeEvent: ((String) -> Unit)? = null
 
     private fun runWithLock(block: () -> Unit) {
         if (isProgrammaticChange) return
         isProgrammaticChange = true
         block()
         isProgrammaticChange = false
+    }
+
+    fun onFormattedChangeEvent(callback: (String) -> Unit) {
+        onFormattedChangeEvent = callback
     }
 
     override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
@@ -124,6 +129,10 @@ class FormatPanTextWatcher(
             // intuitively for users
             val newEnd = getTransformedPosition(end, rawInput, newText)
             editText.setSelection(newEnd)
+
+            // fire the change event for the merchant now that we've
+            // established the new (formatted) value
+            onFormattedChangeEvent?.invoke(newText)
         }
     }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/FormatPanTextWatcher.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/FormatPanTextWatcher.kt
@@ -80,7 +80,7 @@ fun getTransformedPosition(pos: Int, oldPrettyText: String, newPrettyText: Strin
 }
 
 class FormatPanTextWatcher(
-    private val editText: EditText,
+    private val editText: EditText
 ) : TextWatcher {
     private var isProgrammaticChange: Boolean = false
     private var onFormattedChangeEvent: ((String) -> Unit)? = null

--- a/forage-android/src/test/java/com/joinforage/forage/android/ui/FormatPanTextWatcherTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/ui/FormatPanTextWatcherTest.kt
@@ -582,5 +582,4 @@ class OnFormattedChangeEventTest {
         assertThat(actualPAN).isEqualTo(expectedFormattedPAN)
         assertThat(callbackCount).isEqualTo(1)
     }
-
 }

--- a/forage-android/src/test/java/com/joinforage/forage/android/ui/FormatPanTextWatcherTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/ui/FormatPanTextWatcherTest.kt
@@ -555,3 +555,32 @@ class BackspaceInteractionsTest {
         assertThat(editText.selectionEnd).isEqualTo(8)
     }
 }
+
+@RunWith(RobolectricTestRunner::class)
+class OnFormattedChangeEventTest {
+    @Test
+    fun `correctly passes the formatted text to the callback`() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+        val watcher = FormatPanTextWatcher(editText)
+        editText.addTextChangedListener(watcher)
+
+        // mutable state to help us test the callback
+        var callbackCount = 0
+        var actualPAN = ""
+        watcher.onFormattedChangeEvent { formattedCardNumber ->
+            callbackCount++
+            actualPAN = formattedCardNumber
+        }
+
+        // simulate a paste event
+        editText.setText("505349012345")
+
+        // we expect the callback to be passed the correctly
+        // formatted PAN exactly once
+        val expectedFormattedPAN = "5053 4901 2345"
+        assertThat(editText.text.toString()).isEqualTo(expectedFormattedPAN)
+        assertThat(actualPAN).isEqualTo(expectedFormattedPAN)
+        assertThat(callbackCount).isEqualTo(1)
+    }
+
+}


### PR DESCRIPTION
# Description

There are two updates to the `TextInputEditText` when the user types
something. 1) is the actual user's update and 2) is the update that
reformats the input field based on the lastest changes.

Previously, the `ForagePANEditText` was invoking the changEvent callback
for each of these, which is suboptimal. To fix this, we defer the
responsibility of knowing to invoke the user's registered callback to
the `FormatPanTextWatcher` since it holds the source of truth to

## Tests Added / Updated?
- YES - adds a test to the `FormatPanTextWatcher` to ensure that the callback gets invoked exactly once and passes the formatted value

## Screenshots

https://github.com/teamforage/forage-android-sdk/assets/12377418/ae995307-99fa-461f-8db3-f2ecbdb1ce8a
