### PR TITLE
Set ForagePANEditText keyboard to numbers

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
 import android.text.Editable
+import android.text.InputType
 import android.text.TextWatcher
+import android.text.method.DigitsKeyListener
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.ActionMode
@@ -83,6 +85,14 @@ class ForagePANEditText @JvmOverloads constructor(
                         if (textSize != -1f) {
                             setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize)
                         }
+
+                        // make the keyboard digits only instead of QWERTY. It is
+                        // necessary to declare that we accept digits and " " so
+                        // that the app does not crash when the PanFormatTextWatcher
+                        // programmatically inserts spaces. By default it disallows
+                        // whitespace
+                        inputType = InputType.TYPE_CLASS_NUMBER
+                        keyListener = DigitsKeyListener.getInstance("0123456789 ")
                     }
                 } finally {
                     recycle()


### PR DESCRIPTION
## Description
Previously, we did not use the `keyListener` attribute of the
`TextInputEditText` and that would cause the app to crash because the
PanFormatTextWatcher would insert whitespaces that were disallowed.
This combination of attributes seems to fix the issue and has everything
playing nicely together.

## Tests Added / Updated?
- NO - this is just a view-level configuration

## Screenshots
<img src="https://github.com/teamforage/forage-android-sdk/assets/12377418/a4c7b5e4-317d-4b9d-bced-70fb7f9b093a" alt="image" height="400px"/>
