### PR TITLE
Add support for `clearText` to PIN and PAN elements.

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
@@ -85,6 +85,10 @@ internal class BTVaultWrapper @JvmOverloads constructor(
             }
     }
 
+    override fun clearText() {
+        _internalTextElement.setText("")
+    }
+
     override fun getVGSEditText(): VGSEditText {
         throw RuntimeException("Unimplemented for this vault!")
     }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -127,6 +127,10 @@ class ForagePANEditText @JvmOverloads constructor(
         logger.i("ForagePANEditText successfully rendered")
     }
 
+    override fun clearText() {
+        textInputEditText.setText("")
+    }
+
     // NOTE: do not call this method inside `init {}`
     // There was a timing bug that caused the focus
     // callback to not get registered correctly when

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -46,6 +46,10 @@ class ForagePINEditText @JvmOverloads constructor(
         logger.i("ForagePINEditText successfully rendered")
     }
 
+    override fun clearText() {
+        vault.clearText()
+    }
+
     // While the events that ForageElements expose mirrors the
     // blur, focus, change etc events of an Android view,
     // they represent different abstractions. Our users need to

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageUI.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageUI.kt
@@ -14,6 +14,9 @@ import com.joinforage.forage.android.core.element.state.ElementState
 
 interface ForageUI {
     var typeface: Typeface?
+
+    fun clearText()
+
     fun setTextColor(textColor: Int)
     fun setTextSize(textSize: Float)
     fun setHint(hint: String)

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
@@ -107,6 +107,10 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
             }
     }
 
+    override fun clearText() {
+        _internalEditText.setText("")
+    }
+
     override fun getVGSEditText(): VGSEditText {
         return _internalEditText
     }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VaultWrapper.kt
@@ -28,6 +28,8 @@ abstract class VaultWrapper @JvmOverloads constructor(
     // with every set call
     internal abstract val manager: PinElementStateManager
 
+    abstract fun clearText()
+
     abstract fun setTextColor(textColor: Int)
     abstract fun setTextSize(textSize: Float)
     abstract fun setHint(hint: String)


### PR DESCRIPTION
# Description
Adds support for `.clearText()` method to all `ForageElements` as requested by GoPuff [here](https://joinforage.slack.com/archives/C04FQM5F2DA/p1693327253627219)

## Tests Added / Updated?
- NO. We need (and don't have) expresso to create automated test on the UI

## Screenshots
Demo of `ForagePANEditText.clearText()` working as expected

https://github.com/teamforage/forage-android-sdk/assets/12377418/81166a18-253e-4ff7-9e89-f7d2424f63a4



Demo of `ForagePINEditText.clearText()` working as expected

https://github.com/teamforage/forage-android-sdk/assets/12377418/803a5b68-291e-4e2f-abe7-8eb009907411

