### PR TITLE
Bump version for 2.0.6 release

### DIFF
--- a/forage-android/build.gradle
+++ b/forage-android/build.gradle
@@ -145,7 +145,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'com.joinforage'
-    PUBLISH_VERSION = '2.0.5'
+    PUBLISH_VERSION = '2.0.6'
     PUBLISH_ARTIFACT_ID = 'forage-android'
     PUBLISH_DESCRIPTION = 'Forage Android SDK'
     PUBLISH_URL = 'https://github.com/teamforage/forage-android-sdk'

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-publishVersion="2.0.5"
+publishVersion="2.0.6"


### PR DESCRIPTION
# Description
Bumpt to v2.0.6 to release to `.clearText` to GoPuff today