### PR TITLE
Bump BT to version 2.5.0

### DIFF
--- a/forage-android/build.gradle
+++ b/forage-android/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     api 'com.verygoodsecurity:vgscollect:1.7.3'
 
     // Basis Theory SDK
-    implementation ('com.github.basis-theory:basistheory-android:2.1.1') {
+    implementation ('com.github.basis-theory:basistheory-android:2.5.0') {
         // Unable to build without excluding this dependency
         // based on advice from this thread: https://github.com/gradle/gradle/issues/3065#issuecomment-341418873
         exclude group: 'javax.ws.rs'


### PR DESCRIPTION
# Description
Bump Basis Theory package to `v2.5.0` to support [overriding text-align](https://github.com/Basis-Theory/basistheory-android/pull/92).

## Notes
- We're going to wait for @dleis612 to come back before merging this in case there were reasons we did not want to keep the Basis Theory package up to date with the latest

## Tests Added / Updated?
- Tested PIN capture using BT on my machine and it worked so seems fine