### PR TITLE
[SYM-104] Inner private-text alignment for PIN field should be center aligned

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
+import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
@@ -63,7 +64,10 @@ internal class BTVaultWrapper @JvmOverloads constructor(
                             cornerRadii = floatArrayOf(boxCornerRadiusTopStart, boxCornerRadiusTopStart, boxCornerRadiusTopEnd, boxCornerRadiusTopEnd, boxCornerRadiusBottomStart, boxCornerRadiusBottomStart, boxCornerRadiusBottomEnd, boxCornerRadiusBottomEnd)
                             setStroke(5, boxStrokeColor)
                         }
+
                         background = customBackground
+
+                        gravity = Gravity.CENTER
                     }
 
                     // Basis Theory keeps a list of as many listeners as you want

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
@@ -6,6 +6,7 @@ import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
 import android.util.TypedValue
+import android.view.Gravity
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import com.basistheory.android.view.TextElement
@@ -72,6 +73,7 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
 
                         setTextColor(textColor)
                         setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize)
+                        setGravity(Gravity.CENTER)
 
                         // Constant VGS configuration. Can't be externally altered!
                         setFieldName(ForageConstants.VGS.PIN_FIELD_NAME)


### PR DESCRIPTION
# Description
Align PIN textfield on center.

## Tests Added / Updated?
- NO. Not that big of a change.

## Screenshots
<img width="280" alt="Screenshot 2023-09-06 at 17 06 19" src="https://github.com/teamforage/forage-android-sdk/assets/136574617/59d10e4d-d170-4dd5-9b49-99fb9853211c">
