### PR TITLE
Add details field to ForageErrorObj

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
@@ -115,7 +115,7 @@ internal class CapturePaymentRepository(
                                     "content_id" to contentId
                                 )
                             )
-                            return ForageApiResponse.Failure(listOf(ForageError(error.statusCode, error.forageCode, error.message)))
+                            return ForageApiResponse.Failure.fromSQSError(error)
                         }
                         break
                     }
@@ -129,7 +129,7 @@ internal class CapturePaymentRepository(
                                 "content_id" to contentId
                             )
                         )
-                        return ForageApiResponse.Failure(listOf(ForageError(error.statusCode, error.forageCode, error.message)))
+                        return ForageApiResponse.Failure.fromSQSError(error)
                     }
                 }
                 else -> {

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/model/ForageApiResponse.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/model/ForageApiResponse.kt
@@ -5,15 +5,29 @@ import org.json.JSONObject
 sealed class ForageApiResponse<out T> {
     data class Success<out T>(val data: T) : ForageApiResponse<T>()
 
-    data class Failure(val errors: List<ForageError>) : ForageApiResponse<Nothing>()
+    data class Failure(val errors: List<ForageError>) : ForageApiResponse<Nothing>() {
+        companion object {
+            fun fromSQSError(sqsError: SQSError): Failure {
+                val forageError = ForageError(
+                    sqsError.statusCode,
+                    sqsError.forageCode,
+                    sqsError.message,
+                    sqsError.details
+                )
+                return Failure(listOf(forageError))
+            }
+        }
+    }
 }
 
 data class ForageError(
     val httpStatusCode: Int,
     val code: String,
-    val message: String
+    val message: String,
+    val details: ErrorMessageDetails? = null
 ) {
     override fun toString(): String {
+        // TODO: should we include the stringified JSON details in the toString() ?
         return "Code: $code\nMessage: $message\nStatus Code: $httpStatusCode"
     }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/model/ForageApiResponse.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/model/ForageApiResponse.kt
@@ -27,8 +27,7 @@ data class ForageError(
     val details: ErrorMessageDetails? = null
 ) {
     override fun toString(): String {
-        // TODO: should we include the stringified JSON details in the toString() ?
-        return "Code: $code\nMessage: $message\nStatus Code: $httpStatusCode"
+        return "Code: $code\nMessage: $message\nStatus Code: $httpStatusCode\nError Details (below):\n$details"
     }
 }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/model/ForageApiResponse.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/model/ForageApiResponse.kt
@@ -20,10 +20,21 @@ sealed class ForageApiResponse<out T> {
     }
 }
 
+// Learn more about `ForageError`s [here](https://docs.joinforage.app/reference/forage-js-errors#forageerror)
 data class ForageError(
+    // The HTTP status that the Forage API returns in response to the request.
     val httpStatusCode: Int,
+
+    // A short string explaining why the request failed. The [error code](https://docs.joinforage.app/reference/errors#error-codes)
+    // string corresponds to the HTTP status code.
     val code: String,
+
+    // A developer-facing message about the error, not to be displayed to customers.
     val message: String,
+
+    // Additional data associated with certain ForageErrors include for your
+    // convenience. Guaranteed to be present for ForageErrors with details
+    // (e.g. error_code_51 Insufficient Balance). null for all other ForageErrors
     val details: ErrorMessageDetails? = null
 ) {
     override fun toString(): String {

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/model/ForageApiResponse.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/model/ForageApiResponse.kt
@@ -35,7 +35,7 @@ data class ForageError(
     // Additional data associated with certain ForageErrors include for your
     // convenience. Guaranteed to be present for ForageErrors with details
     // (e.g. error_code_51 Insufficient Balance). null for all other ForageErrors
-    val details: ErrorMessageDetails? = null
+    val details: ForageErrorDetails? = null
 ) {
     override fun toString(): String {
         return "Code: $code\nMessage: $message\nStatus Code: $httpStatusCode\nError Details (below):\n$details"

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/model/ForageApiResponse.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/model/ForageApiResponse.kt
@@ -32,7 +32,7 @@ data class ForageError(
     // A developer-facing message about the error, not to be displayed to customers.
     val message: String,
 
-    // Additional data associated with certain ForageErrors include for your
+    // Additional data associated with certain ForageErrors included for your
     // convenience. Guaranteed to be present for ForageErrors with details
     // (e.g. error_code_51 Insufficient Balance). null for all other ForageErrors
     val details: ForageErrorDetails? = null

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/model/Message.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/model/Message.kt
@@ -2,8 +2,8 @@ package com.joinforage.forage.android.network.model
 
 import org.json.JSONObject
 
-sealed class ErrorMessageDetails {
-    data class EbtError51Details(val snapBalance: String? = null, val cashBalance: String? = null) : ErrorMessageDetails() {
+sealed class ForageErrorDetails {
+    data class EbtError51Details(val snapBalance: String? = null, val cashBalance: String? = null) : ForageErrorDetails() {
         companion object {
             fun from(detailsJson: JSONObject?): EbtError51Details {
                 // TODO: should probably add a log here if detailsJSON
@@ -22,7 +22,7 @@ data class SQSError(
     val statusCode: Int,
     val forageCode: String,
     val message: String,
-    val details: ErrorMessageDetails? = null
+    val details: ForageErrorDetails? = null
 ) {
     companion object SQSErrorMapper {
         fun from(jsonString: String): SQSError {
@@ -34,7 +34,7 @@ data class SQSError(
             val rawDetails = jsonObject.optJSONObject("details")
 
             val parsedDetails = when (forageCode) {
-                "ebt_error_51" -> ErrorMessageDetails.EbtError51Details.from(rawDetails)
+                "ebt_error_51" -> ForageErrorDetails.EbtError51Details.from(rawDetails)
                 else -> null
             }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/model/Message.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/model/Message.kt
@@ -3,14 +3,14 @@ package com.joinforage.forage.android.network.model
 import org.json.JSONObject
 
 sealed class ErrorMessageDetails {
-    data class InsufficientFundsDetails(val snapBalance: String? = null, val cashBalance: String? = null) : ErrorMessageDetails() {
+    data class EbtError51Details(val snapBalance: String? = null, val cashBalance: String? = null) : ErrorMessageDetails() {
         companion object {
-            fun from(detailsJson: JSONObject?): InsufficientFundsDetails {
+            fun from(detailsJson: JSONObject?): EbtError51Details {
                 // TODO: should probably add a log here if detailsJSON
                 //  is null since it should not be null if this is called
                 val snapBalance = detailsJson?.optString("snap_balance", null)
                 val cashBalance = detailsJson?.optString("cash_balance", null)
-                return InsufficientFundsDetails(snapBalance, cashBalance)
+                return EbtError51Details(snapBalance, cashBalance)
             }
         }
 
@@ -34,7 +34,7 @@ data class SQSError(
             val rawDetails = jsonObject.optJSONObject("details")
 
             val parsedDetails = when (forageCode) {
-                "ebt_error_51" -> ErrorMessageDetails.InsufficientFundsDetails.from(rawDetails)
+                "ebt_error_51" -> ErrorMessageDetails.EbtError51Details.from(rawDetails)
                 else -> null
             }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/model/Message.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/model/Message.kt
@@ -13,6 +13,8 @@ sealed class ErrorMessageDetails {
                 return InsufficientFundsDetails(snapBalance, cashBalance)
             }
         }
+
+        override fun toString(): String = "Cash Balance: $cashBalance\nSNAP Balance: $snapBalance"
     }
 }
 

--- a/forage-android/src/test/java/com/joinforage/forage/android/model/SQSErrorTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/model/SQSErrorTest.kt
@@ -1,0 +1,147 @@
+package com.joinforage.forage.android.model
+
+import com.joinforage.forage.android.network.model.ErrorMessageDetails
+import com.joinforage.forage.android.network.model.SQSError
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+
+class SQSErrorFromTest {
+
+    @Test
+    fun `passing JSON with NO returns null details`() {
+        // Given
+        val jsonString = """{
+            "status_code": 420,
+            "forage_code": "yeah_mon",
+            "message": "I'm on one"
+        }"""
+
+        // When
+        val result = SQSError.SQSErrorMapper.from(jsonString)
+
+        // Then
+        assertThat(result.statusCode).isEqualTo(420)
+        assertThat(result.forageCode).isEqualTo("yeah_mon")
+        assertThat(result.message).isEqualTo("I'm on one")
+        assertThat(result.details).isNull()
+    }
+
+    @Test
+    fun `passing JSON with details=null returns null details`() {
+        // Given
+        val jsonString = """{
+            "status_code": 420,
+            "forage_code": "yeah_mon",
+            "message": "I'm on one",
+            "details": null
+        }"""
+
+        // When
+        val result = SQSError.SQSErrorMapper.from(jsonString)
+
+        // Then
+        assertThat(result.statusCode).isEqualTo(420)
+        assertThat(result.forageCode).isEqualTo("yeah_mon")
+        assertThat(result.message).isEqualTo("I'm on one")
+        assertThat(result.details).isNull()
+    }
+
+    @Test
+    fun `passing SQSError WITH arbitrary details returns null details`() {
+        // Given
+        val jsonString = """{
+            "status_code": 400,
+            "forage_code": "blah_blah",
+            "message": "try again",
+            "details": {
+                "some_value": "hello",
+            }
+        }"""
+
+        // When
+        val result = SQSError.SQSErrorMapper.from(jsonString)
+
+        // Then
+        assertThat(result.statusCode).isEqualTo(400)
+        assertThat(result.forageCode).isEqualTo("blah_blah")
+        assertThat(result.message).isEqualTo("try again")
+        assertThat(result.details).isNull()
+    }
+
+    @Test
+    fun `handles ebt_error_51 correctly`() {
+        // Given
+        val jsonString = """{
+            "status_code": 400,
+            "forage_code": "ebt_error_51",
+            "message": "Insufficient EBT Funds",
+            "details": {
+                "snap_balance": "10.00",
+                "cash_balance": "5.00"
+            }
+        }"""
+
+        // When
+        val result = SQSError.SQSErrorMapper.from(jsonString)
+
+        // Then
+        assertThat(result.statusCode).isEqualTo(400)
+        assertThat(result.forageCode).isEqualTo("ebt_error_51")
+        assertThat(result.message).isEqualTo("Insufficient EBT Funds")
+
+        // be cause we know we're dealing with ebt_error_51, we
+        // can make this type assertion
+        val details = result.details as ErrorMessageDetails.InsufficientFundsDetails
+        assertThat(details.snapBalance).isEqualTo("10.00")
+        assertThat(details.cashBalance).isEqualTo("5.00")
+    }
+}
+
+class InsufficientFundsDetailsTest {
+
+    @Test
+    fun `null details yields null balance fields`() {
+        // Given
+        val jsonObject = null
+
+        // When
+        val result = ErrorMessageDetails.InsufficientFundsDetails.from(jsonObject)
+
+        // Then
+        assertThat(result.snapBalance).isNull()
+        assertThat(result.cashBalance).isNull()
+    }
+
+    @Test
+    fun `missing detail fields yields null for those fields`() {
+        // Given
+        val jsonObject = JSONObject("{}")
+
+        // When
+        val result = ErrorMessageDetails.InsufficientFundsDetails.from(jsonObject)
+
+        // Then
+        assertThat(result.snapBalance).isNull()
+        assertThat(result.cashBalance).isNull()
+    }
+
+    @Test
+    fun `expected fields should work as expected`() {
+        // Given
+        val jsonObject = JSONObject(
+            """{
+                "snap_balance": "200.00",
+                "cash_balance": "100.00"
+            }"""
+        )
+
+        // When
+        val result = ErrorMessageDetails.InsufficientFundsDetails.from(jsonObject)
+
+        // Then
+        val details = result as ErrorMessageDetails.InsufficientFundsDetails
+        assertThat(details.snapBalance).isEqualTo("200.00")
+        assertThat(details.cashBalance).isEqualTo("100.00")
+    }
+}

--- a/forage-android/src/test/java/com/joinforage/forage/android/model/SQSErrorTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/model/SQSErrorTest.kt
@@ -92,7 +92,7 @@ class SQSErrorFromTest {
 
         // be cause we know we're dealing with ebt_error_51, we
         // can make this type assertion
-        val details = result.details as ErrorMessageDetails.InsufficientFundsDetails
+        val details = result.details as ErrorMessageDetails.EbtError51Details
         assertThat(details.snapBalance).isEqualTo("10.00")
         assertThat(details.cashBalance).isEqualTo("5.00")
     }
@@ -106,7 +106,7 @@ class InsufficientFundsDetailsTest {
         val jsonObject = null
 
         // When
-        val result = ErrorMessageDetails.InsufficientFundsDetails.from(jsonObject)
+        val result = ErrorMessageDetails.EbtError51Details.from(jsonObject)
 
         // Then
         assertThat(result.snapBalance).isNull()
@@ -119,7 +119,7 @@ class InsufficientFundsDetailsTest {
         val jsonObject = JSONObject("{}")
 
         // When
-        val result = ErrorMessageDetails.InsufficientFundsDetails.from(jsonObject)
+        val result = ErrorMessageDetails.EbtError51Details.from(jsonObject)
 
         // Then
         assertThat(result.snapBalance).isNull()
@@ -137,10 +137,10 @@ class InsufficientFundsDetailsTest {
         )
 
         // When
-        val result = ErrorMessageDetails.InsufficientFundsDetails.from(jsonObject)
+        val result = ErrorMessageDetails.EbtError51Details.from(jsonObject)
 
         // Then
-        val details = result as ErrorMessageDetails.InsufficientFundsDetails
+        val details = result as ErrorMessageDetails.EbtError51Details
         assertThat(details.snapBalance).isEqualTo("200.00")
         assertThat(details.cashBalance).isEqualTo("100.00")
     }

--- a/forage-android/src/test/java/com/joinforage/forage/android/model/SQSErrorTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/model/SQSErrorTest.kt
@@ -1,6 +1,6 @@
 package com.joinforage.forage.android.model
 
-import com.joinforage.forage.android.network.model.ErrorMessageDetails
+import com.joinforage.forage.android.network.model.ForageErrorDetails
 import com.joinforage.forage.android.network.model.SQSError
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
@@ -92,7 +92,7 @@ class SQSErrorFromTest {
 
         // be cause we know we're dealing with ebt_error_51, we
         // can make this type assertion
-        val details = result.details as ErrorMessageDetails.EbtError51Details
+        val details = result.details as ForageErrorDetails.EbtError51Details
         assertThat(details.snapBalance).isEqualTo("10.00")
         assertThat(details.cashBalance).isEqualTo("5.00")
     }
@@ -106,7 +106,7 @@ class InsufficientFundsDetailsTest {
         val jsonObject = null
 
         // When
-        val result = ErrorMessageDetails.EbtError51Details.from(jsonObject)
+        val result = ForageErrorDetails.EbtError51Details.from(jsonObject)
 
         // Then
         assertThat(result.snapBalance).isNull()
@@ -119,7 +119,7 @@ class InsufficientFundsDetailsTest {
         val jsonObject = JSONObject("{}")
 
         // When
-        val result = ErrorMessageDetails.EbtError51Details.from(jsonObject)
+        val result = ForageErrorDetails.EbtError51Details.from(jsonObject)
 
         // Then
         assertThat(result.snapBalance).isNull()
@@ -137,10 +137,10 @@ class InsufficientFundsDetailsTest {
         )
 
         // When
-        val result = ErrorMessageDetails.EbtError51Details.from(jsonObject)
+        val result = ForageErrorDetails.EbtError51Details.from(jsonObject)
 
         // Then
-        val details = result as ErrorMessageDetails.EbtError51Details
+        val details = result as ForageErrorDetails.EbtError51Details
         assertThat(details.snapBalance).isEqualTo("200.00")
         assertThat(details.cashBalance).isEqualTo("100.00")
     }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/payment/capture/FlowCapturePaymentViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/payment/capture/FlowCapturePaymentViewModel.kt
@@ -66,7 +66,7 @@ class FlowCapturePaymentViewModel @Inject constructor(
 
                     _uiState.value = _uiState.value!!.copy(
                         isLoading = false,
-                        snapResponse = response.errors[0].message
+                        snapResponse = response.errors[0].toString()
                     )
                 }
             }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/payment/capture/FlowCapturePaymentViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/payment/capture/FlowCapturePaymentViewModel.kt
@@ -66,7 +66,8 @@ class FlowCapturePaymentViewModel @Inject constructor(
 
                     _uiState.value = _uiState.value!!.copy(
                         isLoading = false,
-                        snapResponse = response.errors[0].toString()
+                        snapResponse = response.errors[0].message,
+                        snapResponseError = response.errors[0].toString()
                     )
                 }
             }
@@ -98,7 +99,8 @@ class FlowCapturePaymentViewModel @Inject constructor(
 
                     _uiState.value = _uiState.value!!.copy(
                         isLoading = false,
-                        cashResponse = response.errors[0].message
+                        cashResponse = response.errors[0].message,
+                        cashResponseError = response.errors[0].toString()
                     )
                 }
             }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/payment/capture/model/FlowCapturePaymentUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/payment/capture/model/FlowCapturePaymentUIState.kt
@@ -7,7 +7,9 @@ data class FlowCapturePaymentUIState(
     val snapPaymentRef: String,
     val cashPaymentRef: String,
     val snapResponse: String = "",
-    val cashResponse: String = ""
+    val cashResponse: String = "",
+    val snapResponseError: String = "",
+    val cashResponseError: String = ""
 ) {
     val isCaptureSnapVisible = snapPaymentRef.isNotEmpty()
     val isCaptureCashVisible = cashPaymentRef.isNotEmpty()

--- a/sample-app/src/main/res/layout/fragment_flow_capture_payment.xml
+++ b/sample-app/src/main/res/layout/fragment_flow_capture_payment.xml
@@ -11,123 +11,151 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="@dimen/activity_vertical_margin"
-        tools:context=".ui.complete.flow.tokens.FlowTokensFragment">
+    <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fillViewport="true">
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="@dimen/activity_vertical_margin"
+            tools:context=".ui.complete.flow.tokens.FlowTokensFragment">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/snapAmountLayout"
-            isVisible="@{viewModel.uiState.captureSnapVisible}"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp"
-            android:enabled="false"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/snapAmountEditText"
-                android:layout_width="match_parent"
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/snapAmountLayout"
+                isVisible="@{viewModel.uiState.captureSnapVisible}"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:text="@{viewModel.uiState.snapAmountString}" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_margin="16dp"
+                android:enabled="false"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
 
-        <com.joinforage.forage.android.ui.ForagePINEditText
-            android:id="@+id/snapPinEditText"
-            style="@style/ForagePINEditTextStyle"
-            isVisible="@{viewModel.uiState.captureSnapVisible}"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toTopOf="@id/captureSnapAmount"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/snapAmountLayout" />
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/snapAmountEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@{viewModel.uiState.snapAmountString}" />
+            </com.google.android.material.textfield.TextInputLayout>
 
-        <Button
-            android:id="@+id/captureSnapAmount"
-            isVisible="@{viewModel.uiState.captureSnapVisible}"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp"
-            android:text="@string/capture_snap"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/snapPinEditText" />
-
-        <TextView
-            android:id="@+id/snapResponse"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp"
-            android:text="@{viewModel.uiState.snapResponse}"
-            app:layout_constraintBottom_toTopOf="@id/nonSnapAmountLayout"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/captureSnapAmount" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/nonSnapAmountLayout"
-            isVisible="@{viewModel.uiState.captureCashVisible}"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp"
-            android:enabled="false"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/snapResponse">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/nonSnapAmountEditText"
-                android:layout_width="match_parent"
+            <com.joinforage.forage.android.ui.ForagePINEditText
+                android:id="@+id/snapPinEditText"
+                style="@style/ForagePINEditTextStyle"
+                isVisible="@{viewModel.uiState.captureSnapVisible}"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:text="@{viewModel.uiState.cashAmountString}" />
-        </com.google.android.material.textfield.TextInputLayout>
+                app:layout_constraintBottom_toTopOf="@id/captureSnapAmount"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/snapAmountLayout" />
 
-        <com.joinforage.forage.android.ui.ForagePINEditText
-            android:id="@+id/cashPinEditText"
-            style="@style/ForagePINEditTextStyle"
-            isVisible="@{viewModel.uiState.captureCashVisible}"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toTopOf="@id/captureNonSnapAmount"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/nonSnapAmountLayout" />
+            <Button
+                android:id="@+id/captureSnapAmount"
+                isVisible="@{viewModel.uiState.captureSnapVisible}"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:text="@string/capture_snap"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/snapPinEditText" />
 
-        <Button
-            android:id="@+id/captureNonSnapAmount"
-            isVisible="@{viewModel.uiState.captureCashVisible}"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp"
-            android:layout_marginTop="12dp"
-            android:layout_marginEnd="4dp"
-            android:text="@string/capture_non_snap"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cashPinEditText" />
+            <TextView
+                android:id="@+id/snapResponse"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:text="@{viewModel.uiState.snapResponse}"
+                app:layout_constraintTop_toBottomOf="@id/captureSnapAmount"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/snapResponseError" />
 
-        <TextView
-            android:id="@+id/cashResponse"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp"
-            android:text="@{viewModel.uiState.cashResponse}"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/captureNonSnapAmount" />
+            <TextView
+                android:id="@+id/snapResponseError"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:text="@{viewModel.uiState.snapResponseError}"
+                app:layout_constraintTop_toBottomOf="@id/snapResponse"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/nonSnapAmountLayout" />
 
-        <ProgressBar
-            android:id="@+id/progressBar"
-            style="?android:attr/progressBarStyle"
-            isVisible="@{viewModel.uiState.isLoading}"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/nonSnapAmountLayout"
+                isVisible="@{viewModel.uiState.captureCashVisible}"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:enabled="false"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/snapResponseError">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/nonSnapAmountEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@{viewModel.uiState.cashAmountString}" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.joinforage.forage.android.ui.ForagePINEditText
+                android:id="@+id/cashPinEditText"
+                style="@style/ForagePINEditTextStyle"
+                isVisible="@{viewModel.uiState.captureCashVisible}"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toTopOf="@id/captureNonSnapAmount"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/nonSnapAmountLayout" />
+
+            <Button
+                android:id="@+id/captureNonSnapAmount"
+                isVisible="@{viewModel.uiState.captureCashVisible}"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="4dp"
+                android:text="@string/capture_non_snap"
+                app:layout_constraintTop_toBottomOf="@id/cashPinEditText"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/cashResponse" />
+
+            <TextView
+                android:id="@+id/cashResponse"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:text="@{viewModel.uiState.cashResponse}"
+                app:layout_constraintTop_toBottomOf="@id/captureNonSnapAmount"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/cashResponseError" />
+
+            <TextView
+                android:id="@+id/cashResponseError"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:text="@{viewModel.uiState.cashResponseError}"
+                app:layout_constraintTop_toBottomOf="@id/cashResponse"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <ProgressBar
+                android:id="@+id/progressBar"
+                style="?android:attr/progressBarStyle"
+                isVisible="@{viewModel.uiState.isLoading}"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
 </layout>

--- a/sample-app/src/main/res/layout/fragment_flow_capture_payment.xml
+++ b/sample-app/src/main/res/layout/fragment_flow_capture_payment.xml
@@ -11,10 +11,6 @@
 
     </data>
 
-    <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fillViewport="true">
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -157,5 +153,4 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.core.widget.NestedScrollView>
 </layout>


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

<!-- Describe your changes here -->

GoPuff would like the ability to easily read the latest value of the EBT Cash and SNAP values of a PaymentMethod if the PaymentMethod yield an `ebt_error_51` (insufficient funds) error when trying to capture a payment. (see [slack convo](https://joinforage.slack.com/archives/C04FQM5F2DA/p1693922478724489)).

This PR introduces an opaque `.details` field on the `ForageError` that will be `null` for be an instantiation of `ErrorMessageDetails`. Right the only instance is `ErrorMessageDetails.InsufficientFundsDetails` but this can be straightforwardly extended if, in the future, other `ForageError`s ought to carry their own information.

************************************Specifically, this PR does:************************************

- display the full ForageError, including the new details field, as a separate TextView for both
    - SNAP payment capture
    - Cash payment capture
- Add support for ForageErrorObj.details ([linear ticket](https://linear.app/joinforage/issue/FX-528/android-expose-details-field-for-errors)])
- Add helpful comments to error to improve dev experience and reduce integration time

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

- Follow new design (strategy B) [described here](https://www.notion.so/Details-in-Error-Object-Discussion-c1948a15620f477ea9e426e60ad701ca?pvs=21)
- Linear ticket: https://linear.app/joinforage/issue/FX-528/android-expose-details-field-for-errors

## Test Plan

<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ Android QA Tests pass on Github
- ✅ Unit Tests passed locally

## Screenshots

### Sample App for Insufficient Funds
<img src="https://github.com/teamforage/forage-android-sdk/assets/12377418/88fd16f6-d0e4-40e9-aec3-f1899eca0a2e" height="500">

### Sample App for Stolen Card Error

<img src="https://github.com/teamforage/forage-android-sdk/assets/12377418/7bcf651e-cf1d-4d52-a92e-5f8cd0303b71" height="500">

## How

<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is but should be released at the same times as [the iOS equivalent](https://github.com/teamforage/forage-ios-sdk/pull/101))

Can share the following snippet with GoPuff:

```kotlin
when (response) {
	is ForageApiResponse.Success -> {
	    // handle successful capture
	}
	is ForageApiResponse.Failure -> {
	    val error = response.errors[0]
	    
	    // handle Insufficient Funds error
	    if (error.code == "ebt_error_51") {
	        val details = error.details as ForageErrorDetails.EbtError51Details
	        val (snapBalance, cashBalance) = details

	        // do something with balances ...
	    }
	}
}
```