### PR TITLE
[SYM-114] Support custom background + border color for PIN input field

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/BTVaultWrapper.kt
@@ -31,6 +31,7 @@ internal class BTVaultWrapper @JvmOverloads constructor(
                     com.joinforage.forage.android.R.styleable.ForagePINEditText_boxStrokeColor,
                     getThemeAccentColor(context)
                 )
+                val boxBackgroundColor = getColor(com.joinforage.forage.android.R.styleable.ForagePINEditText_boxBackgroundColor, Color.TRANSPARENT)
                 val defRadius = resources.getDimension(com.joinforage.forage.android.R.dimen.default_horizontal_field)
                 val boxCornerRadius =
                     getDimension(com.joinforage.forage.android.R.styleable.ForagePINEditText_boxCornerRadius, defRadius)
@@ -63,10 +64,10 @@ internal class BTVaultWrapper @JvmOverloads constructor(
                             shape = GradientDrawable.RECTANGLE
                             cornerRadii = floatArrayOf(boxCornerRadiusTopStart, boxCornerRadiusTopStart, boxCornerRadiusTopEnd, boxCornerRadiusTopEnd, boxCornerRadiusBottomStart, boxCornerRadiusBottomStart, boxCornerRadiusBottomEnd, boxCornerRadiusBottomEnd)
                             setStroke(5, boxStrokeColor)
+                            setColor(boxBackgroundColor)
                         }
 
                         background = customBackground
-
                         gravity = Gravity.CENTER
                     }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/VGSVaultWrapper.kt
@@ -36,6 +36,7 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
                         com.joinforage.forage.android.R.styleable.ForagePINEditText_boxStrokeColor,
                         getThemeAccentColor(context)
                     )
+                    val boxBackgroundColor = getColor(com.joinforage.forage.android.R.styleable.ForagePINEditText_boxBackgroundColor, Color.TRANSPARENT)
                     val defRadius = resources.getDimension(com.joinforage.forage.android.R.dimen.default_horizontal_field)
                     val boxCornerRadius =
                         getDimension(com.joinforage.forage.android.R.styleable.ForagePINEditText_boxCornerRadius, defRadius)
@@ -68,6 +69,7 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
                             shape = GradientDrawable.RECTANGLE
                             cornerRadii = floatArrayOf(boxCornerRadiusTopStart, boxCornerRadiusTopStart, boxCornerRadiusTopEnd, boxCornerRadiusTopEnd, boxCornerRadiusBottomStart, boxCornerRadiusBottomStart, boxCornerRadiusBottomEnd, boxCornerRadiusBottomEnd)
                             setStroke(5, boxStrokeColor)
+                            setColor(boxBackgroundColor)
                         }
                         background = customBackground
 

--- a/forage-android/src/main/res/values/attrs.xml
+++ b/forage-android/src/main/res/values/attrs.xml
@@ -24,6 +24,7 @@
         <attr name="textSize" />
         <attr name="textColor" />
         <attr name="boxStrokeColor" />
+        <attr name="boxBackgroundColor" />
         <attr name="hintTextColor" format="color" />
         <attr format="dimension" name="boxCornerRadiusTopEnd" />
 

--- a/forage-android/src/main/res/values/attrs.xml
+++ b/forage-android/src/main/res/values/attrs.xml
@@ -24,7 +24,7 @@
         <attr name="textSize" />
         <attr name="textColor" />
         <attr name="boxStrokeColor" />
-        <attr name="boxBackgroundColor" />
+        <attr name="boxBackgroundColor" format="color" />
         <attr name="hintTextColor" format="color" />
         <attr format="dimension" name="boxCornerRadiusTopEnd" />
 


### PR DESCRIPTION
## What

- Add background and border color for PIN input field.

## Test Plan

- ❌ I've added unit tests for this change. <!-- If not, why? -->
- ❌ The reviewer should manually test the changes in this PR. <!-- If so, please describe how to test below. -->

## Demo

Custom:

<table><tr>
<td> 
  <p align="center" style="padding: 10px">
    <img width="282" alt="Screenshot 2023-09-11 at 16 09 54" src="https://github.com/teamforage/forage-android-sdk/assets/136574617/a63fa64c-1871-445c-8c46-999fcf00526e">
    <br>
    <em style="color: grey">VGS</em>
  </p> 
</td>
<td> 
  <p align="center">
    <img width="283" alt="Screenshot 2023-09-11 at 16 12 35" src="https://github.com/teamforage/forage-android-sdk/assets/136574617/fb57eb0d-31f2-44d3-9b91-3b77f6c50244">
    <br>
    <em style="color: grey">BT</em>
  </p> 
</td>
</tr></table>

Default:

<table><tr>
<td> 
  <p align="center" style="padding: 10px">
    <img width="282" alt="Screenshot 2023-09-07 at 20 39 46" src="https://github.com/teamforage/forage-android-sdk/assets/136574617/4e329fac-ac77-4a50-b80a-dbbb5c4438e8">
    <br>
    <em style="color: grey">VGS</em>
  </p> 
</td>
<td> 
  <p align="center">
    <img width="286" alt="Screenshot 2023-09-11 at 16 28 40" src="https://github.com/teamforage/forage-android-sdk/assets/136574617/35e2a7c3-0ac1-4987-927a-ba751e5a9348">
    <br>
    <em style="color: grey">BT</em>
  </p> 
</td>
</tr></table>