### PR TITLE
[FX-518] Can auto-generate docs for forage-android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ local.properties
 SecretRingKey.gpg
 /buildSrc/build/
 *.jks
+
+# Dokka HTML documentation
+reference-docs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,3 +103,17 @@ This project uses [Spotless](https://github.com/diffplug/spotless) to format the
 ### Optimizing SVGs
 
 We can run [avocado](https://github.com/alexjlockwood/avocado) command line tool to optimize the SVGs before importing them to the project.
+
+## Reference Documentation
+
+You may generate the reference documentation locally by running:
+
+```bash
+./gradlew dokkaHtml # generate reference-docs/
+npx http-serve reference-docs
+
+open http://localhost:8080
+
+# or alternatively
+open reference-docs/index.html # which sometimes has issues loading the navigation sidebar
+```

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,21 @@ plugins {
     id 'com.google.dagger.hilt.android' version '2.44' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
     id 'org.jetbrains.kotlinx.kover' version '0.6.1'
+    id "org.jetbrains.dokka" version "1.9.0"
+}
+
+subprojects {
+    if (name != "forage-android") return
+
+    apply plugin: 'org.jetbrains.dokka'
+
+    tasks.named("dokkaHtml", org.jetbrains.dokka.gradle.DokkaTask.class) {
+        outputDirectory.set(file("${rootDir}/reference-docs"))
+        
+        pluginsMapConfiguration.set(
+            ["org.jetbrains.dokka.base.DokkaBase": """{ "separateInheritedMembers": true}"""]
+        )
+    }
 }
 
 spotless {


### PR DESCRIPTION
## What

- Adds SDK reference docs generator [using Dokka](https://github.com/Kotlin/dokka)

### Demo here 👉🏻  https://64ff457005e28927ecd4924f--endearing-semolina-5b7c34.netlify.app/

```
# sync Gradle in Android Studio

./gradlew dokkaHtml # generate reference-docs/

cd reference-docs/ # 
open index.html # or npx http-serve to open the docs website.
```

## Why

- [Separate inherited members in docs](https://github.com/teamforage/forage-android-sdk/pull/90/commits/789a53d7bb974c8b53d032b7428fe06a08842c00) 
  - Helps clean up the docs pages where we inherit from chunky classes like LinearLayout.
  - With the latest version of Dokka, we cannot hide these inherited members entirely, we can only separate them.

## Tests Added / Updated?

No, gradle change.

Used netlify drop to deploy "temporary" hosted version of these docs to review them.

## Screenshots

<img src="https://github.com/teamforage/forage-android-sdk/assets/32694765/1e90e4e8-4d02-4b1d-a895-63f9ab964d4c" width="400">

## How

- Can be released as-is and allow us to manually generate docs
- Created a ticket to make the [internal code internal ](https://linear.app/joinforage/issue/FX-543/make-internal-things-internal-in-android-sdk)
- Will/can be followed by Github action change PR so we can auto deploy docs on new releases.