### PR TITLE
Don't short circuit integ test before retry

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -52,7 +52,7 @@ jobs:
         run: |
           cd mobile-qa-tests
           pip install -r requirements.txt
-          pytest android/tests/test_basic_flow.py
+          pytest android/tests/test_basic_flow.py || true
           pytest --lf --last-failed-no-failures none  --suppress-no-test-exit-code android/tests/test_basic_flow.py
 
       - name: Upload build outputs (APKs and SDK AARs)


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
See title.
<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
Appears to want to retry failed tests with the second line but won't do so because the error code of the first failure will short-circuit the Github Action. Use `|| true` to always return 0 and let the second attempt have the final say. 
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
Test change.

## Demo
CI change only.
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
Merge.
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
