### PR TITLE
[SYM-115] Support border width, color and corner radius for PAN

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -64,6 +64,11 @@ class ForagePANEditText @JvmOverloads constructor(
                         getThemeAccentColor(context)
                     )
 
+                    val focusedBoxStrokeWidth = getDimension(
+                        R.styleable.ForagePANEditText_boxStrokeWidthFocused,
+                        3f
+                    )
+
                     val strokeWidth = getFloat(
                         R.styleable.ForagePANEditText_android_strokeWidth,
                         3f
@@ -91,6 +96,8 @@ class ForagePANEditText @JvmOverloads constructor(
                                 LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
 
                             boxStrokeColor = focusedBoxStrokeColor
+                            boxStrokeWidthFocused = focusedBoxStrokeWidth.toInt()
+
                             boxStrokeWidth = strokeWidth.toInt()
                             hintTextColor = ColorStateList.valueOf(focusedBoxStrokeColor)
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -1,6 +1,7 @@
 package com.joinforage.forage.android.ui
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.graphics.Color
 import android.graphics.Typeface
 import android.text.Editable
@@ -58,6 +59,16 @@ class ForagePANEditText @JvmOverloads constructor(
         context.obtainStyledAttributes(attrs, R.styleable.ForagePANEditText, defStyleAttr, 0)
             .apply {
                 try {
+                    val focusedBoxStrokeColor = getColor(
+                        R.styleable.ForagePANEditText_android_strokeColor,
+                        getThemeAccentColor(context)
+                    )
+
+                    val strokeWidth = getFloat(
+                        R.styleable.ForagePANEditText_android_strokeWidth,
+                        3f
+                    )
+
                     val textInputLayoutStyleAttribute =
                         getResourceId(R.styleable.ForagePANEditText_textInputLayoutStyle, 0)
                     val textColor =
@@ -65,10 +76,30 @@ class ForagePANEditText @JvmOverloads constructor(
 
                     val textSize = getDimension(R.styleable.ForagePANEditText_android_textSize, -1f)
 
+                    val defRadius = resources.getDimension(R.dimen.default_horizontal_field)
+                    val focusedBoxCornerRadius =
+                        getDimension(R.styleable.ForagePANEditText_cornerRadius, defRadius)
+
+                    val boxCornerRadiusTopStart = getBoxCornerRadiusTopStart(focusedBoxCornerRadius)
+                    val boxCornerRadiusTopEnd = getBoxCornerRadiusTopEnd(focusedBoxCornerRadius)
+                    val boxCornerRadiusBottomStart = getBoxCornerRadiusBottomStart(focusedBoxCornerRadius)
+                    val boxCornerRadiusBottomEnd = getBoxCornerRadiusBottomEnd(focusedBoxCornerRadius)
+
                     textInputLayout =
                         TextInputLayout(context, null, textInputLayoutStyleAttribute).apply {
                             layoutParams =
                                 LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
+
+                            boxStrokeColor = focusedBoxStrokeColor
+                            boxStrokeWidth = strokeWidth.toInt()
+                            hintTextColor = ColorStateList.valueOf(focusedBoxStrokeColor)
+
+                            setBoxCornerRadii(
+                                boxCornerRadiusTopStart,
+                                boxCornerRadiusTopEnd,
+                                boxCornerRadiusBottomStart,
+                                boxCornerRadiusBottomEnd
+                            )
                         }
 
                     textInputEditText = TextInputEditText(textInputLayout.context).apply {
@@ -180,6 +211,9 @@ class ForagePANEditText @JvmOverloads constructor(
     }
     override fun setHintTextColor(hintTextColor: Int) {
         // no-ops for now
+    }
+    override fun setBoxStrokeColor(boxStrokeColor: Int) {
+        textInputLayout.boxStrokeColor = boxStrokeColor
     }
 
     private fun disableCopyCardNumber() {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -92,13 +92,12 @@ class ForagePANEditText @JvmOverloads constructor(
                             layoutParams =
                                 LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
 
-                            // Set stroke color/width on focused text
+                            // Set stroke color on focused text
                             boxStrokeColor = focusedBoxStrokeColor
+                            // Set stroke width on focused text
                             boxStrokeWidthFocused = focusedBoxStrokeWidth.toInt()
-
                             // Set stroke width on unfocused text
                             boxStrokeWidth = strokeWidth.toInt()
-
                             // Match hint text color with stroke color
                             hintTextColor = ColorStateList.valueOf(focusedBoxStrokeColor)
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -92,10 +92,14 @@ class ForagePANEditText @JvmOverloads constructor(
                             layoutParams =
                                 LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
 
+                            // Set stroke color/width on focused text
                             boxStrokeColor = focusedBoxStrokeColor
                             boxStrokeWidthFocused = focusedBoxStrokeWidth.toInt()
 
+                            // Set stroke width on unfocused text
                             boxStrokeWidth = strokeWidth.toInt()
+
+                            // Match hint text color with stroke color
                             hintTextColor = ColorStateList.valueOf(focusedBoxStrokeColor)
 
                             setBoxCornerRadii(

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -130,4 +130,7 @@ class ForagePINEditText @JvmOverloads constructor(
     override fun setHintTextColor(hintTextColor: Int) {
         vault.setHintTextColor(hintTextColor)
     }
+    override fun setBoxStrokeColor(boxStrokeColor: Int) {
+        // no-ops for now
+    }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePanTextUtils.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePanTextUtils.kt
@@ -1,0 +1,30 @@
+package com.joinforage.forage.android.ui
+import android.content.Context
+import android.content.res.TypedArray
+import android.util.TypedValue
+
+internal fun getThemeAccentColor(context: Context): Int {
+    val outValue = TypedValue()
+    context.theme.resolveAttribute(android.R.attr.colorAccent, outValue, true)
+    return outValue.data
+}
+internal fun TypedArray.getBoxCornerRadiusBottomStart(boxCornerRadius: Float): Float {
+    val boxCornerRadiusBottomStart =
+        getDimension(com.joinforage.forage.android.R.styleable.ForagePANEditText_boxCornerBottomStart, 0f)
+    return if (boxCornerRadiusBottomStart == 0f) boxCornerRadius else boxCornerRadiusBottomStart
+}
+internal fun TypedArray.getBoxCornerRadiusTopEnd(boxCornerRadius: Float): Float {
+    val boxCornerRadiusTopEnd =
+        getDimension(com.joinforage.forage.android.R.styleable.ForagePANEditText_boxCornerTopEnd, 0f)
+    return if (boxCornerRadiusTopEnd == 0f) boxCornerRadius else boxCornerRadiusTopEnd
+}
+internal fun TypedArray.getBoxCornerRadiusBottomEnd(boxCornerRadius: Float): Float {
+    val boxCornerRadiusBottomEnd =
+        getDimension(com.joinforage.forage.android.R.styleable.ForagePANEditText_boxCornerBottomEnd, 0f)
+    return if (boxCornerRadiusBottomEnd == 0f) boxCornerRadius else boxCornerRadiusBottomEnd
+}
+internal fun TypedArray.getBoxCornerRadiusTopStart(boxCornerRadius: Float): Float {
+    val boxCornerRadiusTopStart =
+        getDimension(com.joinforage.forage.android.R.styleable.ForagePANEditText_boxCornerTopStart, 0f)
+    return if (boxCornerRadiusTopStart == 0f) boxCornerRadius else boxCornerRadiusTopStart
+}

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageUI.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageUI.kt
@@ -21,6 +21,7 @@ interface ForageUI {
     fun setTextSize(textSize: Float)
     fun setHint(hint: String)
     fun setHintTextColor(hintTextColor: Int)
+    fun setBoxStrokeColor(boxStrokeColor: Int)
 
     fun getElementState(): ElementState
     fun setOnFocusEventListener(l: SimpleElementListener)

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/FormatPanTextWatcher.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/FormatPanTextWatcher.kt
@@ -1,5 +1,8 @@
 package com.joinforage.forage.android.ui
 
+import android.content.Context
+import android.content.res.TypedArray
+import android.util.TypedValue
 import android.text.Editable
 import android.text.TextWatcher
 import android.widget.EditText
@@ -77,6 +80,36 @@ fun getTransformedPosition(pos: Int, oldPrettyText: String, newPrettyText: Strin
     // ensure we are within the newPrettyText's bounds
     val shiftedPos = pos + spacesShift
     return minOf(shiftedPos, newPrettyText.length)
+}
+
+fun getThemeAccentColor(context: Context): Int {
+    val outValue = TypedValue()
+    context.theme.resolveAttribute(android.R.attr.colorAccent, outValue, true)
+    return outValue.data
+}
+
+fun TypedArray.getBoxCornerRadiusBottomStart(boxCornerRadius: Float): Float {
+    val boxCornerRadiusBottomStart =
+        getDimension(com.joinforage.forage.android.R.styleable.ForagePANEditText_boxCornerBottomStart, 0f)
+    return if (boxCornerRadiusBottomStart == 0f) boxCornerRadius else boxCornerRadiusBottomStart
+}
+
+fun TypedArray.getBoxCornerRadiusTopEnd(boxCornerRadius: Float): Float {
+    val boxCornerRadiusTopEnd =
+        getDimension(com.joinforage.forage.android.R.styleable.ForagePANEditText_boxCornerTopEnd, 0f)
+    return if (boxCornerRadiusTopEnd == 0f) boxCornerRadius else boxCornerRadiusTopEnd
+}
+
+fun TypedArray.getBoxCornerRadiusBottomEnd(boxCornerRadius: Float): Float {
+    val boxCornerRadiusBottomEnd =
+        getDimension(com.joinforage.forage.android.R.styleable.ForagePANEditText_boxCornerBottomEnd, 0f)
+    return if (boxCornerRadiusBottomEnd == 0f) boxCornerRadius else boxCornerRadiusBottomEnd
+}
+
+fun TypedArray.getBoxCornerRadiusTopStart(boxCornerRadius: Float): Float {
+    val boxCornerRadiusTopStart =
+        getDimension(com.joinforage.forage.android.R.styleable.ForagePANEditText_boxCornerTopStart, 0f)
+    return if (boxCornerRadiusTopStart == 0f) boxCornerRadius else boxCornerRadiusTopStart
 }
 
 class FormatPanTextWatcher(

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/FormatPanTextWatcher.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/FormatPanTextWatcher.kt
@@ -1,10 +1,7 @@
 package com.joinforage.forage.android.ui
 
-import android.content.Context
-import android.content.res.TypedArray
 import android.text.Editable
 import android.text.TextWatcher
-import android.util.TypedValue
 import android.widget.EditText
 import com.joinforage.forage.android.model.queryForStateIIN
 
@@ -80,36 +77,6 @@ fun getTransformedPosition(pos: Int, oldPrettyText: String, newPrettyText: Strin
     // ensure we are within the newPrettyText's bounds
     val shiftedPos = pos + spacesShift
     return minOf(shiftedPos, newPrettyText.length)
-}
-
-fun getThemeAccentColor(context: Context): Int {
-    val outValue = TypedValue()
-    context.theme.resolveAttribute(android.R.attr.colorAccent, outValue, true)
-    return outValue.data
-}
-
-fun TypedArray.getBoxCornerRadiusBottomStart(boxCornerRadius: Float): Float {
-    val boxCornerRadiusBottomStart =
-        getDimension(com.joinforage.forage.android.R.styleable.ForagePANEditText_boxCornerBottomStart, 0f)
-    return if (boxCornerRadiusBottomStart == 0f) boxCornerRadius else boxCornerRadiusBottomStart
-}
-
-fun TypedArray.getBoxCornerRadiusTopEnd(boxCornerRadius: Float): Float {
-    val boxCornerRadiusTopEnd =
-        getDimension(com.joinforage.forage.android.R.styleable.ForagePANEditText_boxCornerTopEnd, 0f)
-    return if (boxCornerRadiusTopEnd == 0f) boxCornerRadius else boxCornerRadiusTopEnd
-}
-
-fun TypedArray.getBoxCornerRadiusBottomEnd(boxCornerRadius: Float): Float {
-    val boxCornerRadiusBottomEnd =
-        getDimension(com.joinforage.forage.android.R.styleable.ForagePANEditText_boxCornerBottomEnd, 0f)
-    return if (boxCornerRadiusBottomEnd == 0f) boxCornerRadius else boxCornerRadiusBottomEnd
-}
-
-fun TypedArray.getBoxCornerRadiusTopStart(boxCornerRadius: Float): Float {
-    val boxCornerRadiusTopStart =
-        getDimension(com.joinforage.forage.android.R.styleable.ForagePANEditText_boxCornerTopStart, 0f)
-    return if (boxCornerRadiusTopStart == 0f) boxCornerRadius else boxCornerRadiusTopStart
 }
 
 class FormatPanTextWatcher(

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/FormatPanTextWatcher.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/FormatPanTextWatcher.kt
@@ -2,9 +2,9 @@ package com.joinforage.forage.android.ui
 
 import android.content.Context
 import android.content.res.TypedArray
-import android.util.TypedValue
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.TypedValue
 import android.widget.EditText
 import com.joinforage.forage.android.model.queryForStateIIN
 

--- a/forage-android/src/main/res/values/attrs.xml
+++ b/forage-android/src/main/res/values/attrs.xml
@@ -21,6 +21,7 @@
 
         <attr name="android:strokeColor" />
         <attr name="android:strokeWidth" />
+        <attr name="boxStrokeWidthFocused" />
     </declare-styleable>
 
     <!-- Style attributes for the ForagePanEditText component. -->

--- a/forage-android/src/main/res/values/attrs.xml
+++ b/forage-android/src/main/res/values/attrs.xml
@@ -12,6 +12,15 @@
         <attr name="android:textColor" />
         <!-- Reusing android:textColor attribute -->
         <attr name="android:textSize" />
+
+        <attr name="cornerRadius" />
+        <attr format="dimension" name="boxCornerTopEnd" />
+        <attr format="dimension" name="boxCornerTopStart" />
+        <attr format="dimension" name="boxCornerBottomStart" />
+        <attr format="dimension" name="boxCornerBottomEnd" />
+
+        <attr name="android:strokeColor" />
+        <attr name="android:strokeWidth" />
     </declare-styleable>
 
     <!-- Style attributes for the ForagePanEditText component. -->

--- a/forage-android/src/main/res/values/attrs.xml
+++ b/forage-android/src/main/res/values/attrs.xml
@@ -13,15 +13,15 @@
         <!-- Reusing android:textColor attribute -->
         <attr name="android:textSize" />
 
-        <attr name="cornerRadius" />
+        <attr format="dimension" name="cornerRadius" />
         <attr format="dimension" name="boxCornerTopEnd" />
         <attr format="dimension" name="boxCornerTopStart" />
         <attr format="dimension" name="boxCornerBottomStart" />
         <attr format="dimension" name="boxCornerBottomEnd" />
 
-        <attr name="android:strokeColor" />
-        <attr name="android:strokeWidth" />
-        <attr name="boxStrokeWidthFocused" />
+        <attr format="color" name="android:strokeColor" />
+        <attr format="float" name="android:strokeWidth" />
+        <attr format="dimension" name="boxStrokeWidthFocused" />
     </declare-styleable>
 
     <!-- Style attributes for the ForagePanEditText component. -->

--- a/sample-app/src/main/res/values/colors.xml
+++ b/sample-app/src/main/res/values/colors.xml
@@ -11,4 +11,5 @@
     <color name="colorAccent">#26A6D4</color>
     <color name="yellow_800">#F9A825</color>
     <color name="red">#F50057</color>
+    <color name="mtrl_textinput_default_box_stroke_color">#FF3700B3</color>
 </resources>

--- a/sample-app/src/main/res/values/styles.xml
+++ b/sample-app/src/main/res/values/styles.xml
@@ -15,6 +15,7 @@
     <style name="TokenizeForageTextInputLayoutStyle" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
         <item name="android:hint">@string/tokenize_forage_edit_text_hint</item>
         <item name="boxStrokeWidth">1dp</item>
+        <item name="boxStrokeColor">@color/mtrl_textinput_default_box_stroke_color</item>
     </style>
 
     <!-- Style for the first ForagePanEditText in catalog Fragment. -->

--- a/sample-app/src/main/res/values/styles.xml
+++ b/sample-app/src/main/res/values/styles.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="DefaultForagePANEditTextStyle">
+    <style name="DefaultForagePANEditTextStyle" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+        <item name="android:strokeColor">@color/purple_700</item>
+        <item name="cornerRadius">@dimen/corner_radius</item>
         <!-- Default properties can be added here that will be applied to every ForagePANEditText. -->
     </style>
 


### PR DESCRIPTION
## What

Add support for border width, border color and corner radius for PAN field.

## Test Plan

- ❌ I've added unit tests for this change.
- ❌ The reviewer should manually test the changes in this PR.

## Demo

Focused:

<table><tr>
<td> 
  <p align="center" style="padding: 10px">
<img width="316" alt="Screenshot 2023-09-12 at 16 17 31" src="https://github.com/teamforage/forage-android-sdk/assets/136574617/004952a0-3365-4997-92a1-e82eb849520e">
    <br>
    <em style="color: grey">Default</em>
  </p> 
</td>
<td> 
  <p align="center">
<img width="315" alt="Screenshot 2023-09-12 at 16 16 26" src="https://github.com/teamforage/forage-android-sdk/assets/136574617/e5eb50bf-ff6b-49f7-a162-1e29c8789646">
    <br>
    <em style="color: grey">Custom</em>
  </p> 
</td>
</tr></table>

Unfocused:

<table><tr>
<td> 
  <p align="center" style="padding: 10px">
<img width="316" alt="Screenshot 2023-09-12 at 16 17 44" src="https://github.com/teamforage/forage-android-sdk/assets/136574617/0448c499-d640-4145-9ec9-2891477eb383">
    <br>
    <em style="color: grey">Default</em>
  </p> 
</td>
<td> 
  <p align="center">
<img width="316" alt="Screenshot 2023-09-12 at 16 35 56" src="https://github.com/teamforage/forage-android-sdk/assets/136574617/0bfc4ff5-0cc6-43c0-baf7-9faab122b2ec">
    <br>
    <em style="color: grey">Custom</em>
  </p> 
</td>
</tr></table>
