### PR TITLE
[POP-180] Adding jitter to retry logic

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/Utils.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/Utils.kt
@@ -1,0 +1,14 @@
+package com.joinforage.forage.android
+
+import kotlin.random.Random
+
+/**
+ * We generate a random jitter amount to add to our retry delay when polling for the status of
+ * Payments and Payment Methods so that we can avoid a thundering herd scenario in which there are
+ * several requests retrying at the same exact time.
+ *
+ * Returns a random integer between -25 and 25
+ */
+internal fun getJitterAmount(random: Random = Random.Default): Int {
+    return random.nextInt(-25, 26)
+}

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
@@ -2,6 +2,7 @@ package com.joinforage.forage.android.network.data
 
 import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.core.Log
+import com.joinforage.forage.android.getJitterAmount
 import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.model.Payment
 import com.joinforage.forage.android.model.PaymentMethod
@@ -13,7 +14,6 @@ import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.network.model.Message
 import kotlinx.coroutines.delay
-import kotlin.random.Random
 
 internal class CapturePaymentRepository(
     private val pinCollector: PinCollector,
@@ -150,9 +150,7 @@ internal class CapturePaymentRepository(
             }
 
             attempt += 1
-            val random = Random.Default
-            val jitter = random.nextInt(-25, 26)
-            delay(POLLING_INTERVAL_IN_MILLIS + jitter)
+            delay(POLLING_INTERVAL_IN_MILLIS + getJitterAmount())
         }
 
         logger.i(

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
@@ -13,6 +13,7 @@ import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.network.model.Message
 import kotlinx.coroutines.delay
+import kotlin.random.Random
 
 internal class CapturePaymentRepository(
     private val pinCollector: PinCollector,
@@ -149,7 +150,9 @@ internal class CapturePaymentRepository(
             }
 
             attempt += 1
-            delay(POLLING_INTERVAL_IN_MILLIS)
+            val random = Random.Default
+            val jitter = random.nextInt(-25, 26)
+            delay(POLLING_INTERVAL_IN_MILLIS + jitter)
         }
 
         logger.i(

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
@@ -2,6 +2,7 @@ package com.joinforage.forage.android.network.data
 
 import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.core.Log
+import com.joinforage.forage.android.getJitterAmount
 import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.EncryptionKeyService
@@ -11,7 +12,6 @@ import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.network.model.Message
 import kotlinx.coroutines.delay
-import kotlin.random.Random
 
 internal class CheckBalanceRepository(
     private val pinCollector: PinCollector,
@@ -132,9 +132,7 @@ internal class CheckBalanceRepository(
             }
 
             attempt += 1
-            val random = Random.Default
-            val jitter = random.nextInt(-25, 26)
-            delay(POLLING_INTERVAL_IN_MILLIS + jitter)
+            delay(POLLING_INTERVAL_IN_MILLIS + getJitterAmount())
         }
 
         logger.i(

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
@@ -11,6 +11,7 @@ import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.network.model.Message
 import kotlinx.coroutines.delay
+import kotlin.random.Random
 
 internal class CheckBalanceRepository(
     private val pinCollector: PinCollector,
@@ -131,7 +132,9 @@ internal class CheckBalanceRepository(
             }
 
             attempt += 1
-            delay(POLLING_INTERVAL_IN_MILLIS)
+            val random = Random.Default
+            val jitter = random.nextInt(-25, 26)
+            delay(POLLING_INTERVAL_IN_MILLIS + jitter)
         }
 
         logger.i(

--- a/forage-android/src/test/java/com/joinforage/forage/android/utils/UtilsTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/utils/UtilsTest.kt
@@ -1,0 +1,24 @@
+package com.joinforage.forage.android.utils
+
+import com.joinforage.forage.android.getJitterAmount
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import kotlin.random.Random
+
+class UtilsTest {
+    @Test
+    fun `Jitter value should be in range -25 to 25`() = runTest {
+        val fixedRandomZero = Random(13)
+        val jitterZero = getJitterAmount(fixedRandomZero)
+        assertThat(jitterZero).isEqualTo(0)
+
+        val fixedRandomMin = Random(16)
+        val jitterMin = getJitterAmount(fixedRandomMin)
+        assertThat(jitterMin).isEqualTo(-25)
+
+        val fixedRandomMax = Random(60)
+        val jitterMax = getJitterAmount(fixedRandomMax)
+        assertThat(jitterMax).isEqualTo(25)
+    }
+}


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

Adding +/- 25ms jitter to polling so that we can avoid a thundering herd issue if our clients retry all at the same time. Now all retries to polling will have some randomness added to their delay interval.

## Why

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- ✅ | ❌ I've added unit tests for this change. <!-- If not, why? -->
- ✅ | ❌ The reviewer should manually test the changes in this PR. <!-- If so, please describe how to test below. -->

## Demo

<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How

<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
