### PR TITLE
[POP-76] Configure polling with feature flag

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
@@ -1,5 +1,6 @@
 package com.joinforage.forage.android.network.data
 
+import com.joinforage.forage.android.LDManager
 import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.core.telemetry.Log
 import com.joinforage.forage.android.getJitterAmount
@@ -74,6 +75,7 @@ internal class CheckBalanceRepository(
         paymentMethodRef: String
     ): ForageApiResponse<String> {
         var attempt = 1
+        val pollingIntervals = LDManager.getPollingIntervals()
 
         while (true) {
             logger.i(
@@ -134,8 +136,15 @@ internal class CheckBalanceRepository(
                 return ForageApiResponse.Failure(listOf(ForageError(500, "unknown_server_error", "Unknown Server Error")))
             }
 
+            val index = attempt - 1
+            var intervalTime: Long = if (index < pollingIntervals.size) {
+                pollingIntervals[index]
+            } else {
+                1000L
+            }
+
             attempt += 1
-            delay(POLLING_INTERVAL_IN_MILLIS + getJitterAmount())
+            delay(intervalTime + getJitterAmount())
         }
 
         logger.i(
@@ -163,7 +172,6 @@ internal class CheckBalanceRepository(
     }
 
     companion object {
-        private const val POLLING_INTERVAL_IN_MILLIS = 1000L
         private const val MAX_ATTEMPTS = 10
 
         private fun ForageApiResponse<String>.getStringResponse() = when (this) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -102,7 +102,10 @@ class ForagePINEditText @JvmOverloads constructor(
         // its relying on forageConfig under the hood. This
         // relationship will be made explicit once we drop
         // StopgapGlobalState
-        val vaultType = LDManager.getVaultProvider(context.applicationContext as Application, logger)
+
+        LDManager.initialize(context.applicationContext as Application, logger)
+        val vaultType = LDManager.getVaultProvider()
+
         _SET_ONLY_vault = if (vaultType == VaultType.BT_VAULT_TYPE) {
             btVaultWrapper
         } else {

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
@@ -42,13 +42,15 @@ class LaunchDarklyTest() {
         // Set the test data to send all traffic to BT
         td.update(td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(LDValue.of(alwaysBT)))
         val app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
-        val vaultType = LDManager.getVaultProvider(app, logger = Log.getSilentInstance(), dataSource = td)
+        LDManager.initialize(app, logger = Log.getSilentInstance(), dataSource = td)
+        val vaultType = LDManager.getVaultProvider()
         assertThat(vaultType).isEqualTo(VaultType.BT_VAULT_TYPE)
 
         // Update the test data to send all traffic to VGS
         // Since ForageSDK is a singleton, we should still return BT in this instance
         td.update(td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(LDValue.of(alwaysVGS)))
-        val secondVaultType = LDManager.getVaultProvider(app, logger = Log.getSilentInstance(), dataSource = td)
+
+        val secondVaultType = LDManager.getVaultProvider()
         assertThat(secondVaultType).isEqualTo(VaultType.BT_VAULT_TYPE)
     }
 
@@ -57,13 +59,27 @@ class LaunchDarklyTest() {
         // Set the test data to send all traffic to VGS
         td.update(td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(LDValue.of(alwaysVGS)))
         val app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
-        val vaultType = LDManager.getVaultProvider(app, logger = Log.getSilentInstance(), dataSource = td)
+
+        LDManager.initialize(app, logger = Log.getSilentInstance(), dataSource = td)
+        val vaultType = LDManager.getVaultProvider()
         assertThat(vaultType).isEqualTo(VaultType.VGS_VAULT_TYPE)
 
         // Update the test data to send all traffic to BT
         // Since ForageSDK is a singleton, we should still return VGS in this instance
         td.update(td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(LDValue.of(alwaysBT)))
-        val secondVaultType = LDManager.getVaultProvider(app, logger = Log.getSilentInstance(), dataSource = td)
+
+        val secondVaultType = LDManager.getVaultProvider()
         assertThat(secondVaultType).isEqualTo(VaultType.VGS_VAULT_TYPE)
+    }
+
+    @Test
+    fun `Default polling intervals`() = runTest {
+        // Set the test data to be {"intervals" : [1000]}
+        td.update(td.flag(LDFlags.ISO_POLLING_WAIT_INTERVALS).variations(LDValue.buildObject().put("intervals", LDValue.buildArray().add(1000L).build()).build()))
+        val app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
+
+        LDManager.initialize(app, logger = Log.getSilentInstance(), dataSource = td)
+        val pollingIntervals = LDManager.getPollingIntervals()
+        assertThat(pollingIntervals).isEqualTo(longArrayOf(1000L))
     }
 }


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

Reading the `iso-polling-wait-intervals` feature flag value to determine how long to wait between each polling retry.

## Why

Make polling more configurable instead of waiting 1 second every poll attempt. Leads to faster response times from our clients.

## Test Plan

- ✅ | ❌ I've added unit tests for this change. <!-- If not, why? -->
- ✅ | ❌ The reviewer should manually test the changes in this PR. <!-- If so, please describe how to test below. -->

## Demo

<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How

<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
