### PR TITLE
[FX-593] Convert floats to dimensions for styling

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -71,12 +71,12 @@ class ForagePANEditText @JvmOverloads constructor(
                         getThemeAccentColor(context)
                     )
 
-                    val panFocusedBoxStrokeWidth = getFloat(
+                    val panBoxStrokeWidthFocused = getDimension(
                         R.styleable.ForagePANEditText_panBoxStrokeWidthFocused,
                         3f
                     )
 
-                    val panBoxStrokeWidth = getFloat(
+                    val panBoxStrokeWidth = getDimension(
                         R.styleable.ForagePANEditText_panBoxStrokeWidth,
                         3f
                     )
@@ -105,7 +105,7 @@ class ForagePANEditText @JvmOverloads constructor(
                             // Set stroke color on focused text
                             boxStrokeColor = panBoxStrokeColor
                             // Set stroke width on focused text
-                            boxStrokeWidthFocused = panFocusedBoxStrokeWidth.toInt()
+                            boxStrokeWidthFocused = panBoxStrokeWidthFocused.toInt()
                             // Set stroke width on unfocused text
                             boxStrokeWidth = panBoxStrokeWidth.toInt()
 

--- a/forage-android/src/main/res/values/attrs.xml
+++ b/forage-android/src/main/res/values/attrs.xml
@@ -20,8 +20,8 @@
         <attr format="dimension" name="boxCornerBottomEnd" />
 
         <attr format="color" name="panBoxStrokeColor" />
-        <attr format="float" name="panBoxStrokeWidth" />
-        <attr format="float" name="panBoxStrokeWidthFocused" />
+        <attr format="dimension" name="panBoxStrokeWidth" />
+        <attr format="dimension" name="panBoxStrokeWidthFocused" />
     </declare-styleable>
 
     <!-- Style attributes for the ForagePanEditText component. -->

--- a/sample-app/src/main/res/values/styles.xml
+++ b/sample-app/src/main/res/values/styles.xml
@@ -10,17 +10,18 @@
     <!-- Style for the ForagePANEditText in tokenize Fragment. -->
     <style name="TokenizeForagePANEditTextStyle" parent="DefaultForagePANEditTextStyle">
         <item name="textInputLayoutStyle">@attr/tokenizeForageTextInputLayoutStyle</item>
+        <item name="panBoxStrokeWidth">5dp</item>
+        <item name="panBoxStrokeColor">@color/mtrl_textinput_default_box_stroke_color</item>
     </style>
 
     <style name="TokenizeForageTextInputLayoutStyle" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
         <item name="android:hint">@string/tokenize_forage_edit_text_hint</item>
-        <item name="panBoxStrokeWidth">1.0</item>
-        <item name="panBoxStrokeColor">@color/mtrl_textinput_default_box_stroke_color</item>
     </style>
 
     <!-- Style for the first ForagePanEditText in catalog Fragment. -->
     <style name="CatalogFirstForagePanEditTextStyle" parent="DefaultForagePANEditTextStyle">
         <item name="textInputLayoutStyle">@attr/catalogFirstForageTextInputLayoutStyle</item>
+        <item name="panBoxStrokeWidthFocused">5dp</item>
     </style>
 
     <style name="CatalogFirstForageTextInputLayoutStyle" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">

--- a/sample-app/src/main/res/values/styles.xml
+++ b/sample-app/src/main/res/values/styles.xml
@@ -10,7 +10,8 @@
     <!-- Style for the ForagePANEditText in tokenize Fragment. -->
     <style name="TokenizeForagePANEditTextStyle" parent="DefaultForagePANEditTextStyle">
         <item name="textInputLayoutStyle">@attr/tokenizeForageTextInputLayoutStyle</item>
-        <item name="panBoxStrokeWidth">5dp</item>
+        <item name="panBoxStrokeWidth">1dp</item>
+        <item name="panBoxStrokeWidthFocused">5dp</item>
         <item name="panBoxStrokeColor">@color/mtrl_textinput_default_box_stroke_color</item>
     </style>
 
@@ -21,6 +22,7 @@
     <!-- Style for the first ForagePanEditText in catalog Fragment. -->
     <style name="CatalogFirstForagePanEditTextStyle" parent="DefaultForagePANEditTextStyle">
         <item name="textInputLayoutStyle">@attr/catalogFirstForageTextInputLayoutStyle</item>
+        <item name="panBoxStrokeWidth">1dp</item>
         <item name="panBoxStrokeWidthFocused">5dp</item>
     </style>
 
@@ -31,6 +33,8 @@
     <!-- Style for the second ForagePanEditText in catalog fragment. -->
     <style name="CatalogSecondForagePanEditTextStyle" parent="DefaultForagePANEditTextStyle">
         <item name="textInputLayoutStyle">@attr/catalogSecondForageTextInputLayoutStyle</item>
+        <item name="panBoxStrokeWidth">1dp</item>
+        <item name="panBoxStrokeWidthFocused">5dp</item>
     </style>
 
     <style name="CatalogSecondForageTextInputLayoutStyle" parent="Widget.MaterialComponents.TextInputLayout.FilledBox">


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Linear ticket [here](https://linear.app/joinforage/issue/FX-593/android-convert-floats-dimensions-for-panstrokewidth)
<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
Dimensions are the appropriate unit for visuals with a length component, so they scale correctly to various screen sizes. Float don't scale at all
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- ❌ I've added unit tests for this change. No tests because we don't have anything set up to test view layer
- ❌ The reviewer should manually test the changes in this PR. <!-- If so, please describe how to test below. --> No need to manually test. the demo should suffice

## Demo
Demo showing the different stroke sizes based on `focused` and `unfocused` state

https://github.com/teamforage/forage-android-sdk/assets/12377418/27c97baf-30a1-493f-aa8a-eae912660d6d


<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
It can be rolled out as is. NOTE that it is a breaking change, but gopuff is expecting it, and it is small so I"m thinking we just bump to a minor version instead of a major.
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
