### PR TITLE
[FX-596] Make `setForageConfig` safe to call multiple times

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/AbstractForageElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/AbstractForageElement.kt
@@ -12,13 +12,36 @@ abstract class AbstractForageElement(
 ) : LinearLayout(context, attrs, defStyleAttr), ForageElement {
 
     private var _forageConfig: ForageConfig? = null
+
+    // designated method that subclass can run all the
+    // side-effect things exactly once the first time
+    // setForageConfig is called
+    protected abstract fun initWithForageConfig()
+
     override fun setForageConfig(forageConfig: ForageConfig) {
+        // keep a record of whether this was the first time
+        // setForageConfig is getting called. we'll use
+        // this info later
+        val isFirstCallToSet = _forageConfig == null
+
+        // update the forage config
         this._forageConfig = forageConfig
 
         // TODO: 9/20/23: This is a temporary workaround and is
         //  not meant to stick around. See this doc for more details
         //  https://www.notion.so/joinforage/226d8ee6f8294d2694b1bb451791960b
         StopgapGlobalState.forageConfig = forageConfig
+
+        // there are a number of side effect operations that we
+        // need to run as soon as a ForageElement has access to
+        // ForageConfig data. However, we don't want to run these
+        // operations on any subsequent calls to setForageConfig
+        // or else that could crash the app.
+        if (isFirstCallToSet) initWithForageConfig()
+        else {
+            // TODO: possible opportunity to log that
+            //  they tried to do sessionToken refreshing
+        }
     }
 
     // internal because submit methods need read-access

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/AbstractForageElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/AbstractForageElement.kt
@@ -15,7 +15,9 @@ abstract class AbstractForageElement(
 
     // designated method that subclass can run all the
     // side-effect things exactly once the first time
-    // setForageConfig is called
+    // setForageConfig is called. Side effect include
+    // initializing logger module, feature flag module,
+    // and view UI manipulation logic
     protected abstract fun initWithForageConfig()
 
     override fun setForageConfig(forageConfig: ForageConfig) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -145,17 +145,14 @@ class ForagePANEditText @JvmOverloads constructor(
             }
     }
 
-    override fun setForageConfig(forageConfig: ForageConfig) {
-        // super is responsible for initializing the log and some
-        // global state so it must be called first
-        super.setForageConfig(forageConfig)
-
+    override fun initWithForageConfig() {
         // Must initialize DD at the beginning of each render function. DD requires the context,
         // so we need to wait until a context is present to run initialization code. However,
         // we have logging all over the SDK that relies on the render happening first.
         val logger = Log.getInstance()
         logger.initializeDD(context)
 
+        val forageConfig = getForageConfig() // already set by parent class
         _SET_ONLY_manager = if (EnvConfig.inProd(forageConfig)) {
             // strictly support only valid Ebt PAN numbers
             PanElementStateManager.forEmptyInput()

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -91,17 +91,17 @@ class ForagePINEditText @JvmOverloads constructor(
             }
     }
 
-    override fun setForageConfig(forageConfig: ForageConfig) {
-        // super is responsible for initializing the log and some
-        // global state so it must be called first
-        super.setForageConfig(forageConfig)
-
+    override fun initWithForageConfig() {
         // Must initialize DD at the beginning of each render function. DD requires the context,
         // so we need to wait until a context is present to run initialization code. However,
         // we have logging all over the SDK that relies on the render happening first.
         val logger = Log.getInstance()
         logger.initializeDD(context)
 
+        // flagging that LDManager depends on StopgapGlobalState so
+        // its relying on forageConfig under the hood. This
+        // relationship will be made explicit once we drop
+        // StopgapGlobalState
         val vaultType = LDManager.getVaultProvider(context.applicationContext as Application, logger)
         _SET_ONLY_vault = if (vaultType == VaultConstants.BT_VAULT_TYPE) {
             btVaultWrapper

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/catalog/CatalogFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/catalog/CatalogFragment.kt
@@ -40,6 +40,18 @@ class CatalogFragment : Fragment() {
         binding.secondForagePINEditText.setForageConfig(forageConfig)
         binding.thirdForagePINEditText.setForageConfig(forageConfig)
 
+        // NOTE: we call setForageConfig a second time here so that
+        //  the CI tests always confirm that running setForageConfig
+        //  more than once is OK and does not cause a crash. So,
+        //  these duplicate calls are intentional here
+        binding.firstForageEditText.setForageConfig(forageConfig)
+        binding.secondEditText.setForageConfig(forageConfig)
+        binding.thirdEditText.setForageConfig(forageConfig)
+        binding.fourthEditText.setForageConfig(forageConfig)
+        binding.foragePinEditText.setForageConfig(forageConfig)
+        binding.secondForagePINEditText.setForageConfig(forageConfig)
+        binding.thirdForagePINEditText.setForageConfig(forageConfig)
+
         return root
     }
 


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
The linear ticket is [here](https://linear.app/joinforage/issue/FX-596/android-make-sure-that-setforageconfig-can-be-called-multiple-times). Also, see the commit messages for detailed explanations of changes

<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
One of the design goals of introducing `setForageConfig` is to be able to handle `sessionToken` refresh or even update `merchantId` on the fly. This means `setForageConfig` needs to be safe to be called multiple times. Right now, it is not safe to call multiple times. It will actually crash the app:

![image](https://github.com/teamforage/forage-android-sdk/assets/12377418/3303f43b-eadd-491b-b728-b3a686576338)

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
- ❌ I've added unit tests for this change. <!-- If not, why? --> In theory, there is logic in here that can be extracted out into a unit test. However, given the modifications this PR makes to `CatalogFragment.kt`, we gain some confidence that the logic in `AbstractForageElement` is working correctly. So, I decided to punt the unit tests for later
- ❌ The reviewer should manually test the changes in this PR. <!-- If so, please describe how to test below. -->No need to test these changes manually because the CI pipeline combined with the modifications I made to `CatalogFragment.kt` will confirm this change works

## Demo
An image showcasing the catalog page working. This means it's not crashing and that `setForageConfig` can be called multiple times.
![image](https://github.com/teamforage/forage-android-sdk/assets/12377418/c8c3bbdf-fcf2-48db-a1b2-74b7f18d72ed)

<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
This change can be released as is and in a patch level change.
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
