### PR TITLE
[FX-599] Don't hit VGS or BT when invalid PIN submitted

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
@@ -34,6 +34,22 @@ internal class BTPinCollector(
         cardToken: String,
         encryptionKey: String
     ): ForageApiResponse<String> {
+        // If the PIN isn't valid (less than 4 numbers) then return a response here.
+        if (!pinForageEditText.getElementState().isComplete) {
+            logger.e(
+                "[BT] User attempted to submit an invalid PIN",
+                attributes = mapOf(
+                    "merchant_ref" to merchantAccount,
+                    "payment_method_ref" to paymentMethodRef
+                )
+            )
+            return ForageApiResponse.Failure(
+                listOf(
+                    ForageError(400, "user_error", "Attempted to submit an invalid PIN")
+                )
+            )
+        }
+
         val bt = buildBt()
 
         // This block is used for Metrics Tracking!
@@ -140,6 +156,22 @@ internal class BTPinCollector(
         cardToken: String,
         encryptionKey: String
     ): ForageApiResponse<String> {
+        // If the PIN isn't valid (less than 4 numbers) then return a response here.
+        if (!pinForageEditText.getElementState().isComplete) {
+            logger.e(
+                "[BT] User attempted to submit an invalid PIN",
+                attributes = mapOf(
+                    "merchant_ref" to merchantAccount,
+                    "payment_ref" to paymentRef
+                )
+            )
+            return ForageApiResponse.Failure(
+                listOf(
+                    ForageError(400, "user_error", "Attempted to submit an invalid PIN")
+                )
+            )
+        }
+
         val bt = buildBt()
 
         // This block is used for Metrics Tracking!

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
@@ -44,7 +44,7 @@ internal class BTPinCollector(
                 )
             )
             return ForageApiResponse.Failure(
-                ForageConstants.ErrorResponseObjects.INVALID_PIN_ERROR
+                ForageConstants.ErrorResponseObjects.INCOMPLETE_PIN_ERROR
             )
         }
 
@@ -164,7 +164,7 @@ internal class BTPinCollector(
                 )
             )
             return ForageApiResponse.Failure(
-                ForageConstants.ErrorResponseObjects.INVALID_PIN_ERROR
+                ForageConstants.ErrorResponseObjects.INCOMPLETE_PIN_ERROR
             )
         }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
@@ -36,7 +36,7 @@ internal class BTPinCollector(
     ): ForageApiResponse<String> {
         // If the PIN isn't valid (less than 4 numbers) then return a response here.
         if (!pinForageEditText.getElementState().isComplete) {
-            logger.e(
+            logger.w(
                 "[BT] User attempted to submit an invalid PIN",
                 attributes = mapOf(
                     "merchant_ref" to merchantAccount,
@@ -44,9 +44,7 @@ internal class BTPinCollector(
                 )
             )
             return ForageApiResponse.Failure(
-                listOf(
-                    ForageError(400, "user_error", "Attempted to submit an invalid PIN")
-                )
+                ForageConstants.ErrorResponseObjects.INVALID_PIN_ERROR
             )
         }
 
@@ -158,7 +156,7 @@ internal class BTPinCollector(
     ): ForageApiResponse<String> {
         // If the PIN isn't valid (less than 4 numbers) then return a response here.
         if (!pinForageEditText.getElementState().isComplete) {
-            logger.e(
+            logger.w(
                 "[BT] User attempted to submit an invalid PIN",
                 attributes = mapOf(
                     "merchant_ref" to merchantAccount,
@@ -166,9 +164,7 @@ internal class BTPinCollector(
                 )
             )
             return ForageApiResponse.Failure(
-                listOf(
-                    ForageError(400, "user_error", "Attempted to submit an invalid PIN")
-                )
+                ForageConstants.ErrorResponseObjects.INVALID_PIN_ERROR
             )
         }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
@@ -40,6 +40,27 @@ internal class VGSPinCollector(
         cardToken: String,
         encryptionKey: String
     ): ForageApiResponse<String> = suspendCoroutine { continuation ->
+        // If the PIN isn't valid (less than 4 numbers) then return a response here.
+        if (!pinForageEditText.getElementState().isComplete) {
+            logger.e(
+                "[VGS] User attempted to submit an invalid PIN",
+                attributes = mapOf(
+                    "merchant_ref" to merchantAccount,
+                    "payment_method_ref" to paymentMethodRef
+                )
+            )
+            continuation.resumeWith(
+                Result.success(
+                    ForageApiResponse.Failure(
+                        listOf(
+                            ForageError(400, "user_error", "Attempted to submit an invalid PIN")
+                        )
+                    )
+                )
+            )
+            return@suspendCoroutine
+        }
+
         val vgsCollect = buildVGSCollect(context)
 
         val inputField = pinForageEditText.getTextInputEditText()
@@ -173,6 +194,27 @@ internal class VGSPinCollector(
         cardToken: String,
         encryptionKey: String
     ): ForageApiResponse<String> = suspendCoroutine { continuation ->
+        // If the PIN isn't valid (less than 4 numbers) then return a response here.
+        if (!pinForageEditText.getElementState().isComplete) {
+            logger.e(
+                "[VGS] User attempted to submit an invalid PIN",
+                attributes = mapOf(
+                    "merchant_ref" to merchantAccount,
+                    "payment_ref" to paymentRef
+                )
+            )
+            continuation.resumeWith(
+                Result.success(
+                    ForageApiResponse.Failure(
+                        listOf(
+                            ForageError(400, "user_error", "Attempted to submit an invalid PIN")
+                        )
+                    )
+                )
+            )
+            return@suspendCoroutine
+        }
+
         val vgsCollect = buildVGSCollect(context)
 
         vgsCollect.bindView(pinForageEditText.getTextInputEditText())

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
@@ -42,7 +42,7 @@ internal class VGSPinCollector(
     ): ForageApiResponse<String> = suspendCoroutine { continuation ->
         // If the PIN isn't valid (less than 4 numbers) then return a response here.
         if (!pinForageEditText.getElementState().isComplete) {
-            logger.e(
+            logger.w(
                 "[VGS] User attempted to submit an invalid PIN",
                 attributes = mapOf(
                     "merchant_ref" to merchantAccount,
@@ -52,9 +52,7 @@ internal class VGSPinCollector(
             continuation.resumeWith(
                 Result.success(
                     ForageApiResponse.Failure(
-                        listOf(
-                            ForageError(400, "user_error", "Attempted to submit an invalid PIN")
-                        )
+                        ForageConstants.ErrorResponseObjects.INVALID_PIN_ERROR
                     )
                 )
             )
@@ -196,7 +194,7 @@ internal class VGSPinCollector(
     ): ForageApiResponse<String> = suspendCoroutine { continuation ->
         // If the PIN isn't valid (less than 4 numbers) then return a response here.
         if (!pinForageEditText.getElementState().isComplete) {
-            logger.e(
+            logger.w(
                 "[VGS] User attempted to submit an invalid PIN",
                 attributes = mapOf(
                     "merchant_ref" to merchantAccount,
@@ -206,9 +204,7 @@ internal class VGSPinCollector(
             continuation.resumeWith(
                 Result.success(
                     ForageApiResponse.Failure(
-                        listOf(
-                            ForageError(400, "user_error", "Attempted to submit an invalid PIN")
-                        )
+                        ForageConstants.ErrorResponseObjects.INVALID_PIN_ERROR
                     )
                 )
             )

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
@@ -52,7 +52,7 @@ internal class VGSPinCollector(
             continuation.resumeWith(
                 Result.success(
                     ForageApiResponse.Failure(
-                        ForageConstants.ErrorResponseObjects.INVALID_PIN_ERROR
+                        ForageConstants.ErrorResponseObjects.INCOMPLETE_PIN_ERROR
                     )
                 )
             )
@@ -204,7 +204,7 @@ internal class VGSPinCollector(
             continuation.resumeWith(
                 Result.success(
                     ForageApiResponse.Failure(
-                        ForageConstants.ErrorResponseObjects.INVALID_PIN_ERROR
+                        ForageConstants.ErrorResponseObjects.INCOMPLETE_PIN_ERROR
                     )
                 )
             )

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/ForageConstants.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/ForageConstants.kt
@@ -1,6 +1,7 @@
 package com.joinforage.forage.android.network
 
 import com.joinforage.forage.android.core.StopgapGlobalState
+import com.joinforage.forage.android.network.model.ForageError
 import okhttp3.Request
 
 internal object ForageConstants {
@@ -35,5 +36,11 @@ internal object ForageConstants {
 
     object VGS {
         const val PIN_FIELD_NAME = "pin"
+    }
+
+    object ErrorResponseObjects {
+        val INVALID_PIN_ERROR = listOf(
+            ForageError(400, "user_error", "Invalid EBT Card PIN entered. Please enter your 4-digit PIN.")
+        )
     }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/ForageConstants.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/ForageConstants.kt
@@ -39,7 +39,7 @@ internal object ForageConstants {
     }
 
     object ErrorResponseObjects {
-        val INVALID_PIN_ERROR = listOf(
+        val INCOMPLETE_PIN_ERROR = listOf(
             ForageError(400, "user_error", "Invalid EBT Card PIN entered. Please enter your 4-digit PIN.")
         )
     }


### PR DESCRIPTION
## What
If the PIN field is invalid when someone attempts to submit, don't hit our 3rd party APIs and instead just return that the PIN was invalid.

## Test Plan

- ❌ I've added unit tests for this change. -> I WILL BE ADDING A QA TEST FOR THIS
- ✅ The reviewer should manually test the changes in this PR.
