### PR TITLE
Testing changes to CI workflow in seperate file

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -30,17 +30,17 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Run unit tests for the sandboxDebug build
-        run: ./gradlew testSandboxDebugUnitTest --stacktrace
+      - name: Run unit tests for the debug build
+        run: ./gradlew testDebugUnitTest --stacktrace
 
-      - name: Build all build variants
+      - name: Build release and debug variants
         run: ./gradlew assemble --stacktrace
 
       - name: Upload App to BrowserStack
         run: |
           curl -u "${{ secrets.BROWSERSTACK_USERNAME }}:${{ secrets.BROWSERSTACK_ACCESS_KEY }}" -X POST \
           https://api-cloud.browserstack.com/app-automate/upload \
-          -F "file=@${{ github.workspace }}/sample-app/build/outputs/apk/staging/debug/sample-app-staging-debug.apk" \
+          -F "file=@${{ github.workspace }}/sample-app/build/outputs/apk/debug/sample-app-debug.apk" \
           -F "custom_id=AndroidApp"
 
       - name: Checkout Integration Test Repo

--- a/.github/workflows/Lint.yaml
+++ b/.github/workflows/Lint.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: forage-android/build/reports/lint-results-certDebug.sarif
+          sarif_file: forage-android/build/reports/lint-results-debug.sarif
           category: lint-forage-android
 
       - name: Check spotless


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
* Modifies the `CI.yaml` file to refer to `debug` build instead of `sandbox` for unit tests and `stanging` for Appium.
* Modifies `Lint.yaml` to refer to `debug` build instead of `cert`
<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
We no longer have flavors. Instead, we have the standard `release` and `debug` builds that are the default for all Android apps. Technically, it does not matter right now whether we use the `debug` or the `prod` build since `forage-android`'s environment is determined by the `sessionToken` that it gets passed at runtime and [`mobile-qa-tests` reference staging](https://github.com/teamforage/mobile-qa-tests/blob/7f15c11934c8211a38baff87a30ee69b04191031/helpers/forage_api.py#L8-L9). Just to be safe - in case anything changes in the future - I pointed both CI and Lint to the `debug` build.
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
Given that this PR is on top of #113 and #114, it is working with a flavorless version of `forage-android` and `sample-app`. So, that all of the checks are passing means that this PR correctly modified `CI.yaml` and `Lint.yaml` to work with the standard `release` and `debug` and to not rely on flavors.
- ❌ I've added unit tests for this change. <!-- If not, why? --> Nope - these are GitHub action workflow related changes, so unit tests are not relevant
- ❌ The reviewer should manually test the changes in this PR. <!-- If so, please describe how to test below. --> It's not necessary to test this locally. Seeing passing checks on this PR demonstrates the correctness of the changes.

## Demo
The demo is that the `Lint` and `CI` check pass given that we only have `release` and `debug`!!
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
Because this PR and the previous PRs (#113 and #114 ) affect build pipeline things (dropping use on flavors), this PR and the previous PRs need to be merged into a single large PR. From there, that single large PR can get merged into `main`. This will ensure we ship the dropping-of-flavors while not not breaking our GitHub checks in the process 👍 
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
