### PR TITLE
Drop refernce to Build Variants in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,23 +54,6 @@ dependencies {
 }
 ```
 
-### A Note on Build Variants
-
-While the Forage Android SDK comes with a flavor dimension `version` with values
-of `prod` and `sandbox` the Forage Android SDK will infer whether to operate
-in `prod` or `sandbox` based on the [`sessionToken`](https://docs.joinforage.app/reference/create-session-token)
-passed to either [`ForagePANEditText`](#foragepanedittext) or the 
-[`ForagePINEditText`](#foragepinedittext) views. We recommend that you only
-use the `prod` flavor of the Forage Android SDK.
-
-```groovy
-android {
-    defaultConfig {
-        missingDimensionStrategy("version", "prod")
-    }
-}
-```
-
 ## UI Components
 
 The Android SDK exposes two text field components, collectively referred to as


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Drop "A Note on Build Variants" section from the README.md

## Why
Now that we have dropped build flavors, we no longer need to mention it in the README.md
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- ❌ I've added unit tests for this change. <!-- If not, why? --> No tests - just a README update
- The reviewer should manually test the changes in this PR. <!-- If so, please describe how to test below. --> No need to test locally since you can see the rendered README in github

## Demo
N/A
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
This PR can be merged directly into main after #113, #114, and #115 get merged together as one large PR into `main`. Ideally we are not also merging this PR into a mega PR since it is atomic unlike #113 + #114 + #115, which are not atomic individual but are atomic together
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
