### PR TITLE
Bump to v3.2.0 for dropping build flavors

### DIFF
--- a/forage-android/build.gradle
+++ b/forage-android/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'com.joinforage'
-    PUBLISH_VERSION = '3.1.0'
+    PUBLISH_VERSION = '3.2.0'
     PUBLISH_ARTIFACT_ID = 'forage-android'
     PUBLISH_DESCRIPTION = 'Forage Android SDK'
     PUBLISH_URL = 'https://github.com/teamforage/forage-android-sdk'

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/EnvConfig.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/EnvConfig.kt
@@ -24,7 +24,7 @@ internal sealed class EnvConfig(
     // version to code at runtime. It is essential that this
     // value stay in sync with forage-android/build.gradle's
     // PUBLISH_VERSION value.
-    val PUBLISH_VERSION: String = "3.1.0"
+    val PUBLISH_VERSION: String = "3.2.0"
 
     object Dev : EnvConfig(
         FLAVOR = EnvOption.DEV,


### PR DESCRIPTION
Bump to v3.2.0. Release notes [here](https://www.notion.so/joinforage/Release-Tracker-94d996c2c7e14501a96d54722a89532e?pvs=4#c72b0e452e964812b4e606f9fdd6a953)