### PR TITLE
Create single source of truth for the Publish Version

### DIFF
--- a/forage-android/build.gradle
+++ b/forage-android/build.gradle
@@ -5,6 +5,26 @@ plugins {
     id("org.jetbrains.kotlinx.kover") version "0.6.1"
 }
 
+ext {
+    PUBLISH_GROUP_ID = 'com.joinforage'
+    PUBLISH_VERSION = '3.3.0'
+    PUBLISH_ARTIFACT_ID = 'forage-android'
+    PUBLISH_DESCRIPTION = 'Forage Android SDK'
+    PUBLISH_URL = 'https://github.com/teamforage/forage-android-sdk'
+    PUBLISH_LICENSE_NAME = 'MIT License'
+    PUBLISH_LICENSE_URL =
+            'https://github.com/teamforage/forage-android-sdk/blob/main/LICENSE'
+    PUBLISH_DEVELOPER_ID = 'owenkim'
+    PUBLISH_DEVELOPER_NAME = 'Owen Kim'
+    PUBLISH_DEVELOPER_EMAIL = 'owenkim@forage.com'
+    PUBLISH_SCM_CONNECTION =
+            'scm:git:github.com:teamforage/forage-android-sdk.git'
+    PUBLISH_SCM_DEVELOPER_CONNECTION =
+            'scm:git:ssh://github.com:teamforage/forage-android-sdk.git'
+    PUBLISH_SCM_URL =
+            'https://github.com/teamforage/forage-android-sdk/tree/main'
+}
+
 android {
     namespace 'com.joinforage.forage.android'
     compileSdk 33
@@ -15,6 +35,8 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
+
+        buildConfigField 'String', 'PUBLISH_VERSION', "\"${PUBLISH_VERSION}\""
     }
 
     buildTypes {
@@ -81,24 +103,6 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 }
 
-ext {
-    PUBLISH_GROUP_ID = 'com.joinforage'
-    PUBLISH_VERSION = '3.2.0'
-    PUBLISH_ARTIFACT_ID = 'forage-android'
-    PUBLISH_DESCRIPTION = 'Forage Android SDK'
-    PUBLISH_URL = 'https://github.com/teamforage/forage-android-sdk'
-    PUBLISH_LICENSE_NAME = 'MIT License'
-    PUBLISH_LICENSE_URL =
-            'https://github.com/teamforage/forage-android-sdk/blob/main/LICENSE'
-    PUBLISH_DEVELOPER_ID = 'owenkim'
-    PUBLISH_DEVELOPER_NAME = 'Owen Kim'
-    PUBLISH_DEVELOPER_EMAIL = 'owenkim@forage.com'
-    PUBLISH_SCM_CONNECTION =
-            'scm:git:github.com:teamforage/forage-android-sdk.git'
-    PUBLISH_SCM_DEVELOPER_CONNECTION =
-            'scm:git:ssh://github.com:teamforage/forage-android-sdk.git'
-    PUBLISH_SCM_URL =
-            'https://github.com/teamforage/forage-android-sdk/tree/main'
-}
+
 
 apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/EnvConfig.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/EnvConfig.kt
@@ -1,5 +1,6 @@
 package com.joinforage.forage.android.core
 
+import com.joinforage.forage.android.BuildConfig
 import com.joinforage.forage.android.ui.ForageConfig
 
 internal enum class EnvOption(val value: String) {
@@ -20,11 +21,10 @@ internal sealed class EnvConfig(
     val ldMobileKey: String,
     val ddClientToken: String
 ) {
-    // This is how we currently offer access to the the release
-    // version to code at runtime. It is essential that this
-    // value stay in sync with forage-android/build.gradle's
-    // PUBLISH_VERSION value.
-    val PUBLISH_VERSION: String = "3.2.0"
+    // For the time being, I figure we can consume BuildConfig in exactly
+    // one spot (here) to reduce the pieces of source code have to couple
+    // to BuildConfig.
+    val PUBLISH_VERSION: String = BuildConfig.PUBLISH_VERSION
 
     object Dev : EnvConfig(
         FLAVOR = EnvOption.DEV,


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Danny spotted [a way](https://github.com/Basis-Theory/basistheory-android/blob/0a1435feb66c4732714ff9bb1b412636b63f7edf/lib/build.gradle#L16) for us to declare the `PUBLISH_VERSION` in exactly one place and have it exposed at run time via `BuildConfig`.
<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
Have a single source of truth for the release version. Previously, we were updating two variables in the code with every release
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- ❌ I've added unit tests for this change. <!-- If not, why? --> No test because its a build related change
- ❌ The reviewer should manually test the changes in this PR. <!-- If so, please describe how to test below. --> No need since its a simple change and you can see that it works in the demo

## Demo
I tried to highlight the salient lines of code via the red breakpoints:
1. I changed the publish version to something new "3.3.0" which is different form our "3.20"
2. I'm exposing the PUBLISH_VERSION variable in the `defaultConfig` 
3. I've added a `println()` to `ForagePANEditText` that will print the value of `EnvConfig` if this technique
4. It prints so it works!!
![image](https://github.com/teamforage/forage-android-sdk/assets/12377418/1daf4d09-cd22-4bf2-b38c-e5f1593801dd)

<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
This PR can be merged to `main` once it's approved. It has no dependencies
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
