### PR TITLE
[FX-613] Remove throw statement and make error response consistent

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
@@ -286,7 +286,9 @@ internal class BTPinCollector(
                 "payment_method_ref" to paymentMethod.ref
             )
         )
-        throw RuntimeException("BT token not found on card!")
+        // This will lead to a Forage API error, ensuring the app won't crash.
+        // However, the reason for the error may be confusing.
+        return ""
     }
 
     companion object {

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/VGSPinCollector.kt
@@ -144,7 +144,7 @@ internal class VGSPinCollector(
                         )
                         continuation.resumeWith(
                             Result.success(
-                                ForageApiResponse.Failure(listOf(ForageError(response.errorCode, "user_error", "Invalid Data")))
+                                ForageApiResponse.Failure(listOf(ForageError(response.errorCode, "unknown_server_error", "Unknown Server Error")))
                             )
                         )
                     }
@@ -296,7 +296,7 @@ internal class VGSPinCollector(
                         )
                         continuation.resumeWith(
                             Result.success(
-                                ForageApiResponse.Failure(listOf(ForageError(response.errorCode, "user_error", "Invalid Data")))
+                                ForageApiResponse.Failure(listOf(ForageError(response.errorCode, "unknown_server_error", "Unknown Server Error")))
                             )
                         )
                     }


### PR DESCRIPTION
## What
Remove the throw statement in the BT implementation that could potentially crash someone's app. Also, make the random response messages in the VGS implementation conform to the rest of the package.

## Testing
I still need to confirm that this change behaves as I want when Dendu makes a change to the BT PIN script on the backend.
