### PR TITLE
[FX-677] Remove ForageConstants dependence on StopgapGlobalState

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ForageSDK.kt
@@ -1,11 +1,11 @@
 package com.joinforage.forage.android
 
+import com.joinforage.forage.android.core.EnvConfig
 import com.joinforage.forage.android.core.telemetry.CustomerPerceivedResponseMonitor
 import com.joinforage.forage.android.core.telemetry.EventOutcome
 import com.joinforage.forage.android.core.telemetry.Log
 import com.joinforage.forage.android.core.telemetry.UserAction
 import com.joinforage.forage.android.network.EncryptionKeyService
-import com.joinforage.forage.android.network.ForageConstants
 import com.joinforage.forage.android.network.MessageStatusService
 import com.joinforage.forage.android.network.OkHttpClientBuilder
 import com.joinforage.forage.android.network.PaymentMethodService
@@ -52,6 +52,7 @@ class ForageSDK : ForageSDKInterface {
     override suspend fun tokenizeEBTCard(params: TokenizeEBTCardParams): ForageApiResponse<String> {
         val (foragePanEditText, customerId, reusable) = params
         val (merchantId, sessionToken) = _getForageConfigOrThrow(foragePanEditText)
+        val config = EnvConfig.fromSessionToken(sessionToken)
 
         // TODO: replace Log.getInstance() with Log() in future PR
         val logger = Log.getInstance()
@@ -70,7 +71,7 @@ class ForageSDK : ForageSDKInterface {
                 idempotencyKey = UUID.randomUUID().toString(),
                 traceId = logger.getTraceIdValue()
             ),
-            httpUrl = ForageConstants.provideHttpUrl(),
+            httpUrl = config.baseUrl,
             logger = logger
         ).tokenizeCard(
             cardNumber = foragePanEditText.getPanNumber(),
@@ -96,6 +97,7 @@ class ForageSDK : ForageSDKInterface {
     override suspend fun checkBalance(params: CheckBalanceParams): ForageApiResponse<String> {
         val (foragePinEditText, paymentMethodRef) = params
         val (merchantId, sessionToken) = _getForageConfigOrThrow(foragePinEditText)
+        val config = EnvConfig.fromSessionToken(sessionToken)
 
         // TODO: replace Log.getInstance() with Log() in future PR
         val logger = Log.getInstance()
@@ -127,7 +129,7 @@ class ForageSDK : ForageSDKInterface {
                     merchantId,
                     traceId = logger.getTraceIdValue()
                 ),
-                httpUrl = ForageConstants.provideHttpUrl(),
+                httpUrl = config.baseUrl,
                 logger = logger
             ),
             paymentMethodService = PaymentMethodService(
@@ -136,7 +138,7 @@ class ForageSDK : ForageSDKInterface {
                     merchantId,
                     traceId = logger.getTraceIdValue()
                 ),
-                httpUrl = ForageConstants.provideHttpUrl(),
+                httpUrl = config.baseUrl,
                 logger = logger
             ),
             messageStatusService = MessageStatusService(
@@ -145,7 +147,7 @@ class ForageSDK : ForageSDKInterface {
                     merchantId,
                     traceId = logger.getTraceIdValue()
                 ),
-                httpUrl = ForageConstants.provideHttpUrl(),
+                httpUrl = config.baseUrl,
                 logger = logger
             ),
             logger = logger
@@ -183,6 +185,7 @@ class ForageSDK : ForageSDKInterface {
     override suspend fun capturePayment(params: CapturePaymentParams): ForageApiResponse<String> {
         val (foragePinEditText, paymentRef) = params
         val (merchantId, sessionToken) = _getForageConfigOrThrow(foragePinEditText)
+        val config = EnvConfig.fromSessionToken(sessionToken)
 
         // TODO: replace Log.getInstance() with Log() in future PR
         val logger = Log.getInstance()
@@ -214,7 +217,7 @@ class ForageSDK : ForageSDKInterface {
                     merchantId,
                     traceId = logger.getTraceIdValue()
                 ),
-                httpUrl = ForageConstants.provideHttpUrl(),
+                httpUrl = config.baseUrl,
                 logger = logger
             ),
             paymentService = PaymentService(
@@ -223,7 +226,7 @@ class ForageSDK : ForageSDKInterface {
                     merchantId,
                     traceId = logger.getTraceIdValue()
                 ),
-                httpUrl = ForageConstants.provideHttpUrl(),
+                httpUrl = config.baseUrl,
                 logger = logger
             ),
             paymentMethodService = PaymentMethodService(
@@ -232,7 +235,7 @@ class ForageSDK : ForageSDKInterface {
                     merchantId,
                     traceId = logger.getTraceIdValue()
                 ),
-                httpUrl = ForageConstants.provideHttpUrl(),
+                httpUrl = config.baseUrl,
                 logger = logger
             ),
             messageStatusService = MessageStatusService(
@@ -241,7 +244,7 @@ class ForageSDK : ForageSDKInterface {
                     merchantId,
                     traceId = logger.getTraceIdValue()
                 ),
-                httpUrl = ForageConstants.provideHttpUrl(),
+                httpUrl = config.baseUrl,
                 logger = logger
             ),
             logger = logger

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/EncryptionKeyService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/EncryptionKeyService.kt
@@ -5,12 +5,13 @@ import com.joinforage.forage.android.core.telemetry.Log
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.IOException
 
 internal class EncryptionKeyService(
-    private val httpUrl: HttpUrl,
+    private val httpUrl: String,
     okHttpClient: OkHttpClient,
     private val logger: Log
 ) : NetworkService(okHttpClient, logger) {
@@ -33,12 +34,10 @@ internal class EncryptionKeyService(
         return convertCallbackToCoroutine(request)
     }
 
-    private fun getEncryptionKeyUrl(): HttpUrl {
-        return httpUrl
+    private fun getEncryptionKeyUrl(): HttpUrl = httpUrl.toHttpUrlOrNull()!!
             .newBuilder()
             .addPathSegment(ForageConstants.PathSegment.ISO_SERVER)
             .addPathSegment(ForageConstants.PathSegment.ENCRYPTION_ALIAS)
             .addTrailingSlash()
             .build()
-    }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/EncryptionKeyService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/EncryptionKeyService.kt
@@ -35,9 +35,9 @@ internal class EncryptionKeyService(
     }
 
     private fun getEncryptionKeyUrl(): HttpUrl = httpUrl.toHttpUrlOrNull()!!
-            .newBuilder()
-            .addPathSegment(ForageConstants.PathSegment.ISO_SERVER)
-            .addPathSegment(ForageConstants.PathSegment.ENCRYPTION_ALIAS)
-            .addTrailingSlash()
-            .build()
+        .newBuilder()
+        .addPathSegment(ForageConstants.PathSegment.ISO_SERVER)
+        .addPathSegment(ForageConstants.PathSegment.ENCRYPTION_ALIAS)
+        .addTrailingSlash()
+        .build()
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/ForageConstants.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/ForageConstants.kt
@@ -4,7 +4,6 @@ import com.joinforage.forage.android.network.model.ForageError
 
 internal object ForageConstants {
 
-
     object Headers {
         const val X_KEY = "X-KEY"
         const val MERCHANT_ACCOUNT = "Merchant-Account"

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/ForageConstants.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/ForageConstants.kt
@@ -1,13 +1,9 @@
 package com.joinforage.forage.android.network
 
-import com.joinforage.forage.android.core.StopgapGlobalState
 import com.joinforage.forage.android.network.model.ForageError
-import okhttp3.Request
 
 internal object ForageConstants {
-    private val BASE_URL = StopgapGlobalState.envConfig.baseUrl
 
-    fun provideHttpUrl() = Request.Builder().url(BASE_URL).build().url
 
     object Headers {
         const val X_KEY = "X-KEY"

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/MessageStatusService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/MessageStatusService.kt
@@ -40,10 +40,10 @@ internal class MessageStatusService(
     }
 
     private fun getMessageStatusUrl(contentId: String): HttpUrl = httpUrl.toHttpUrlOrNull()!!
-            .newBuilder()
-            .addPathSegment(ForageConstants.PathSegment.API)
-            .addPathSegment(ForageConstants.PathSegment.MESSAGE)
-            .addPathSegment(contentId)
-            .addTrailingSlash()
-            .build()
+        .newBuilder()
+        .addPathSegment(ForageConstants.PathSegment.API)
+        .addPathSegment(ForageConstants.PathSegment.MESSAGE)
+        .addPathSegment(contentId)
+        .addTrailingSlash()
+        .build()
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/MessageStatusService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/MessageStatusService.kt
@@ -5,12 +5,13 @@ import com.joinforage.forage.android.core.telemetry.Log
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.IOException
 
 internal class MessageStatusService(
-    private val httpUrl: HttpUrl,
+    private val httpUrl: String,
     okHttpClient: OkHttpClient,
     private val logger: Log
 ) : NetworkService(okHttpClient, logger) {
@@ -38,13 +39,11 @@ internal class MessageStatusService(
         return convertCallbackToCoroutine(request)
     }
 
-    private fun getMessageStatusUrl(contentId: String): HttpUrl {
-        return httpUrl
+    private fun getMessageStatusUrl(contentId: String): HttpUrl = httpUrl.toHttpUrlOrNull()!!
             .newBuilder()
             .addPathSegment(ForageConstants.PathSegment.API)
             .addPathSegment(ForageConstants.PathSegment.MESSAGE)
             .addPathSegment(contentId)
             .addTrailingSlash()
             .build()
-    }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/PaymentMethodService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/PaymentMethodService.kt
@@ -5,12 +5,13 @@ import com.joinforage.forage.android.core.telemetry.Log
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.IOException
 
 internal class PaymentMethodService(
-    private val httpUrl: HttpUrl,
+    private val httpUrl: String,
     okHttpClient: OkHttpClient,
     private val logger: Log
 ) : NetworkService(okHttpClient, logger) {
@@ -43,13 +44,11 @@ internal class PaymentMethodService(
         return convertCallbackToCoroutine(request)
     }
 
-    private fun getPaymentMethodUrl(paymentMethodRef: String): HttpUrl {
-        return httpUrl
-            .newBuilder()
-            .addPathSegment(ForageConstants.PathSegment.API)
-            .addPathSegment(ForageConstants.PathSegment.PAYMENT_METHODS)
-            .addPathSegment(paymentMethodRef)
-            .addTrailingSlash()
-            .build()
-    }
+    private fun getPaymentMethodUrl(paymentMethodRef: String): HttpUrl = httpUrl.toHttpUrlOrNull()!!
+        .newBuilder()
+        .addPathSegment(ForageConstants.PathSegment.API)
+        .addPathSegment(ForageConstants.PathSegment.PAYMENT_METHODS)
+        .addPathSegment(paymentMethodRef)
+        .addTrailingSlash()
+        .build()
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/PaymentService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/PaymentService.kt
@@ -5,12 +5,13 @@ import com.joinforage.forage.android.core.telemetry.Log
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.IOException
 
 internal class PaymentService(
-    private val httpUrl: HttpUrl,
+    private val httpUrl: String,
     okHttpClient: OkHttpClient,
     private val logger: Log
 ) : NetworkService(okHttpClient, logger) {
@@ -43,13 +44,11 @@ internal class PaymentService(
         return convertCallbackToCoroutine(request)
     }
 
-    private fun getPaymentUrl(paymentRef: String): HttpUrl {
-        return httpUrl
+    private fun getPaymentUrl(paymentRef: String): HttpUrl = httpUrl.toHttpUrlOrNull()!!
             .newBuilder()
             .addPathSegment(ForageConstants.PathSegment.API)
             .addPathSegment(ForageConstants.PathSegment.PAYMENTS)
             .addPathSegment(paymentRef)
             .addTrailingSlash()
             .build()
-    }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/PaymentService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/PaymentService.kt
@@ -45,10 +45,10 @@ internal class PaymentService(
     }
 
     private fun getPaymentUrl(paymentRef: String): HttpUrl = httpUrl.toHttpUrlOrNull()!!
-            .newBuilder()
-            .addPathSegment(ForageConstants.PathSegment.API)
-            .addPathSegment(ForageConstants.PathSegment.PAYMENTS)
-            .addPathSegment(paymentRef)
-            .addTrailingSlash()
-            .build()
+        .newBuilder()
+        .addPathSegment(ForageConstants.PathSegment.API)
+        .addPathSegment(ForageConstants.PathSegment.PAYMENTS)
+        .addPathSegment(paymentRef)
+        .addTrailingSlash()
+        .build()
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/TokenizeCardService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/TokenizeCardService.kt
@@ -7,6 +7,7 @@ import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.network.model.PaymentMethodRequestBody
 import com.joinforage.forage.android.network.model.toJSONObject
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -15,7 +16,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
 
 internal class TokenizeCardService(
-    private val httpUrl: HttpUrl,
+    private val httpUrl: String,
     okHttpClient: OkHttpClient,
     private val logger: Log
 ) : NetworkService(okHttpClient, logger) {
@@ -50,12 +51,10 @@ internal class TokenizeCardService(
         return convertCallbackToCoroutine(request)
     }
 
-    private fun getTokenizeCardUrl(): HttpUrl {
-        return httpUrl
+    private fun getTokenizeCardUrl(): HttpUrl = httpUrl.toHttpUrlOrNull()!!
             .newBuilder()
             .addPathSegment(ForageConstants.PathSegment.API)
             .addPathSegment(ForageConstants.PathSegment.PAYMENT_METHODS)
             .addTrailingSlash()
             .build()
-    }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/TokenizeCardService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/TokenizeCardService.kt
@@ -52,9 +52,9 @@ internal class TokenizeCardService(
     }
 
     private fun getTokenizeCardUrl(): HttpUrl = httpUrl.toHttpUrlOrNull()!!
-            .newBuilder()
-            .addPathSegment(ForageConstants.PathSegment.API)
-            .addPathSegment(ForageConstants.PathSegment.PAYMENT_METHODS)
-            .addTrailingSlash()
-            .build()
+        .newBuilder()
+        .addPathSegment(ForageConstants.PathSegment.API)
+        .addPathSegment(ForageConstants.PathSegment.PAYMENT_METHODS)
+        .addTrailingSlash()
+        .build()
 }

--- a/forage-android/src/test/java/com/joinforage/forage/android/core/env/EnvConfigTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/core/env/EnvConfigTest.kt
@@ -85,18 +85,22 @@ class EnvConfigTest_BaseUrlsAreCorrect {
     fun `test Dev baseUrl is correct`() {
         assertThat(EnvConfig.Dev.baseUrl).isEqualTo("https://api.dev.joinforage.app/")
     }
+
     @Test
     fun `test Staging baseUrl is correct`() {
         assertThat(EnvConfig.Staging.baseUrl).isEqualTo("https://api.staging.joinforage.app/")
     }
+
     @Test
     fun `test Sandbox baseUrl is correct`() {
         assertThat(EnvConfig.Sandbox.baseUrl).isEqualTo("https://api.sandbox.joinforage.app/")
     }
+
     @Test
     fun `test Cert baseUrl is correct`() {
         assertThat(EnvConfig.Cert.baseUrl).isEqualTo("https://api.cert.joinforage.app/")
     }
+
     @Test
     fun `test Prod baseUrl is correct`() {
         assertThat(EnvConfig.Prod.baseUrl).isEqualTo("https://api.joinforage.app/")

--- a/forage-android/src/test/java/com/joinforage/forage/android/core/env/EnvConfigTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/core/env/EnvConfigTest.kt
@@ -79,3 +79,26 @@ class EnvConfigTest_fromForageConfig {
         assertThat(result).isEqualTo(EnvConfig.Dev)
     }
 }
+
+class EnvConfigTest_BaseUrlsAreCorrect {
+    @Test
+    fun `test Dev baseUrl is correct`() {
+        assertThat(EnvConfig.Dev.baseUrl).isEqualTo("https://api.dev.joinforage.app/")
+    }
+    @Test
+    fun `test Staging baseUrl is correct`() {
+        assertThat(EnvConfig.Staging.baseUrl).isEqualTo("https://api.staging.joinforage.app/")
+    }
+    @Test
+    fun `test Sandbox baseUrl is correct`() {
+        assertThat(EnvConfig.Sandbox.baseUrl).isEqualTo("https://api.sandbox.joinforage.app/")
+    }
+    @Test
+    fun `test Cert baseUrl is correct`() {
+        assertThat(EnvConfig.Cert.baseUrl).isEqualTo("https://api.cert.joinforage.app/")
+    }
+    @Test
+    fun `test Prod baseUrl is correct`() {
+        assertThat(EnvConfig.Prod.baseUrl).isEqualTo("https://api.joinforage.app/")
+    }
+}

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/EncryptionKeyServiceTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/EncryptionKeyServiceTest.kt
@@ -28,7 +28,7 @@ class EncryptionKeyServiceTest : MockServerSuite() {
 
         encryptionKeyService = EncryptionKeyService(
             okHttpClient = OkHttpClientBuilder.provideOkHttpClient(bearerToken),
-            httpUrl = server.url(""),
+            httpUrl = server.url("").toUrl().toString(),
             logger = Log.getSilentInstance()
         )
     }

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/MessageStatusServiceTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/MessageStatusServiceTest.kt
@@ -28,7 +28,7 @@ class MessageStatusServiceTest : MockServerSuite() {
 
         messageStatusService = MessageStatusService(
             okHttpClient = OkHttpClientBuilder.provideOkHttpClient(BEARER_TOKEN, MERCHANT_ACCOUNT),
-            httpUrl = server.url(""),
+            httpUrl = server.url("").toUrl().toString(),
             logger = Log.getSilentInstance()
         )
     }

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/TokenizeCardServiceTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/TokenizeCardServiceTest.kt
@@ -40,7 +40,7 @@ class TokenizeCardServiceTest : MockServerSuite() {
                 testData.merchantAccount,
                 idempotencyKey
             ),
-            httpUrl = server.url(""),
+            httpUrl = server.url("").toUrl().toString(),
             logger = Log.getSilentInstance()
         )
     }

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/CapturePaymentRepositoryTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/CapturePaymentRepositoryTest.kt
@@ -47,7 +47,7 @@ class CapturePaymentRepositoryTest : MockServerSuite() {
             pinCollector = pinCollector,
             encryptionKeyService = EncryptionKeyService(
                 okHttpClient = OkHttpClientBuilder.provideOkHttpClient(testData.bearerToken),
-                httpUrl = server.url(""),
+                httpUrl = server.url("").toUrl().toString(),
                 logger = logger
             ),
             messageStatusService = MessageStatusService(
@@ -55,7 +55,7 @@ class CapturePaymentRepositoryTest : MockServerSuite() {
                     testData.bearerToken,
                     merchantAccount = testData.merchantAccount
                 ),
-                httpUrl = server.url(""),
+                httpUrl = server.url("").toUrl().toString(),
                 logger = logger
             ),
             paymentService = PaymentService(
@@ -63,7 +63,7 @@ class CapturePaymentRepositoryTest : MockServerSuite() {
                     testData.bearerToken,
                     merchantAccount = testData.merchantAccount
                 ),
-                httpUrl = server.url(""),
+                httpUrl = server.url("").toUrl().toString(),
                 logger = logger
             ),
             paymentMethodService = PaymentMethodService(
@@ -71,7 +71,7 @@ class CapturePaymentRepositoryTest : MockServerSuite() {
                     testData.bearerToken,
                     merchantAccount = testData.merchantAccount
                 ),
-                httpUrl = server.url(""),
+                httpUrl = server.url("").toUrl().toString(),
                 logger = logger
             ),
             logger = logger

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/CheckBalanceRepositoryTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/CheckBalanceRepositoryTest.kt
@@ -44,7 +44,7 @@ class CheckBalanceRepositoryTest : MockServerSuite() {
             pinCollector = pinCollector,
             encryptionKeyService = EncryptionKeyService(
                 okHttpClient = OkHttpClientBuilder.provideOkHttpClient(testData.bearerToken),
-                httpUrl = server.url(""),
+                httpUrl = server.url("").toUrl().toString(),
                 logger = logger
             ),
             paymentMethodService = PaymentMethodService(
@@ -52,7 +52,7 @@ class CheckBalanceRepositoryTest : MockServerSuite() {
                     testData.bearerToken,
                     merchantAccount = testData.merchantAccount
                 ),
-                httpUrl = server.url(""),
+                httpUrl = server.url("").toUrl().toString(),
                 logger = logger
             ),
             messageStatusService = MessageStatusService(
@@ -60,7 +60,7 @@ class CheckBalanceRepositoryTest : MockServerSuite() {
                     testData.bearerToken,
                     merchantAccount = testData.merchantAccount
                 ),
-                httpUrl = server.url(""),
+                httpUrl = server.url("").toUrl().toString(),
                 logger = logger
             ),
             logger = logger


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
This PR is associated with [removing `ForageConstant.kt`'s dependence on `StopgapGlobalState`](https://www.notion.so/joinforage/Pre-GoPuff-Launch-Cleanup-Proposal-aa5c5caf4a6747fc930ad511e83b79b6?pvs=4#357ef83068174aabba9256e14e36198b), part of the remaining cleanup work associated with Android 3.0

`ForageConstant.kt`'s depended on `StopgapGlobalState` because of `BASE_URL`. However, `BASE_URL` is only directly consumed by `ForageSDK`, which means we make moving the related logic directly into `ForageSDK` by parsing the `sessionToken` to extract the `baseUrl`


## Why

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
- ✅ and ❌. I added unit tests to ensure surface if any of the `EncConfig` `baseUrl`s ever become malformed because we are unable to get the compiler's guarantee of non-null values or that it won't throw runtime errors. We had a thoughtful conversation about this [below](https://github.com/teamforage/forage-android-sdk/pull/126#discussion_r1383861013)
- ❌ It's not necessary to manually test these changes as the CI tests will flag if there's an issue with these changes.

## How
This can be rolled out once approved!
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
