### PR TITLE
[FX-678] Remove Forage Log's dependence on StopgapGlobalState

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/telemetry/Log.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/telemetry/Log.kt
@@ -7,11 +7,12 @@ import com.joinforage.datadog.android.log.Logger
 import com.joinforage.datadog.android.log.Logs
 import com.joinforage.datadog.android.log.LogsConfiguration
 import com.joinforage.datadog.android.privacy.TrackingConsent
-import com.joinforage.forage.android.core.StopgapGlobalState
+import com.joinforage.forage.android.core.EnvConfig
+import com.joinforage.forage.android.ui.ForageConfig
 import kotlin.random.Random
 
 internal interface Log {
-    fun initializeDD(context: Context)
+    fun initializeDD(context: Context, config: ForageConfig)
     fun d(msg: String, attributes: Map<String, Any?> = emptyMap())
     fun i(msg: String, attributes: Map<String, Any?> = emptyMap())
     fun w(msg: String, attributes: Map<String, Any?> = emptyMap())
@@ -35,14 +36,16 @@ internal interface Log {
             var traceId: String? = null
             private var logger: Logger? = null
 
-            override fun initializeDD(context: Context) {
+            override fun initializeDD(context: Context, config: ForageConfig) {
                 if (logger != null) {
                     return
                 }
+                val envConfig = EnvConfig.fromForageConfig(config)
+
                 val configuration = Configuration.Builder(
-                    clientToken = StopgapGlobalState.envConfig.ddClientToken,
-                    env = StopgapGlobalState.envConfig.FLAVOR.value,
-                    variant = StopgapGlobalState.envConfig.FLAVOR.value
+                    clientToken = envConfig.ddClientToken,
+                    env = envConfig.FLAVOR.value,
+                    variant = envConfig.FLAVOR.value
                 ).build()
                 Datadog.initialize(context, configuration, TrackingConsent.GRANTED)
                 val logsConfig = LogsConfiguration.Builder().build()
@@ -60,8 +63,8 @@ internal interface Log {
                     traceId = generateTraceId()
                 }
 
-                logger?.addAttribute(VERSION_CODE, StopgapGlobalState.envConfig.PUBLISH_VERSION)
-                logger?.addTag(VERSION_CODE, StopgapGlobalState.envConfig.PUBLISH_VERSION)
+                logger?.addAttribute(VERSION_CODE, envConfig.PUBLISH_VERSION)
+                logger?.addTag(VERSION_CODE, envConfig.PUBLISH_VERSION)
                 logger?.addAttribute(TRACE_ID, traceId)
             }
 
@@ -90,7 +93,7 @@ internal interface Log {
         }
 
         private val SILENT = object : Log {
-            override fun initializeDD(context: Context) {
+            override fun initializeDD(context: Context, config: ForageConfig) {
             }
 
             override fun d(msg: String, attributes: Map<String, Any?>) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/AbstractForageElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/AbstractForageElement.kt
@@ -18,7 +18,7 @@ abstract class AbstractForageElement(
     // setForageConfig is called. Side effect include
     // initializing logger module, feature flag module,
     // and view UI manipulation logic
-    protected abstract fun initWithForageConfig()
+    protected abstract fun initWithForageConfig(forageConfig: ForageConfig)
 
     override fun setForageConfig(forageConfig: ForageConfig) {
         // keep a record of whether this was the first time
@@ -40,7 +40,7 @@ abstract class AbstractForageElement(
         // operations on any subsequent calls to setForageConfig
         // or else that could crash the app.
         if (isFirstCallToSet) {
-            initWithForageConfig()
+            initWithForageConfig(forageConfig)
         } else {
             // TODO: possible opportunity to log that
             //  they tried to do sessionToken refreshing

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -145,14 +145,13 @@ class ForagePANEditText @JvmOverloads constructor(
             }
     }
 
-    override fun initWithForageConfig() {
+    override fun initWithForageConfig(forageConfig: ForageConfig) {
         // Must initialize DD at the beginning of each render function. DD requires the context,
         // so we need to wait until a context is present to run initialization code. However,
         // we have logging all over the SDK that relies on the render happening first.
         val logger = Log.getInstance()
-        logger.initializeDD(context)
+        logger.initializeDD(context, forageConfig)
 
-        val forageConfig = getForageConfig() // already set by parent class
         _SET_ONLY_manager = if (EnvConfig.inProd(forageConfig)) {
             // strictly support only valid Ebt PAN numbers
             PanElementStateManager.forEmptyInput()

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -91,12 +91,12 @@ class ForagePINEditText @JvmOverloads constructor(
             }
     }
 
-    override fun initWithForageConfig() {
+    override fun initWithForageConfig(forageConfig: ForageConfig) {
         // Must initialize DD at the beginning of each render function. DD requires the context,
         // so we need to wait until a context is present to run initialization code. However,
         // we have logging all over the SDK that relies on the render happening first.
         val logger = Log.getInstance()
-        logger.initializeDD(context)
+        logger.initializeDD(context, forageConfig)
 
         // flagging that LDManager depends on StopgapGlobalState so
         // its relying on forageConfig under the hood. This

--- a/forage-android/src/test/java/com/joinforage/forage/android/core/telemetry/metrics/ResponseMonitorTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/core/telemetry/metrics/ResponseMonitorTest.kt
@@ -12,6 +12,7 @@ import com.joinforage.forage.android.core.telemetry.ResponseMonitor
 import com.joinforage.forage.android.core.telemetry.UnknownForageErrorCode
 import com.joinforage.forage.android.core.telemetry.UserAction
 import com.joinforage.forage.android.core.telemetry.VaultProxyResponseMonitor
+import com.joinforage.forage.android.ui.ForageConfig
 import org.assertj.core.api.Assertions
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,7 +40,7 @@ private class MockLogger : Log {
     val infoLogs: MutableList<LogEntry> = mutableListOf()
     val errorLogs: MutableList<LogEntry> = mutableListOf()
 
-    override fun initializeDD(context: Context) {
+    override fun initializeDD(context: Context, forageConfig: ForageConfig) {
         return
     }
 


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
This PR is associated with [removing `Log.kt`'s dependence on `StopgapGlobalState`](https://www.notion.so/joinforage/Pre-GoPuff-Launch-Cleanup-Proposal-aa5c5caf4a6747fc930ad511e83b79b6?pvs=4#13dcc917df71402190f0b96fd8a4ac2a), part of the remaining cleanup work associated with Android 3.0

`Log.kt`'s depended on `StopgapGlobalState` because of the Datadog client key and we were able to remove that dependence by having `Log.initializeDD(...)` accept a `ForageConfig` as a param


## Test Plan
- ❌.  No novel unit tests were add but I updated the unit tests in accordance with the changes made
- ❌ It's not necessary to manually test these changes as the CI tests will flag if there's an issue with these changes.

## How
This can be rolled out once approved!
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
