### PR TITLE
[FX-681] Remove LDManager's dependence on StopgapGlobalState

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/LDManager.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/LDManager.kt
@@ -63,7 +63,7 @@ internal object LDManager {
         val vaultType = computeVaultType(vaultPercent)
         logger.i("[LaunchDarkly] Vault type set to $vaultType")
 
-        // return vault provider derived from the novel or cached flag value
+        // return vault provider
         return vaultType
     }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/LDManager.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/LDManager.kt
@@ -30,8 +30,8 @@ internal object LDContextKind {
     const val SERVICE = "service"
 }
 
-internal val ALWAYS_BT = 100.0
-internal val ALWAYS_VGS = 0.0
+internal val ALWAYS_BT_PERCENT = 100.0
+internal val ALWAYS_VGS_PERCENT = 0.0
 
 internal fun computeVaultType(trafficPrimaryPercentFlag: Double): VaultType {
     val randomNum = Math.random() * 100
@@ -55,8 +55,8 @@ internal object LDManager {
     internal fun getVaultProvider(logger: Log = Log.getSilentInstance()): VaultType {
         val vaultPercent = client?.doubleVariation(
             LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG,
-            ALWAYS_VGS
-        ) ?: ALWAYS_VGS
+            ALWAYS_VGS_PERCENT
+        ) ?: ALWAYS_VGS_PERCENT
         logger.i("[LaunchDarkly] Vault percent of $vaultPercent return from LD")
 
         // convert the flag percent into an answer to which vault provider to use

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
@@ -93,7 +93,7 @@ internal class CapturePaymentRepository(
         paymentRef: String
     ): ForageApiResponse<String> {
         var attempt = 1
-        val pollingIntervals = LDManager.getPollingIntervals()
+        val pollingIntervals = LDManager.getPollingIntervals(logger)
 
         while (true) {
             logger.i(

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
@@ -76,7 +76,7 @@ internal class CheckBalanceRepository(
         paymentMethodRef: String
     ): ForageApiResponse<String> {
         var attempt = 1
-        val pollingIntervals = LDManager.getPollingIntervals()
+        val pollingIntervals = LDManager.getPollingIntervals(logger)
 
         while (true) {
             logger.i(

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -15,6 +15,7 @@ import com.joinforage.forage.android.VaultType
 import com.joinforage.forage.android.collect.BTPinCollector
 import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.collect.VGSPinCollector
+import com.joinforage.forage.android.core.EnvConfig
 import com.joinforage.forage.android.core.element.SimpleElementListener
 import com.joinforage.forage.android.core.element.StatefulElementListener
 import com.joinforage.forage.android.core.element.state.ElementState
@@ -98,14 +99,13 @@ class ForagePINEditText @JvmOverloads constructor(
         val logger = Log.getInstance()
         logger.initializeDD(context, forageConfig)
 
-        // flagging that LDManager depends on StopgapGlobalState so
-        // its relying on forageConfig under the hood. This
-        // relationship will be made explicit once we drop
-        // StopgapGlobalState
+        // initialize Launch Darkly singleton
+        val ldMobileKey = EnvConfig.fromForageConfig(forageConfig).ldMobileKey
+        val ldConfig = LDManager.createLdConfig(ldMobileKey)
+        LDManager.initialize(context.applicationContext as Application, logger, ldConfig)
 
-        LDManager.initialize(context.applicationContext as Application, logger)
+        // decide on a vault provider and the corresponding vault wrapper
         val vaultType = LDManager.getVaultProvider()
-
         _SET_ONLY_vault = if (vaultType == VaultType.BT_VAULT_TYPE) {
             btVaultWrapper
         } else {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -103,7 +103,7 @@ class ForagePINEditText @JvmOverloads constructor(
         // initialize Launch Darkly singleton
         val ldMobileKey = EnvConfig.fromForageConfig(forageConfig).ldMobileKey
         val ldConfig = LDConfig.Builder().mobileKey(ldMobileKey).build()
-        LDManager.initialize(context.applicationContext as Application,ldConfig)
+        LDManager.initialize(context.applicationContext as Application, ldConfig)
 
         // decide on a vault provider and the corresponding vault wrapper
         val vaultType = LDManager.getVaultProvider(logger)

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -20,6 +20,7 @@ import com.joinforage.forage.android.core.element.SimpleElementListener
 import com.joinforage.forage.android.core.element.StatefulElementListener
 import com.joinforage.forage.android.core.element.state.ElementState
 import com.joinforage.forage.android.core.telemetry.Log
+import com.launchdarkly.sdk.android.LDConfig
 import com.verygoodsecurity.vgscollect.widget.VGSEditText
 
 class ForagePINEditText @JvmOverloads constructor(
@@ -101,11 +102,11 @@ class ForagePINEditText @JvmOverloads constructor(
 
         // initialize Launch Darkly singleton
         val ldMobileKey = EnvConfig.fromForageConfig(forageConfig).ldMobileKey
-        val ldConfig = LDManager.createLdConfig(ldMobileKey)
-        LDManager.initialize(context.applicationContext as Application, logger, ldConfig)
+        val ldConfig = LDConfig.Builder().mobileKey(ldMobileKey).build()
+        LDManager.initialize(context.applicationContext as Application,ldConfig)
 
         // decide on a vault provider and the corresponding vault wrapper
-        val vaultType = LDManager.getVaultProvider()
+        val vaultType = LDManager.getVaultProvider(logger)
         _SET_ONLY_vault = if (vaultType == VaultType.BT_VAULT_TYPE) {
             btVaultWrapper
         } else {

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
@@ -63,7 +63,6 @@ class LaunchDarklyTest() {
         assertThat(postUpdate).isEqualTo(VaultType.BT_VAULT_TYPE)
     }
 
-
     @Test
     fun `Default polling intervals`() = runTest {
         // set up LDManager

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
@@ -2,8 +2,8 @@ package com.joinforage.forage.android.network.data
 
 import android.app.Application
 import androidx.test.platform.app.InstrumentationRegistry
-import com.joinforage.forage.android.ALWAYS_BT
-import com.joinforage.forage.android.ALWAYS_VGS
+import com.joinforage.forage.android.ALWAYS_BT_PERCENT
+import com.joinforage.forage.android.ALWAYS_VGS_PERCENT
 import com.joinforage.forage.android.LDFlags
 import com.joinforage.forage.android.LDManager
 import com.joinforage.forage.android.VaultType
@@ -36,12 +36,12 @@ class LaunchDarklyTest() {
 
     @Test
     fun `Test computeVaultType returns BT percent is 100f`() {
-        assertThat(computeVaultType(ALWAYS_BT)).isEqualTo(VaultType.BT_VAULT_TYPE)
+        assertThat(computeVaultType(ALWAYS_BT_PERCENT)).isEqualTo(VaultType.BT_VAULT_TYPE)
     }
 
     @Test
     fun `Test computeVaultType returns VGS percent is 0f`() {
-        assertThat(computeVaultType(ALWAYS_VGS)).isEqualTo(VaultType.VGS_VAULT_TYPE)
+        assertThat(computeVaultType(ALWAYS_VGS_PERCENT)).isEqualTo(VaultType.VGS_VAULT_TYPE)
     }
 
     @Test
@@ -56,7 +56,7 @@ class LaunchDarklyTest() {
         assertThat(original).isEqualTo(VaultType.VGS_VAULT_TYPE)
 
         // Set the test data to send all traffic to BT
-        td.update(td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(LDValue.of(ALWAYS_BT)))
+        td.update(td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(LDValue.of(ALWAYS_BT_PERCENT)))
 
         // it should consume the flag and choose BT
         val postUpdate = LDManager.getVaultProvider()

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
@@ -1,84 +1,97 @@
-package com.joinforage.forage.android.network
+package com.joinforage.forage.android.network.data
 
 import android.app.Application
 import androidx.test.platform.app.InstrumentationRegistry
+import com.joinforage.forage.android.ALWAYS_BT
+import com.joinforage.forage.android.ALWAYS_VGS
 import com.joinforage.forage.android.LDFlags
 import com.joinforage.forage.android.LDManager
 import com.joinforage.forage.android.VaultType
+import com.joinforage.forage.android.computeVaultType
 import com.joinforage.forage.android.core.telemetry.Log
 import com.launchdarkly.sdk.LDValue
 import com.launchdarkly.sdk.android.integrations.TestData
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
-import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
-@OptIn(ExperimentalCoroutinesApi::class)
+val LD_MOBILE_KEY = "some key"
+
 @RunWith(RobolectricTestRunner::class)
 class LaunchDarklyTest() {
-    private val alwaysBT = 100.0
-    private val alwaysVGS = 0.0
 
+    // NOTE: It is essential that the TestData source live in a
+    // companion object. For some reason moving this variable
+    // to be a instance variable instead of a static variable causes
+    // race conditions within tests
     companion object {
-        private lateinit var td: TestData
-
-        @BeforeClass @JvmStatic
-        fun setup() {
-            td = TestData.dataSource()
-        }
-    }
-
-    @After
-    fun resetForage() {
-        LDManager.vaultType = null
+        private var td: TestData = TestData.dataSource()
     }
 
     @Test
-    fun `The outcome should always be BT`() = runTest {
-        // Set the test data to send all traffic to BT
-        td.update(td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(LDValue.of(alwaysBT)))
+    fun `Test computeVaultType returns BT percent is 100f`() {
+        assertThat(computeVaultType(ALWAYS_BT)).isEqualTo(VaultType.BT_VAULT_TYPE)
+    }
+
+    @Test
+    fun `Test computeVaultType returns VGS percent is 0f`() {
+        assertThat(computeVaultType(ALWAYS_VGS)).isEqualTo(VaultType.VGS_VAULT_TYPE)
+    }
+
+    @Test
+    fun `It should default to using VGS as the vault provider`() = runTest {
+        // set up LDManager, importantly, we're not giving it any value for
+        // primaryTrafficPercent since we want to test it defaults to VGS
         val app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
-        LDManager.initialize(app, logger = Log.getSilentInstance(), dataSource = td)
-        val vaultType = LDManager.getVaultProvider()
-        assertThat(vaultType).isEqualTo(VaultType.BT_VAULT_TYPE)
+        val ldConfig = LDManager.TEST_createLdConfig(LD_MOBILE_KEY, td)
+        LDManager.initialize(app, logger = Log.getSilentInstance(), ldConfig)
+
+        // we don't want to use the cached value from another test
+        // since LDManager is a singleton
+        LDManager.TEST_clearPrimaryTrafficPercentCache()
+
+        // it should default to using VGS as the vault provider
+        assertThat(LDManager.getVaultProvider()).isEqualTo(VaultType.VGS_VAULT_TYPE)
+    }
+
+    @Test
+    fun `It should cache primaryTrafficPercent flag for subsequent calls to getVaultProvider`() = runTest {
+        // set up LDManager
+        val app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
+        val ldConfig = LDManager.TEST_createLdConfig(LD_MOBILE_KEY, td)
+        LDManager.initialize(app, logger = Log.getSilentInstance(), ldConfig)
+
+        // we don't want to use the cached value from another test
+        // since LDManager is a singleton
+        LDManager.TEST_clearPrimaryTrafficPercentCache()
+
+        // Set the test data to send all traffic to BT
+        td.update(td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(LDValue.of(ALWAYS_BT)))
+
+        // it should consume the flag and choose BT
+        val original = LDManager.getVaultProvider()
+        assertThat(original).isEqualTo(VaultType.BT_VAULT_TYPE)
 
         // Update the test data to send all traffic to VGS
-        // Since ForageSDK is a singleton, we should still return BT in this instance
-        td.update(td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(LDValue.of(alwaysVGS)))
+        td.update(td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(LDValue.of(ALWAYS_VGS)))
 
-        val secondVaultType = LDManager.getVaultProvider()
-        assertThat(secondVaultType).isEqualTo(VaultType.BT_VAULT_TYPE)
-    }
-
-    @Test
-    fun `The outcome should always be VGS`() = runTest {
-        // Set the test data to send all traffic to VGS
-        td.update(td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(LDValue.of(alwaysVGS)))
-        val app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
-
-        LDManager.initialize(app, logger = Log.getSilentInstance(), dataSource = td)
-        val vaultType = LDManager.getVaultProvider()
-        assertThat(vaultType).isEqualTo(VaultType.VGS_VAULT_TYPE)
-
-        // Update the test data to send all traffic to BT
-        // Since ForageSDK is a singleton, we should still return VGS in this instance
-        td.update(td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(LDValue.of(alwaysBT)))
-
-        val secondVaultType = LDManager.getVaultProvider()
-        assertThat(secondVaultType).isEqualTo(VaultType.VGS_VAULT_TYPE)
+        // we expect the value to be cached and thus should be BT again
+        val cached = LDManager.getVaultProvider()
+        assertThat(cached).isEqualTo(VaultType.BT_VAULT_TYPE)
     }
 
     @Test
     fun `Default polling intervals`() = runTest {
-        // Set the test data to be {"intervals" : [1000]}
-        td.update(td.flag(LDFlags.ISO_POLLING_WAIT_INTERVALS).variations(LDValue.buildObject().put("intervals", LDValue.buildArray().add(1000L).build()).build()))
+        // set up LDManager
         val app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
+        val ldConfig = LDManager.TEST_createLdConfig(LD_MOBILE_KEY, td)
+        LDManager.initialize(app, logger = Log.getSilentInstance(), ldConfig)
 
-        LDManager.initialize(app, logger = Log.getSilentInstance(), dataSource = td)
+        // Set the test data to be {"intervals" : [1000]}
+        td.update(td.flag(LDFlags.ISO_POLLING_WAIT_INTERVALS).variations(LDValue.buildObject().put("intervals", LDValue.Convert.Long.arrayFrom(List(1) { 1000L })).build()))
+
         val pollingIntervals = LDManager.getPollingIntervals()
         assertThat(pollingIntervals).isEqualTo(longArrayOf(1000L))
     }


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
This PR is associated with [removing `LDManager.kt`'s dependence on `StopgapGlobalState`](https://www.notion.so/joinforage/Pre-GoPuff-Launch-Cleanup-Proposal-aa5c5caf4a6747fc930ad511e83b79b6?pvs=4#31c155cd4bdb40d78f8e78295c7b2bc5), part of the remaining cleanup work associated with Android 3.0

`LDManage.kt` depended on `StopgapGlobalState` for the Launch Darkly client key. We were able to remove that dependence by having `LDMangager.initialize(...)` accept an `LDConfig`, which will have the LD client key already set.


## Test Plan
- ❌ While the code coverage will not change with this PR, I did introduce two additional unit tests to explicitly test the helpder function responsible for mapping the primary vault traffic flag to a Vault Provider
- ❌ It's not necessary to manually test these changes as the CI tests will flag if there's an issue with these changes.

## How
This can be rolled out once approved!
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
