### PR TITLE
Add support for manual triggering of CI Github action

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
   schedule:
     - cron: '0 12 * * *' # Run every day at 7/8 AM Eastern


### PR DESCRIPTION

## Why
Right now the only way to run CI tests on a branch is to create a PR. It would be create if we could just run the CI tests on an arbitrary branch rather than PR-intended branches as some branches are just meant for exploration
<!-- Describe the motivations behind this change if they are a subset of your ticket -->


## How
Can be merged in whenever
