### PR TITLE
[FX-792] Add consumer-rules to Forage SDK

### DIFF
--- a/forage-android/consumer-rules.pro
+++ b/forage-android/consumer-rules.pro
@@ -1,0 +1,3 @@
+-keepclassmembers class com.joinforage.forage.android.collect.ProxyRequestObject {
+    *;
+}

--- a/forage-android/proguard-rules.pro
+++ b/forage-android/proguard-rules.pro
@@ -1,21 +1,13 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+## IF YOU WANT TO ENABLE PROGUARD IN FORAGE-SDK, UNCOMMENT THESE DIRECTIVES
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
+# Keep the StringConcatFactory class and its methods
+#-keep class java.lang.invoke.StringConcatFactory {
+#    *;
 #}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+#
+## Keep the TimeInfo class and its methods
+#-keep class com.joinforage.datadog.android.api.context.TimeInfo {
+#    *;
+#}
+#
+#-dontwarn java.lang.invoke.StringConcatFactory

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/BTPinCollector.kt
@@ -3,6 +3,7 @@ package com.joinforage.forage.android.collect
 import com.basistheory.android.service.BasisTheoryElements
 import com.basistheory.android.service.HttpMethod
 import com.basistheory.android.service.ProxyRequest
+import com.basistheory.android.view.TextElement
 import com.joinforage.forage.android.VaultType
 import com.joinforage.forage.android.core.StopgapGlobalState
 import com.joinforage.forage.android.core.telemetry.Log
@@ -17,6 +18,8 @@ import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.ui.ForagePINEditText
 import org.json.JSONException
 import java.util.*
+
+internal data class ProxyRequestObject(val pin: TextElement, val card_number_token: String)
 
 internal class BTPinCollector(
     private val pinForageEditText: ForagePINEditText,
@@ -66,10 +69,10 @@ internal class BTPinCollector(
 
         val proxyRequest: ProxyRequest = ProxyRequest().apply {
             headers = buildHeaders(encryptionKey, merchantAccount, traceId = logger.getTraceIdValue())
-            body = object {
-                val pin = pinForageEditText.getTextElement()
-                val card_number_token = cardToken
-            }
+            body = ProxyRequestObject(
+                pin = pinForageEditText.getTextElement(),
+                card_number_token = cardToken
+            )
             path = requestPath
         }
 
@@ -186,10 +189,10 @@ internal class BTPinCollector(
 
         val proxyRequest: ProxyRequest = ProxyRequest().apply {
             headers = buildHeaders(encryptionKey, merchantAccount, paymentRef, traceId = logger.getTraceIdValue())
-            body = object {
-                val pin = pinForageEditText.getTextElement()
-                val card_number_token = cardToken
-            }
+            body = ProxyRequestObject(
+                pin = pinForageEditText.getTextElement(),
+                card_number_token = cardToken
+            )
             path = capturePaymentPath(paymentRef)
         }
 

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -26,6 +26,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+        /**
+         * IF YOU WANT TO ENABLE PROGUARD, USE THESE BUILD TYPES
+         */
 //        release {
 //            minifyEnabled true
 //            shrinkResources true

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -26,6 +26,16 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+//        release {
+//            minifyEnabled true
+//            shrinkResources true
+//            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+//        }
+//        debug {
+//            minifyEnabled true
+//            shrinkResources true
+//            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+//        }
     }
 
     compileOptions {

--- a/sample-app/proguard-rules.pro
+++ b/sample-app/proguard-rules.pro
@@ -1,21 +1,20 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
+## IF PROGUARD IS ENABLED FOR SAMPLE APP, UNCOMMENT THESE DIRECTIVES.
+## THIS SHOULD UNBLOCK THE SAMPLE APP THROUGH A BALANCE CHECK, BUT THE NEXT SCREEN
+## MAY STILL FAIL!
+
+#-dontwarn javax.validation.valueextraction.UnwrapByDefault
+#-dontwarn javax.validation.valueextraction.ValueExtractor
 #
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+### Gson uses generic type information stored in a class file when working with
+### fields. Proguard removes such information by default, keep it.
+#-keepattributes Signature
+#
+## This is also needed for R8 in compat mode since multiple
+## optimizations will remove the generic signature such as class
+## merging and argument removal. See:
+## https://r8.googlesource.com/r8/+/refs/heads/main/compatibility-faq.md#troubleshooting-gson-gson
+#-keep class com.google.gson.reflect.TypeToken { *; }
+#-keep class * extends com.google.gson.reflect.TypeToken
+#
+## Optional. For using GSON @Expose annotation
+#-keepattributes AnnotationDefault,RuntimeVisibleAnnotations


### PR DESCRIPTION
## What
Create a data class for the BT body parameters and add a directive to the `consumer-rules.pro` file so that people who use Forage don't obfuscate the object.

## Why
GoPuff (and probably others in the future) use ProGuard or a similar tool that obfuscates their code. Since they consume our SDK, this also obfuscates _OUR_ code. When this happens, the BT integration fails because the `card_number_token` and `pin` fields are changed to `a` and `b`. These names are important and must stay consistent.

## Test Plan
I have tested this change locally by running ProGuard on our sample app and replicating the issue. After adding the `consumer-rules.pro` directive, I re-ran the build process and can see that the code is not obfuscated. Then, I ran the release .apk file and was able to interact with BT.
