### PR TITLE
[FX-839] Use dynamic Browserstack custom ID 

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    env:
+      # Avoid concurrency issues
+      BROWSERSTACK_CUSTOM_ID: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && format('pr-{0}', github.sha) || 'AndroidApp' }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -42,7 +46,7 @@ jobs:
           curl -u "${{ secrets.BROWSERSTACK_USERNAME }}:${{ secrets.BROWSERSTACK_ACCESS_KEY }}" -X POST \
           https://api-cloud.browserstack.com/app-automate/upload \
           -F "file=@${{ github.workspace }}/sample-app/build/outputs/apk/debug/sample-app-debug.apk" \
-          -F "custom_id=AndroidApp"
+          -F "custom_id=${{ env.BROWSERSTACK_CUSTOM_ID }}"
 
       - name: Checkout Integration Test Repo
         uses: actions/checkout@v3
@@ -56,6 +60,7 @@ jobs:
         run: |
           cd mobile-qa-tests
           pip install -r requirements.txt
+          export BROWSERSTACK_CUSTOM_ID=${{ env.BROWSERSTACK_CUSTOM_ID }}
           pytest android/tests/test_basic_flow.py || true
           pytest --lf --last-failed-no-failures none  --suppress-no-test-exit-code android/tests/test_basic_flow.py
 


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What


## Why

to prevent CI check concurrency issues

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- [x] CI check passes on this PR
- [x] Verify that custom_id is being referenced within BrowserStack
- [ ] CI check passes once merged to main (main branch uses the default `custom_id=AndroidApp` )

## How

https://github.com/teamforage/mobile-qa-tests/pull/35 should be merged first

<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
