### PR TITLE
[FX-880] Add POS option to bottom nav that goes to empty view

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/MainActivity.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/MainActivity.kt
@@ -30,7 +30,8 @@ class MainActivity : AppCompatActivity() {
         val appBarConfiguration = AppBarConfiguration(
             setOf(
                 R.id.navigation_complete_flow,
-                R.id.navigation_catalog
+                R.id.navigation_catalog,
+                R.id.navigation_pos,
             )
         )
         setupActionBarWithNavController(navController, appBarConfiguration)

--- a/sample-app/src/main/java/com/joinforage/android/example/MainActivity.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/MainActivity.kt
@@ -31,7 +31,7 @@ class MainActivity : AppCompatActivity() {
             setOf(
                 R.id.navigation_complete_flow,
                 R.id.navigation_catalog,
-                R.id.navigation_pos,
+                R.id.navigation_pos
             )
         )
         setupActionBarWithNavController(navController, appBarConfiguration)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
@@ -2,5 +2,4 @@ package com.joinforage.android.example.ui.pos
 
 import androidx.fragment.app.Fragment
 
-class POSFragment: Fragment() {
-}
+class POSFragment : Fragment()

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
@@ -1,0 +1,6 @@
+package com.joinforage.android.example.ui.pos
+
+import androidx.fragment.app.Fragment
+
+class POSFragment: Fragment() {
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -1,0 +1,5 @@
+package com.joinforage.android.example.ui.pos
+
+import androidx.lifecycle.ViewModel
+class POSViewModel: ViewModel() {
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -1,5 +1,5 @@
 package com.joinforage.android.example.ui.pos
 
 import androidx.lifecycle.ViewModel
-class POSViewModel: ViewModel() {
-}
+
+class POSViewModel : ViewModel()

--- a/sample-app/src/main/res/menu/bottom_nav_menu.xml
+++ b/sample-app/src/main/res/menu/bottom_nav_menu.xml
@@ -10,4 +10,10 @@
         android:id="@+id/navigation_catalog"
         android:icon="@drawable/ic_dashboard_black_24dp"
         android:title="@string/title_dashboard" />
+
+    <item
+        android:id="@+id/navigation_pos"
+        android:icon="@drawable/ic_credit_card_24"
+        android:title="@string/title_pos" />
+
 </menu>

--- a/sample-app/src/main/res/navigation/mobile_navigation.xml
+++ b/sample-app/src/main/res/navigation/mobile_navigation.xml
@@ -6,6 +6,11 @@
     app:startDestination="@+id/navigation_complete_flow">
 
     <fragment
+        android:id="@+id/navigation_pos"
+        android:name="com.joinforage.android.example.ui.pos.POSFragment"
+        android:label="@string/title_pos" />
+
+    <fragment
         android:id="@+id/navigation_catalog"
         android:name="com.joinforage.android.example.ui.catalog.CatalogFragment"
         android:label="@string/title_dashboard"

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">forage-android</string>
     <string name="title_tokenize_card">Tokenize</string>
     <string name="title_dashboard">Catalog</string>
+    <string name="title_pos">POS</string>
     <string name="title_balance">Balance</string>
     <string name="title_setup">Setup Authentication</string>
     <string name="title_tokenize_ebt">Tokenize EBT Card</string>


### PR DESCRIPTION
## What
Adds a link to a POS flow that will eventually be built out for FIS certification. For now, it just goes to an empty view. 

## Why
Creating a place to build out the rest of the flow. I'm new to Android dev so this seemed like a low-stakes way for me to get started.

## Test Plan

- ❌ I've added unit tests for this change. 
  - Doesn't really seem like the kind of thing to have a unit test for since it's just Android navigation functionality.
- ✅ The reviewer should manually test the changes in this PR.
  - Run the sample app on a test device (either physical or virtual) and see the POS nav item. Tap the item to be taken to a new empty view. 

## Demo

https://github.com/teamforage/forage-android-sdk/assets/11556475/b25a05e5-50b9-48a3-8b14-23796cabbbb4


## How
I'm not sure how we want to roll this out, or if we just want to branch off of this for future development on this new flow. Is this something we want actually in the sample app yet, or should it not get added until it's fully done? Not sure, just getting what I have so far posted here.