### PR TITLE
[FX-751] Add Support to Print and Display Receipts

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/CPayPrinter.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/CPayPrinter.kt
@@ -1,0 +1,121 @@
+package com.joinforage.android.example.pos.receipts
+
+import android.os.Bundle
+import com.pos.sdk.printer.PrinterDevice
+import com.pos.sdk.printer.param.MultipleTextPrintItemParam
+import com.pos.sdk.printer.param.PrintItemAlign
+import com.pos.sdk.printer.param.TextPrintItemParam
+
+
+// TODO: write tests for the classes and methods in this file
+//  as they are business logic and are straightforward to test
+
+/**
+ * This class and the methods it uses effectively map
+ * ReceiptLayouts, ReceiptLayoutLines, and ReceiptLineParts
+ * to the data structures that the CPay SDK uses for printing
+ */
+internal class CPayPrinter(private val cpayPrinter: PrinterDevice) {
+    fun setLayout(layout: ReceiptLayout) {
+        // clear the buffer before setting anything new
+        cpayPrinter.clearBufferArea()
+
+        // transform and write lines to the CPay printer's buffer
+        layout.lines.forEach {
+            CPayLine.of(it).addLineToPrinter(cpayPrinter)
+        }
+    }
+    fun print() {
+        val state = cpayPrinter.printSync(Bundle())
+        println("result is ${state.stateCode},msg is ${state.stateMsg}")
+    }
+}
+
+/**
+ * An abstract class that represents an abstraction over
+ * lines on a receipt in the CPay SDK. This makes it easier
+ * to isolate and test business logic for handling the
+ * difference between single and multi part receipt lines
+ */
+internal abstract class CPayLine(protected val line: ReceiptLayoutLine) {
+    abstract fun addLineToPrinter(cpayPrinter: PrinterDevice)
+    companion object {
+        fun of(line: ReceiptLayoutLine): CPayLine {
+            return if (line.parts.size == 1) {
+                SingleCPayLine(line)
+            } else {
+                MultiCPayLine(line)
+            }
+        }
+    }
+}
+
+internal class SingleCPayLine(line: ReceiptLayoutLine) : CPayLine(line) {
+    override fun addLineToPrinter(cpayPrinter: PrinterDevice) {
+        val single = processSinglePartLine(line)
+        cpayPrinter.addTextPrintItem(single)
+    }
+}
+
+internal class MultiCPayLine(line: ReceiptLayoutLine) : CPayLine(line) {
+    override fun addLineToPrinter(cpayPrinter: PrinterDevice) {
+        val multi = processMultiPartLine(line)
+        cpayPrinter.addMultipleTextPrintItem(multi)
+    }
+}
+
+/**
+ * A function that maps ReceiptLayoutLines with more than 1 part into
+ * CPay SDK representations of lines with more than one column.
+ *
+ * While TextPrintItemParam are the smallest representation in the
+ * CPay SDK, MultipleTextPrintItemParam represent lines with multiple
+ * parts are are composed of TextPrintItemParams
+ */
+internal fun processMultiPartLine(line: ReceiptLayoutLine): MultipleTextPrintItemParam {
+    val scales = line.parts.map { part -> part.colWeight }.toFloatArray()
+    val textPrintItems = line.parts.map { processLinePart(it) }.toTypedArray()
+    return MultipleTextPrintItemParam(scales, textPrintItems)
+}
+
+/**
+ * a function that maps ReceiptLayoutLInes with exactly 1 part
+ * to CPay SDK representations of lines with exactly one column,
+ * called TextPrintItemParam.
+ */
+internal fun processSinglePartLine(line: ReceiptLayoutLine): TextPrintItemParam {
+    val part = line.parts[0]
+    return processLinePart(part)
+}
+
+/**
+ * Here the smallest units of our ReceiptLayout data structure
+ * get transformed into the atomic units of receipts for the
+ * CPay SDK. In our case, the atomic units of a receipt are
+ * ReceiptLineParts. For CPay SDK, the atomic units are
+ * TextPrintItemParam
+ */
+internal fun processLinePart(part: ReceiptLinePart): TextPrintItemParam {
+    val item = TextPrintItemParam()
+
+    // set the string content to be printed
+    item.content = part.content
+
+    // set any formatting of the string content
+    item.textSize = part.format.textSize
+    item.lineSpace = part.format.lineSpace
+    item.isUnderLine = part.format.isUnderLine
+    item.isBold = part.format.isBold
+    item.isItalic = part.format.isItalic
+    item.isStrikeThruText = part.format.isStrikeThruText
+
+    // set the alignment
+    when (part.alignment) {
+        LinePartAlignment.LEFT -> item.itemAlign = PrintItemAlign.LEFT
+        LinePartAlignment.CENTER -> item.itemAlign = PrintItemAlign.CENTER
+        LinePartAlignment.RIGHT -> item.itemAlign = PrintItemAlign.RIGHT
+    }
+
+    // we're done
+    return item
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/CPayPrinter.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/CPayPrinter.kt
@@ -6,7 +6,6 @@ import com.pos.sdk.printer.param.MultipleTextPrintItemParam
 import com.pos.sdk.printer.param.PrintItemAlign
 import com.pos.sdk.printer.param.TextPrintItemParam
 
-
 // TODO: write tests for the classes and methods in this file
 //  as they are business logic and are straightforward to test
 

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/CPayPrinter.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/CPayPrinter.kt
@@ -1,6 +1,7 @@
 package com.joinforage.android.example.pos.receipts
 
 import android.os.Bundle
+import android.util.Log
 import com.pos.sdk.printer.PrinterDevice
 import com.pos.sdk.printer.param.MultipleTextPrintItemParam
 import com.pos.sdk.printer.param.PrintItemAlign
@@ -26,7 +27,7 @@ internal class CPayPrinter(private val cpayPrinter: PrinterDevice) {
     }
     fun print() {
         val state = cpayPrinter.printSync(Bundle())
-        println("result is ${state.stateCode},msg is ${state.stateMsg}")
+        Log.i("CPay SDK", "result is ${state.stateCode},msg is ${state.stateMsg}")
     }
 }
 

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/ReceiptFormatting.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/ReceiptFormatting.kt
@@ -1,0 +1,16 @@
+package com.joinforage.android.example.pos.receipts
+
+/**
+ * A class to capture the different ways that text on
+ * a physical or digital receipt can be formatted.
+ *
+ * NOTE: that this excludes alignment as alignment by design
+ */
+data class ReceiptFormatting(
+    val textSize: Int = 24,
+    val lineSpace: Int = 1,
+    val isUnderLine: Boolean = false,
+    val isBold: Boolean = false,
+    val isItalic: Boolean = false,
+    val isStrikeThruText: Boolean = false
+)

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/ReceiptLayout.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/ReceiptLayout.kt
@@ -70,7 +70,6 @@ internal class ReceiptLayout(
         internal fun cashPaymentAndWithdrawalReceipt(): Nothing = TODO("implement me!!!")
         internal fun snapPaymentReceipt(): Nothing = TODO("implement me!!!")
 
-
         // these are static receipt layouts occasionally useful for
         // developing and testing
         internal val EmptyReceiptLayout = ReceiptLayout(

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/ReceiptLayout.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/ReceiptLayout.kt
@@ -1,0 +1,139 @@
+package com.joinforage.android.example.pos.receipts
+
+/**
+ * The high level data structure that describes the text
+ * laid out on a receipt. This data structure is meant to
+ * be consumed any code that cares about. In practice,
+ * the ReceiptPrinter service consumes ReceiptLayout
+ * instance and translates it into the data structures that
+ * the CPay SDK cares about. And, the ReceiptViewer consumes
+ * a ReceiptLayout and displays a LinearLayout representation
+ * of the receipt.
+ *
+ * Ultimately a ReceiptLayout is a list of lines
+ * (called ReceiptLayoutLines) and each line has a list of
+ * parts (called ReceiptLineParts). parts are what is
+ * ultimately formatted, aligned, and contains text.
+ */
+internal class ReceiptLayout(
+    internal vararg val lines: ReceiptLayoutLine
+) {
+
+    // a bunch of factory methods to make defining FIS cert test
+    // scenarios easier. There are also some static layouts for
+    // for simple testing
+    companion object {
+        internal fun merchantInfoLayout(
+            merchant: MerchantReceiptInfo
+        ) = ReceiptLayout(
+            ReceiptLayoutLine.singleColCenter(merchant.name),
+            ReceiptLayoutLine.singleColCenter("${merchant.streetNumber} ${merchant.streetName}"),
+            ReceiptLayoutLine.singleColCenter("${merchant.city}, ${merchant.state}, ${merchant.zipCode}")
+        )
+
+        internal fun terminalInfoLayout(
+            terminal: TerminalReceiptInfo
+        ) = ReceiptLayout(
+            ReceiptLayoutLine.singleColLeft("TERM ID ${terminal.terminalId}"),
+            ReceiptLayoutLine.singleColLeft("MERCH TERM ID ${terminal.merchantTerminalId}"),
+            ReceiptLayoutLine.singleColLeft("SEQ # ${terminal.seqId}"),
+            ReceiptLayoutLine.singleColLeft("CLERK # ${terminal.clerkId}"),
+            ReceiptLayoutLine.singleColLeft(terminal.txTimestamp)
+        )
+
+        internal fun cardInfoLayout(
+            card: CardReceiptInfo
+        ) = ReceiptLayout(
+            ReceiptLayoutLine.singleColLeft("CARD# XXXXXXXXX${card.last4}"),
+            ReceiptLayoutLine.singleColLeft("STATE: ${card.issuingState}")
+        )
+
+        internal fun testCaseReceipt(
+            merchant: MerchantReceiptInfo,
+            terminal: TerminalReceiptInfo,
+            card: CardReceiptInfo,
+            vararg mainContent: ReceiptLayoutLine
+        ) = ReceiptLayout(
+            *merchantInfoLayout(merchant).lines,
+            *terminalInfoLayout(terminal).lines,
+            *cardInfoLayout(card).lines,
+            *mainContent
+        )
+
+        // these methods will be used for building out the receipts
+        // for the FIS Cert test cases. We can implement them as
+        // we get to their respective scenes
+        internal fun voidLastTxReceipt(): Nothing = TODO("implement me!!!")
+        internal fun cordPulledReceipt(): Nothing = TODO("implement me!!!")
+        internal fun cashWithdrawalOnlyReceipt(): Nothing = TODO("implement me!!!")
+        internal fun cashPaymentOnlyReceipt(): Nothing = TODO("implement me!!!")
+        internal fun cashPaymentAndWithdrawalReceipt(): Nothing = TODO("implement me!!!")
+        internal fun snapPaymentReceipt(): Nothing = TODO("implement me!!!")
+
+
+        // these are static receipt layouts occasionally useful for
+        // developing and testing
+        internal val EmptyReceiptLayout = ReceiptLayout(
+            ReceiptLayoutLine.singleColCenter("This is an empty receipt.")
+        )
+
+        internal val ExampleReceipt = ReceiptLayout(
+            ReceiptLayoutLine.singleColCenter("YOUR STORE NAME"),
+            ReceiptLayoutLine.singleColCenter("3609 ANY STREET ADDRESS"),
+            ReceiptLayoutLine.singleColCenter("YOUR TOWN, STATE ZIP CODE"),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.doubleColLeft("TERM ID", "LA0002"),
+            ReceiptLayoutLine.doubleColLeft("MERCH TERM ID", "LA0002330"),
+            ReceiptLayoutLine.doubleColLeft("SEQ#", "131"),
+            ReceiptLayoutLine.doubleColLeft("CLERK", "999"),
+            ReceiptLayoutLine.singleColLeft("07/24/YY 08:22"),
+            ReceiptLayoutLine.doubleColLeft("CARD#", "XXXXXXXXXXXX9023"),
+            ReceiptLayoutLine.doubleColLeft("STATE", "LA"),
+            ReceiptLayoutLine.doubleColLeft("POSTED", "07/24/YY"),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.tripleCol("Total", "TX AMT", "END BAL"),
+            ReceiptLayoutLine.tripleCol("CASH", "$3.26", "$482.00"),
+            ReceiptLayoutLine.tripleCol("FS", "$0.00", "$495.00"),
+            ReceiptLayoutLine.doubleColLeft("CS W/D", "$3.26 APPROVED"),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.doubleColLeft("*** DISP CASH", "$3.26**"),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.lineBreak(),
+            ReceiptLayoutLine.lineBreak()
+        )
+    }
+}
+
+// TODO: It's unclear if this is the most useful separation
+//  of info for receipts. For example, should
+//  CardReceiptInfo and TerminalReceiptInfo be
+//  combined into a single TxReceiptInfo?
+data class TerminalReceiptInfo(
+    val terminalId: String,
+    val merchantTerminalId: String,
+    val seqId: String,
+    val clerkId: String,
+    val txTimestamp: String
+)
+
+data class CardReceiptInfo(
+    val issuingState: String,
+    val last4: String
+)
+
+data class MerchantReceiptInfo(
+    val name: String,
+    val streetNumber: String,
+    val streetName: String,
+    val city: String,
+    val state: String,
+    val zipCode: String
+)

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/ReceiptLayoutLine.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/ReceiptLayoutLine.kt
@@ -1,0 +1,81 @@
+package com.joinforage.android.example.pos.receipts
+
+/**
+ * @param parts - the list of ReceiptLineParts that should *  occupy this line. You can have as many as you want but
+ *  a physical receipt is only so wide so in practice there
+ *  probably shouldn't be more than 4. You can think of it
+ *  like have 1 column per ReceiptLinePart in the list
+ */
+internal class ReceiptLayoutLine(internal vararg val parts: ReceiptLinePart) {
+
+    // a bunch of factory methods that should make assembling
+    // the layout of an actual receipt easier. These are supposed
+    // to serve as lego pieces that you can stack together to
+    // create actually useful receipts
+    companion object {
+        internal fun lineBreak(
+            format: ReceiptFormatting = ReceiptFormatting()
+        ) = ReceiptLayoutLine(
+            ReceiptLinePart.left("", format)
+        )
+
+        internal fun singleColLeft(
+            col1: String,
+            format: ReceiptFormatting = ReceiptFormatting()
+        ) = ReceiptLayoutLine(
+            ReceiptLinePart.left(col1, format)
+        )
+
+        internal fun singleColCenter(
+            col1: String,
+            format: ReceiptFormatting = ReceiptFormatting()
+        ) = ReceiptLayoutLine(
+            ReceiptLinePart.center(col1, format)
+        )
+
+        internal fun singleColRight(
+            col1: String,
+            format: ReceiptFormatting = ReceiptFormatting()
+        ) = ReceiptLayoutLine(
+            ReceiptLinePart.right(col1, format)
+        )
+
+        internal fun doubleColLeft(
+            col1: String,
+            col2: String,
+            format: ReceiptFormatting = ReceiptFormatting()
+        ) = ReceiptLayoutLine(
+            ReceiptLinePart.left(col1, format, 1f),
+            ReceiptLinePart.left(col2, format, 1f)
+        )
+
+        internal fun doubleColRight(
+            col1: String,
+            col2: String,
+            format: ReceiptFormatting = ReceiptFormatting()
+        ) = ReceiptLayoutLine(
+            ReceiptLinePart.right(col1, format, 1f),
+            ReceiptLinePart.right(col2, format, 1f)
+        )
+
+        internal fun doubleColCenter(
+            col1: String,
+            col2: String,
+            format: ReceiptFormatting = ReceiptFormatting()
+        ) = ReceiptLayoutLine(
+            ReceiptLinePart.center(col1, format),
+            ReceiptLinePart.center(col2, format)
+        )
+
+        internal fun tripleCol(
+            col1: String,
+            col2: String,
+            col3: String,
+            format: ReceiptFormatting = ReceiptFormatting()
+        ) = ReceiptLayoutLine(
+            ReceiptLinePart.left(col1, format),
+            ReceiptLinePart.center(col2, format),
+            ReceiptLinePart.center(col3, format)
+        )
+    }
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/ReceiptLinePart.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/ReceiptLinePart.kt
@@ -1,0 +1,49 @@
+package com.joinforage.android.example.pos.receipts
+
+/**
+ * an internal representation of the different
+ * text alignments we support
+ */
+internal enum class LinePartAlignment {
+    LEFT, CENTER, RIGHT
+}
+
+/**
+ * @param content - the text value of this ReceiptLinePart
+ * @param alignment - the horizontal alignment of the text
+ *  within the part
+ * @param format - the text formatting to be applied to this
+ *  specific part (e.g. bold, italic, underline, etc)
+ * @param colWeight - the relative weight of this ReceiptLinePart
+ *  compared to other ReceiptLinePart within the same
+ *  ReceiptLayoutLine. For example if there were two parts in
+ *  a line and the left part had weight of 1.5 and the right part
+ *  had a weight of 0.5. Then the left part would be 3x the width
+ *  and the right part would be 1x the width. This (colWeight)
+ *  along with alignment are the two mechanism available for
+ *  hacking together the preferred horizontal layout of text
+ */
+internal class ReceiptLinePart(
+    internal val content: String,
+    internal val alignment: LinePartAlignment,
+    internal val format: ReceiptFormatting,
+    internal val colWeight: Float = 1f
+) {
+    // these are a bunch of helper factory methods that should make
+    // using ReceiptLineParts in practice easier since you only need
+    // to really specify content and choose an alignment factory
+    companion object {
+        fun left(content: String, format: ReceiptFormatting, colWeight: Float) =
+            ReceiptLinePart(content, LinePartAlignment.LEFT, format, colWeight)
+        fun left(content: String, format: ReceiptFormatting) =
+            ReceiptLinePart(content, LinePartAlignment.LEFT, format)
+        fun center(content: String, format: ReceiptFormatting, colWeight: Float) =
+            ReceiptLinePart(content, LinePartAlignment.CENTER, format, colWeight)
+        fun center(content: String, format: ReceiptFormatting) =
+            ReceiptLinePart(content, LinePartAlignment.CENTER, format)
+        fun right(content: String, format: ReceiptFormatting, colWeight: Float) =
+            ReceiptLinePart(content, LinePartAlignment.RIGHT, format, colWeight)
+        fun right(content: String, format: ReceiptFormatting) =
+            ReceiptLinePart(content, LinePartAlignment.RIGHT, format)
+    }
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/ReceiptPrinter.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/ReceiptPrinter.kt
@@ -1,0 +1,17 @@
+package com.joinforage.android.example.pos.receipts
+
+import com.pos.sdk.printer.PrinterDevice
+
+/**
+ * A class that effectively transforms our internal representation
+ * of a receipt (i.e. a ReceiptLayout), into the datastructures
+ * that POS printers can understand. Right now it only supports
+ * printing with the CPay SDK, which is used for our POS terminal
+ */
+internal class ReceiptPrinter(private val layout: ReceiptLayout) {
+    internal fun printWithCPayTerminal(printer: PrinterDevice) {
+        val cpayPrinter = CPayPrinter(printer)
+        cpayPrinter.setLayout(layout)
+        cpayPrinter.print()
+    }
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
@@ -1,5 +1,50 @@
 package com.joinforage.android.example.ui.pos
 
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.joinforage.android.example.databinding.FragmentPosBinding
+import com.joinforage.android.example.pos.receipts.ReceiptLayout
+import com.pos.sdk.DeviceManager
+import com.pos.sdk.DevicesFactory
+import com.pos.sdk.callback.ResultCallback
 
-class POSFragment : Fragment()
+class POSFragment : Fragment() {
+    private var _binding: FragmentPosBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentPosBinding.inflate(inflater, container, false)
+        val root: View = binding.root
+
+        val receiptView = ReceiptView(requireContext())
+        receiptView.setReceiptLayout(ReceiptLayout.ExampleReceipt)
+        binding.mainPosLayout.addView(receiptView)
+
+        return root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // initialize the CPay SDK for later user
+        DevicesFactory.create(
+            requireContext(),
+            object : ResultCallback<DeviceManager> {
+                override fun onFinish(deviceManager: DeviceManager) {
+                    println("onFinish success!")
+                }
+
+                override fun onError(i: Int, s: String) {
+                    println("onError: $i,$s")
+                }
+            }
+        )
+    }
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
@@ -1,6 +1,7 @@
 package com.joinforage.android.example.ui.pos
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -38,11 +39,11 @@ class POSFragment : Fragment() {
             requireContext(),
             object : ResultCallback<DeviceManager> {
                 override fun onFinish(deviceManager: DeviceManager) {
-                    println("onFinish success!")
+                    Log.i("CPay SDK", "DeviceManager created successfully")
                 }
 
                 override fun onError(i: Int, s: String) {
-                    println("onError: $i,$s")
+                    Log.i("CPay SDK", "Failed to create DeviceManager: $i,$s")
                 }
             }
         )

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ReceiptView.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ReceiptView.kt
@@ -145,7 +145,6 @@ class ReceiptView(
             addView(receiptDisplay)
         }
         addView(scrollableContent)
-        println("constructor was called!!")
     }
 
     internal fun setReceiptLayout(newReceiptLayout: ReceiptLayout) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ReceiptView.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ReceiptView.kt
@@ -1,0 +1,163 @@
+package com.joinforage.android.example.ui.pos
+
+import android.content.Context
+import android.graphics.Paint
+import android.graphics.Typeface
+import android.text.SpannableString
+import android.text.style.UnderlineSpan
+import android.view.Gravity
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
+import com.joinforage.android.example.R
+import com.joinforage.android.example.pos.receipts.LinePartAlignment
+import com.joinforage.android.example.pos.receipts.ReceiptLayout
+import com.joinforage.android.example.pos.receipts.ReceiptLayoutLine
+import com.joinforage.android.example.pos.receipts.ReceiptLinePart
+import com.joinforage.android.example.pos.receipts.ReceiptPrinter
+import com.pos.sdk.DevicesFactory
+
+internal fun createReceiptPartTextView(context: Context, part: ReceiptLinePart) = TextView(context).apply {
+    layoutParams = LinearLayout.LayoutParams(
+        0,
+        LinearLayout.LayoutParams.WRAP_CONTENT,
+        part.colWeight
+    )
+    gravity = when (part.alignment) {
+        LinePartAlignment.LEFT -> Gravity.START
+        LinePartAlignment.CENTER -> Gravity.CENTER_HORIZONTAL
+        LinePartAlignment.RIGHT -> Gravity.END
+    }
+
+    // extract commonly used variables
+    val format = part.format
+    val content = part.content
+
+    // take measures to support underline text
+    val spannableString = SpannableString(content)
+    if (format.isUnderLine) {
+        spannableString.setSpan(UnderlineSpan(), 0, content.length, 0)
+    }
+
+    // set the text
+    text = spannableString
+
+    // handle remaining formatting
+    setLineSpacing(format.lineSpace.toFloat(), 1f)
+    setTypeface(
+        null,
+        when {
+            format.isBold && format.isItalic -> Typeface.BOLD_ITALIC
+            format.isBold -> Typeface.BOLD
+            format.isItalic -> Typeface.ITALIC
+            else -> Typeface.NORMAL
+        }
+    )
+    if (format.isStrikeThruText) {
+        paintFlags = paintFlags or Paint.STRIKE_THRU_TEXT_FLAG
+    }
+
+    // fonts appear much larger on the screen than on the receipt
+    // so we shrink the font size on the display to keep the sizes
+    // similar
+    val adjustedFontSize = format.textSize.toFloat() / 2
+    textSize = adjustedFontSize
+}
+
+internal fun createReceiptLineLinearLayout(context: Context, line: ReceiptLayoutLine) = LinearLayout(context).apply {
+    line.parts.forEach { part ->
+        val textView = createReceiptPartTextView(context, part)
+        addView(textView)
+    }
+}
+
+internal fun createReceiptDisplay(context: Context, receiptLayout: ReceiptLayout) = LinearLayout(context).apply {
+    orientation = LinearLayout.VERTICAL
+
+    layoutParams = LinearLayout.LayoutParams(
+        LinearLayout.LayoutParams.MATCH_PARENT,
+        LinearLayout.LayoutParams.WRAP_CONTENT
+    )
+
+    // Set background color
+    val backgroundColor = ContextCompat.getColor(context, R.color.light_grey)
+    setBackgroundColor(backgroundColor)
+
+    // Convert 8dp padding to pixels
+    val paddingInPixels = (8 * context.resources.displayMetrics.density).toInt()
+    setPadding(paddingInPixels, paddingInPixels, paddingInPixels, paddingInPixels)
+
+    // add the TextViews that make up the ReceiptDisplay's content
+    receiptLayout.lines.forEach { line ->
+        val lineLayout = createReceiptLineLinearLayout(context, line)
+        addView(lineLayout)
+    }
+}
+
+class ReceiptView(
+    context: Context
+) : ScrollView(context) {
+    private val scrollableContent: LinearLayout
+    private val printReceiptBtn: Button
+    private var receiptDisplay: LinearLayout
+    private var receiptLayout = ReceiptLayout.EmptyReceiptLayout
+
+    init {
+        // organize the scrollview itself will house (the root)
+        // which will house the container that will overflow as scroll
+        layoutParams = LinearLayout.LayoutParams(
+            ConstraintLayout.LayoutParams.MATCH_PARENT,
+            ConstraintLayout.LayoutParams.WRAP_CONTENT
+        )
+        val rootPaddingInPixels = (16 * context.resources.displayMetrics.density).toInt()
+        setPadding(rootPaddingInPixels, rootPaddingInPixels, rootPaddingInPixels, rootPaddingInPixels)
+
+        // organize and add the subviews
+        scrollableContent = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            )
+
+            printReceiptBtn = Button(context).apply {
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                )
+                text = "Print Receipt"
+
+                // when the button is clicked, have it pass the current
+                // receiptLayout (datastructure) to our ReceiptPrinter
+                // service so it so we can print it on the POS terminal
+                setOnClickListener {
+                    val cpayPrinter = DevicesFactory.getDeviceManager().printDevice
+                    ReceiptPrinter(receiptLayout).printWithCPayTerminal(cpayPrinter)
+                }
+            }
+            addView(printReceiptBtn)
+
+            // organize the linear layout that will hold the receipt details
+            receiptDisplay = createReceiptDisplay(context, receiptLayout)
+            addView(receiptDisplay)
+        }
+        addView(scrollableContent)
+        println("constructor was called!!")
+    }
+
+    internal fun setReceiptLayout(newReceiptLayout: ReceiptLayout) {
+        // remove the old view if it exists
+        scrollableContent.removeView(receiptDisplay)
+        // set the new receiptLayout value
+        receiptLayout = newReceiptLayout
+        // create the new receiptView and save it
+        val newReceiptDisplay = createReceiptDisplay(context, newReceiptLayout)
+        // set the new receiptView field
+        receiptDisplay = newReceiptDisplay
+        // add the new receiptView to the parent view
+        scrollableContent.addView(receiptDisplay)
+    }
+}

--- a/sample-app/src/main/res/layout/fragment_pos.xml
+++ b/sample-app/src/main/res/layout/fragment_pos.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.pos.POSFragment">
+
+    <LinearLayout
+            android:id="@+id/main_pos_layout"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->
I debated splitting this PR up but into multiple PRs for ease of consumption but since this PR is strictly adding new services, and  because I organized the commits into stories, I opted to have one medium-large PR for simplicity. I'd be happy to split up this PR if it makes life easier for anyone.

## What
This PR introduces an internal representation of receipt. The highest level is the `ReceiptLayout`, which represents an entire receipt that can be printed or displayed. `ReceiptLayout`s are composed of `ReceiptLayoutLines`, which represent a single line on a receipt. It is common (and necessary) for receipts to depict multiple columns of text, so `ReceiptLayoutLines` are composed of `ReceiptLinePart`s, which are the smallest and atomic units of receipts.

This PR also introduces:
- a `ReceiptView` - a recyclable Android View that both displays a digital version of the receipt and also exposes a button that, when pressed, attempts to print the receipt. This goal of this view is to make it trivial for people to use the POS sample app without needing to be running on the CPay terminal as this works directly in Android Emulator
- a `ReceiptPrinter` class and a `CPayPrinter` class. These effectively translate our internal `ReceiptLayout` representation into the representation that the CPay terminal printer understands

NOTE: while this modifies the `POSFragment` to display the `ReceiptView`, that is not necessary. It can and should be removed in a future PR as the contents of the `POSFragment` evolve with subsequent tickets.

<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
We need to have an internal representation of Receipts so that we can do things like:
- define common parts of receipts such as merchant store info, card info, etc
- have a human readable way of composing / defining novel receipt layouts
- be able to have the same layout interpreted for printing on POS terminal's printer and interpreted for displaying on POS terminal's screen
- have business logic operate on the representation so that we can gain substantial confidence from automated tests instead of only gaining confidence when printing or displaying the receipt

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- ❌ I've added unit tests for this change. <!-- If not, why? --> I made sure that I left the code in a state that adding unit tests would be very easy to do. My plan is to comeback at a later point and write unit tests in the interest of moving on to other tickets 
- ✅ The reviewer should manually test the changes in this PR. <!-- If so, please describe how to test below. --> Yeah you may want to run this PR locally and just confirm that it works / you're seeing a receipt. Not strictly necessary though.

## Demo
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->
![PXL_20240109_152453246 MP](https://github.com/teamforage/forage-android-sdk/assets/12377418/ea62c8c1-8d3e-4277-a027-70c0b6621752)


## How
This PR can be rolled out once approved because it only pertains to the Sample App and is largely introducing net-new services
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
