### PR TITLE
Introduce PollingService

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ForageSDK.kt
@@ -11,6 +11,7 @@ import com.joinforage.forage.android.network.MessageStatusService
 import com.joinforage.forage.android.network.OkHttpClientBuilder
 import com.joinforage.forage.android.network.PaymentMethodService
 import com.joinforage.forage.android.network.PaymentService
+import com.joinforage.forage.android.network.PollingService
 import com.joinforage.forage.android.network.TokenizeCardService
 import com.joinforage.forage.android.network.data.CapturePaymentRepository
 import com.joinforage.forage.android.network.data.CheckBalanceRepository
@@ -83,13 +84,9 @@ class ForageSDK : ForageSDKInterface {
 
         // TODO: replace Log.getInstance() with Log() in future PR
         val logger = Log.getInstance()
-        logger.i(
-            "[HTTP] Tokenizing Payment Method",
-            attributes = mapOf(
-                "merchant_ref" to merchantId,
-                "customer_id" to customerId
-            )
-        )
+            .addAttribute("merchant_ref", merchantId)
+            .addAttribute("customer_id", customerId)
+        logger.i("[Android SDK] Tokenizing Payment Method")
 
         val tokenizeCardService = ServiceFactory(sessionToken, merchantId, logger)
             .createTokenizeCardService()
@@ -133,13 +130,9 @@ class ForageSDK : ForageSDKInterface {
 
         // TODO: replace Log.getInstance() with Log() in future PR
         val logger = Log.getInstance()
-        logger.i(
-            "[HTTP] Submitting balance check for Payment Method $paymentMethodRef",
-            attributes = mapOf(
-                "merchant_ref" to merchantId,
-                "payment_method_ref" to paymentMethodRef
-            )
-        )
+            .addAttribute("merchant_ref", merchantId)
+            .addAttribute("payment_method_ref", paymentMethodRef)
+        logger.i("[Android SDK] Called checkBalance for Payment Method $paymentMethodRef")
 
         // This block is used for Metrics Tracking!
         // ------------------------------------------------------
@@ -195,13 +188,8 @@ class ForageSDK : ForageSDKInterface {
 
         // TODO: replace Log.getInstance() with Log() in future PR
         val logger = Log.getInstance()
-        logger.i(
-            "[HTTP] Submitting capture request for Payment $paymentRef",
-            attributes = mapOf(
-                "merchant_ref" to merchantId,
-                "payment_ref" to paymentRef
-            )
-        )
+            .addAttribute("merchant_ref", merchantId)
+            .addAttribute("payment_ref", paymentRef)
 
         // This block is used for Metrics Tracking!
         // ------------------------------------------------------
@@ -258,13 +246,9 @@ class ForageSDK : ForageSDKInterface {
 
         // TODO: replace Log.getInstance() with Log() in future PR
         val logger = Log.getInstance()
-        logger.i(
-            "[HTTP] Submitting defer capture request for Payment $paymentRef",
-            attributes = mapOf(
-                "merchant_ref" to merchantId,
-                "payment_ref" to paymentRef
-            )
-        )
+            .addAttribute("merchant_ref", merchantId)
+            .addAttribute("payment_ref", paymentRef)
+        logger.i("[Android SDK] Called deferPaymentCapture for Payment $paymentRef")
 
         val deferPaymentCaptureService = ServiceFactory(sessionToken, merchantId, logger)
             .createDeferPaymentCaptureRepository(foragePinEditText)
@@ -314,6 +298,7 @@ class ForageSDK : ForageSDKInterface {
         private val paymentMethodService by lazy { createPaymentMethodService() }
         private val paymentService by lazy { createPaymentService() }
         private val messageStatusService by lazy { createMessageStatusService() }
+        private val pollingService by lazy { createPollingService() }
 
         open fun createTokenizeCardService() = TokenizeCardService(
             config.baseUrl,
@@ -326,7 +311,7 @@ class ForageSDK : ForageSDKInterface {
                 pinCollector = foragePinEditText.getCollector(merchantId),
                 encryptionKeyService = encryptionKeyService,
                 paymentMethodService = paymentMethodService,
-                messageStatusService = messageStatusService,
+                pollingService = pollingService,
                 logger = logger
             )
         }
@@ -337,8 +322,7 @@ class ForageSDK : ForageSDKInterface {
                 encryptionKeyService = encryptionKeyService,
                 paymentService = paymentService,
                 paymentMethodService = paymentMethodService,
-                messageStatusService = messageStatusService,
-                logger = logger
+                pollingService = pollingService
             )
         }
 
@@ -355,5 +339,9 @@ class ForageSDK : ForageSDKInterface {
         private fun createPaymentMethodService() = PaymentMethodService(config.baseUrl, okHttpClient, logger)
         private fun createPaymentService() = PaymentService(config.baseUrl, okHttpClient, logger)
         private fun createMessageStatusService() = MessageStatusService(config.baseUrl, okHttpClient, logger)
+        private fun createPollingService() = PollingService(
+            messageStatusService = messageStatusService,
+            logger = logger
+        )
     }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ForageSDK.kt
@@ -86,7 +86,7 @@ class ForageSDK : ForageSDKInterface {
         val logger = Log.getInstance()
             .addAttribute("merchant_ref", merchantId)
             .addAttribute("customer_id", customerId)
-        logger.i("[Android SDK] Tokenizing Payment Method")
+        logger.i("[ForageSDK] Tokenizing Payment Method")
 
         val tokenizeCardService = ServiceFactory(sessionToken, merchantId, logger)
             .createTokenizeCardService()
@@ -132,7 +132,7 @@ class ForageSDK : ForageSDKInterface {
         val logger = Log.getInstance()
             .addAttribute("merchant_ref", merchantId)
             .addAttribute("payment_method_ref", paymentMethodRef)
-        logger.i("[Android SDK] Called checkBalance for Payment Method $paymentMethodRef")
+        logger.i("[ForageSDK] Called checkBalance for Payment Method $paymentMethodRef")
 
         // This block is used for Metrics Tracking!
         // ------------------------------------------------------
@@ -190,6 +190,7 @@ class ForageSDK : ForageSDKInterface {
         val logger = Log.getInstance()
             .addAttribute("merchant_ref", merchantId)
             .addAttribute("payment_ref", paymentRef)
+        logger.i("[ForageSDK] Called capturePayment for Payment $paymentRef")
 
         // This block is used for Metrics Tracking!
         // ------------------------------------------------------
@@ -248,7 +249,7 @@ class ForageSDK : ForageSDKInterface {
         val logger = Log.getInstance()
             .addAttribute("merchant_ref", merchantId)
             .addAttribute("payment_ref", paymentRef)
-        logger.i("[Android SDK] Called deferPaymentCapture for Payment $paymentRef")
+        logger.i("[ForageSDK] Called deferPaymentCapture for Payment $paymentRef")
 
         val deferPaymentCaptureService = ServiceFactory(sessionToken, merchantId, logger)
             .createDeferPaymentCaptureRepository(foragePinEditText)

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/telemetry/Log.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/telemetry/Log.kt
@@ -18,6 +18,8 @@ internal interface Log {
     fun w(msg: String, attributes: Map<String, Any?> = emptyMap())
     fun e(msg: String, throwable: Throwable? = null, attributes: Map<String, Any?> = emptyMap())
     fun getTraceIdValue(): String
+    fun addAttribute(key: String, value: Any?): Log
+
     companion object {
         private const val LOGGER_NAME = "ForageSDK"
         private const val SERVICE_NAME = "android-sdk"
@@ -90,27 +92,27 @@ internal interface Log {
                 }
                 return traceId as String
             }
+
+            override fun addAttribute(key: String, value: Any?): Log {
+                logger?.addAttribute(key, value)
+                return this
+            }
         }
 
         private val SILENT = object : Log {
-            override fun initializeDD(context: Context, config: ForageConfig) {
-            }
+            override fun initializeDD(context: Context, config: ForageConfig) {}
 
-            override fun d(msg: String, attributes: Map<String, Any?>) {
-            }
+            override fun d(msg: String, attributes: Map<String, Any?>) {}
 
-            override fun i(msg: String, attributes: Map<String, Any?>) {
-            }
+            override fun i(msg: String, attributes: Map<String, Any?>) {}
 
-            override fun w(msg: String, attributes: Map<String, Any?>) {
-            }
+            override fun w(msg: String, attributes: Map<String, Any?>) {}
 
-            override fun e(msg: String, throwable: Throwable?, attributes: Map<String, Any?>) {
-            }
+            override fun e(msg: String, throwable: Throwable?, attributes: Map<String, Any?>) {}
 
-            override fun getTraceIdValue(): String {
-                return ""
-            }
+            override fun getTraceIdValue(): String { return "" }
+
+            override fun addAttribute(key: String, value: Any?) = this
         }
 
         private fun generateTraceId(): String {

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/PollingService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/PollingService.kt
@@ -1,0 +1,84 @@
+package com.joinforage.forage.android.network
+
+import com.joinforage.forage.android.LDManager
+import com.joinforage.forage.android.core.telemetry.Log
+import com.joinforage.forage.android.getJitterAmount
+import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.network.model.ForageError
+import com.joinforage.forage.android.network.model.Message
+import kotlinx.coroutines.delay
+
+internal class PollingService(
+    private val messageStatusService: MessageStatusService,
+    private val logger: Log
+) {
+    /**
+     * Polls until the message status is completed or failed
+     * @param contentId the content id of the message
+     * @param operationDescription e.g. "balance check of Payment Method $paymentMethodRef"
+     */
+    internal suspend fun execute(
+        contentId: String,
+        operationDescription: String
+    ): ForageApiResponse<String> {
+        var attempt = 1
+        val pollingIntervals = LDManager.getPollingIntervals(logger)
+
+        while (true) {
+            logger.i(
+                "[Polling] Start polling Message $contentId to $operationDescription"
+            )
+
+            when (val response = messageStatusService.getStatus(contentId)) {
+                is ForageApiResponse.Success -> {
+                    val sqsMessage = Message.ModelMapper.from(response.data)
+
+                    if (sqsMessage.status == "completed") {
+                        if (sqsMessage.failed) {
+                            val sqsError = sqsMessage.errors[0]
+                            logger.e(
+                                "[Polling] Received response ${sqsError.statusCode} for $operationDescription with message: ${sqsError.message}"
+                            )
+                            return sqsError.toForageError()
+                        }
+                        break
+                    }
+
+                    if (sqsMessage.failed) {
+                        val sqsError = sqsMessage.errors[0]
+                        logger.e(
+                            "[Polling] Received response ${sqsError.statusCode} for $operationDescription with message: ${sqsError.message}"
+                        )
+                        return sqsError.toForageError()
+                    }
+                }
+                else -> {
+                    return response
+                }
+            }
+
+            if (attempt == MAX_ATTEMPTS) {
+                logger.e("[Polling] Max attempts ($MAX_ATTEMPTS) reached for Message $contentId for $operationDescription")
+
+                return ForageApiResponse.Failure(listOf(ForageError(500, "unknown_server_error", "Unknown Server Error")))
+            }
+
+            val index = attempt - 1
+            val intervalTime: Long = if (index < pollingIntervals.size) {
+                pollingIntervals[index]
+            } else {
+                1000L
+            }
+
+            attempt += 1
+            delay(intervalTime + getJitterAmount())
+        }
+
+        logger.i("[Polling] Finished polling Message $contentId for $operationDescription")
+        return ForageApiResponse.Success("")
+    }
+
+    companion object {
+        private const val MAX_ATTEMPTS = 10
+    }
+}

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/model/Message.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/model/Message.kt
@@ -46,6 +46,16 @@ internal data class SQSError(
             )
         }
     }
+
+    fun toForageError(): ForageApiResponse.Failure {
+        val forageError = ForageError(
+            httpStatusCode = statusCode,
+            code = forageCode,
+            message = message,
+            details = details
+        )
+        return ForageApiResponse.Failure(listOf(forageError))
+    }
 }
 
 internal data class Message(

--- a/forage-android/src/test/java/com/joinforage/forage/android/mock/MockLogger.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/mock/MockLogger.kt
@@ -27,6 +27,8 @@ internal class MockLogger : Log {
     val warnLogs: MutableList<LogEntry> = mutableListOf()
     val errorLogs: MutableList<LogEntry> = mutableListOf()
 
+    private val cumulativeAttributes = mutableMapOf<String, Any?>()
+
     override fun initializeDD(context: Context, config: ForageConfig) {
         return
     }
@@ -36,15 +38,20 @@ internal class MockLogger : Log {
     }
 
     override fun i(msg: String, attributes: Map<String, Any?>) {
-        infoLogs.add(LogEntry(msg, attributes))
+        infoLogs.add(LogEntry(msg, cumulativeAttributes.plus(attributes)))
     }
 
     override fun w(msg: String, attributes: Map<String, Any?>) {
-        warnLogs.add(LogEntry(msg, attributes))
+        warnLogs.add(LogEntry(msg, cumulativeAttributes.plus(attributes)))
     }
 
     override fun e(msg: String, throwable: Throwable?, attributes: Map<String, Any?>) {
-        errorLogs.add(LogEntry(msg, attributes))
+        errorLogs.add(LogEntry(msg, cumulativeAttributes.plus(attributes)))
+    }
+
+    override fun addAttribute(key: String, value: Any?): Log {
+        cumulativeAttributes[key] = value
+        return this
     }
 
     override fun getTraceIdValue(): String {

--- a/forage-android/src/test/java/com/joinforage/forage/android/mock/MockRepository.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/mock/MockRepository.kt
@@ -6,6 +6,7 @@ import com.joinforage.forage.android.network.EncryptionKeyService
 import com.joinforage.forage.android.network.MessageStatusService
 import com.joinforage.forage.android.network.OkHttpClientBuilder
 import com.joinforage.forage.android.network.PaymentMethodService
+import com.joinforage.forage.android.network.PollingService
 import com.joinforage.forage.android.network.TokenizeCardService
 import com.joinforage.forage.android.network.data.BaseVaultRequestParams
 import com.joinforage.forage.android.network.data.CheckBalanceRepository
@@ -52,12 +53,15 @@ internal fun createMockCheckBalanceRepository(
             httpUrl = server.url("").toUrl().toString(),
             logger = logger
         ),
-        messageStatusService = MessageStatusService(
-            okHttpClient = OkHttpClientBuilder.provideOkHttpClient(
-                testData.sessionToken,
-                merchantId = testData.merchantId
+        pollingService = PollingService(
+            messageStatusService = MessageStatusService(
+                okHttpClient = OkHttpClientBuilder.provideOkHttpClient(
+                    testData.sessionToken,
+                    merchantId = testData.merchantId
+                ),
+                httpUrl = server.url("").toUrl().toString(),
+                logger = logger
             ),
-            httpUrl = server.url("").toUrl().toString(),
             logger = logger
         ),
         logger = logger

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/CapturePaymentRepositoryTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/CapturePaymentRepositoryTest.kt
@@ -21,6 +21,7 @@ import com.joinforage.forage.android.network.MessageStatusService
 import com.joinforage.forage.android.network.OkHttpClientBuilder
 import com.joinforage.forage.android.network.PaymentMethodService
 import com.joinforage.forage.android.network.PaymentService
+import com.joinforage.forage.android.network.PollingService
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -50,12 +51,15 @@ class CapturePaymentRepositoryTest : MockServerSuite() {
                 httpUrl = server.url("").toUrl().toString(),
                 logger = logger
             ),
-            messageStatusService = MessageStatusService(
-                okHttpClient = OkHttpClientBuilder.provideOkHttpClient(
-                    testData.bearerToken,
-                    merchantId = testData.merchantAccount
+            pollingService = PollingService(
+                messageStatusService = MessageStatusService(
+                    okHttpClient = OkHttpClientBuilder.provideOkHttpClient(
+                        testData.bearerToken,
+                        merchantId = testData.merchantAccount
+                    ),
+                    httpUrl = server.url("").toUrl().toString(),
+                    logger = logger
                 ),
-                httpUrl = server.url("").toUrl().toString(),
                 logger = logger
             ),
             paymentService = PaymentService(
@@ -73,8 +77,7 @@ class CapturePaymentRepositoryTest : MockServerSuite() {
                 ),
                 httpUrl = server.url("").toUrl().toString(),
                 logger = logger
-            ),
-            logger = logger
+            )
         )
     }
 


### PR DESCRIPTION
## What

de-dupe polling across payment capture and balance check

will be used for refund as well

## Why

- DRY up across balance check, capture and refund

## Test Plan

- ✅ unit tests cover polling path and pass

## How

Can be released as-is ; `PollingService` has further room for improvement, but this is a first step