### PR TITLE
Add Abstract PIN submitters

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/AbstractVaultSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/AbstractVaultSubmitter.kt
@@ -142,11 +142,11 @@ internal abstract class AbstractVaultSubmitter<VaultResponse>(
             return UnknownErrorApiResponse
         }
 
-        val vaultApiError = toVaultErrorOrNull(vaultResponse)
-        if (vaultApiError != null) {
+        val vaultError = toVaultErrorOrNull(vaultResponse)
+        if (vaultError != null) {
             val forageErr = parseVaultError(vaultResponse)
             logger.e("[$vaultType] Received error from $vaultType: $forageErr")
-            return vaultApiError
+            return vaultError
         }
 
         val forageApiErrorResponse = toForageErrorOrNull(vaultResponse)
@@ -161,6 +161,7 @@ internal abstract class AbstractVaultSubmitter<VaultResponse>(
             logger.i("[$vaultType] Received successful response from $vaultType")
             return forageApiSuccess
         }
+        logger.e("[$vaultType] Received malformed response from $vaultType")
 
         return UnknownErrorApiResponse
     }

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/AbstractVaultSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/AbstractVaultSubmitter.kt
@@ -12,7 +12,6 @@ import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.network.model.UnknownErrorApiResponse
 import com.joinforage.forage.android.ui.ForagePINEditText
-import com.verygoodsecurity.vgscollect.core.HTTPMethod
 
 internal val IncompletePinError = ForageApiResponse.Failure.fromError(
     ForageError(400, "user_error", "Invalid EBT Card PIN entered. Please enter your 4-digit PIN.")
@@ -74,7 +73,7 @@ internal abstract class AbstractVaultSubmitter<VaultResponse>(
         )
         proxyResponseMonitor
             .setPath(path)
-            .setMethod(HTTPMethod.POST.toString())
+            .setMethod("POST")
             .start()
 
         val vaultProxyRequest = buildProxyRequest(
@@ -126,15 +125,14 @@ internal abstract class AbstractVaultSubmitter<VaultResponse>(
         .setHeader(ForageConstants.Headers.TRACE_ID, logger.getTraceIdValue())
         .setToken(vaultToken)
 
+    // PaymentMethod.card.token is in the comma-separated format <vgs-token>,<basis-theory-token>
     protected fun pickVaultTokenByIndex(paymentMethod: PaymentMethod, index: Int): String? {
         val tokensString = paymentMethod.card.token
         val tokensList = tokensString.split(TOKEN_DELIMITER)
 
-        // VGS is always the first token in the string
         val noTokenStoredInVault = tokensList.size <= index
         if (noTokenStoredInVault) return null
 
-        // grab BasisTheory token
         return tokensList[index]
     }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/AbstractVaultSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/AbstractVaultSubmitter.kt
@@ -1,0 +1,182 @@
+package com.joinforage.forage.android.collect
+
+import android.content.Context
+import com.joinforage.forage.android.VaultType
+import com.joinforage.forage.android.core.telemetry.Log
+import com.joinforage.forage.android.core.telemetry.UserAction
+import com.joinforage.forage.android.core.telemetry.VaultProxyResponseMonitor
+import com.joinforage.forage.android.model.EncryptionKeys
+import com.joinforage.forage.android.model.PaymentMethod
+import com.joinforage.forage.android.network.ForageConstants
+import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.network.model.ForageError
+import com.joinforage.forage.android.network.model.UnknownErrorApiResponse
+import com.joinforage.forage.android.ui.ForagePINEditText
+import com.verygoodsecurity.vgscollect.core.HTTPMethod
+
+internal val IncompletePinError = ForageApiResponse.Failure.fromError(
+    ForageError(400, "user_error", "Invalid EBT Card PIN entered. Please enter your 4-digit PIN.")
+)
+
+internal interface VaultSubmitter {
+    suspend fun submit(
+        encryptionKeys: EncryptionKeys,
+        idempotencyKey: String,
+        merchantId: String,
+        path: String,
+        paymentMethod: PaymentMethod,
+        userAction: UserAction
+    ): ForageApiResponse<String>
+
+    fun getVaultType(): VaultType
+}
+
+internal abstract class AbstractVaultSubmitter<VaultResponse>(
+    protected val foragePinEditText: ForagePINEditText,
+    protected val logger: Log = Log.getInstance(),
+    protected val context: Context,
+    private val vaultType: VaultType
+) : VaultSubmitter {
+    // interface methods
+    override suspend fun submit(
+        encryptionKeys: EncryptionKeys,
+        idempotencyKey: String,
+        merchantId: String,
+        path: String,
+        paymentMethod: PaymentMethod,
+        userAction: UserAction
+    ): ForageApiResponse<String> {
+        logger.addAttribute("payment_method_ref", paymentMethod.ref)
+            .addAttribute("merchant_ref", merchantId)
+        logger.i("[$vaultType] Sending $userAction request to $vaultType")
+
+        // If the PIN isn't valid (less than 4 numbers) then return a response here.
+        if (!foragePinEditText.getElementState().isComplete) {
+            logger.w("[$vaultType] User attempted to submit an incomplete PIN")
+            return IncompletePinError
+        }
+
+        val vaultToken = getVaultToken(paymentMethod)
+        val encryptionKey = parseEncryptionKey(encryptionKeys)
+
+        // if a vault provider is missing a token, we will
+        // gracefully fail here
+        if (vaultToken.isNullOrEmpty()) {
+            logger.e("Vault token is missing from Payments API response")
+            return UnknownErrorApiResponse
+        }
+
+        // ========= USED FOR REPORTING IMPORTANT METRICS =========
+        val proxyResponseMonitor = VaultProxyResponseMonitor(
+            vault = vaultType,
+            userAction = userAction,
+            metricsLogger = logger
+        )
+        proxyResponseMonitor
+            .setPath(path)
+            .setMethod(HTTPMethod.POST.toString())
+            .start()
+
+        val vaultProxyRequest = buildProxyRequest(
+            encryptionKey = encryptionKey,
+            idempotencyKey = idempotencyKey,
+            merchantId = merchantId,
+            vaultToken = vaultToken
+        ).setPath(path)
+        val forageResponse = submitProxyRequest(vaultProxyRequest = vaultProxyRequest)
+        proxyResponseMonitor.end()
+
+        // FNS requirement to clear the PIN after each submission
+        foragePinEditText.clearText()
+
+        val httpStatusCode = when (forageResponse) {
+            is ForageApiResponse.Success -> 200
+            is ForageApiResponse.Failure -> forageResponse.errors[0].httpStatusCode
+        }
+        proxyResponseMonitor.setHttpStatusCode(httpStatusCode).logResult()
+        // ==========================================================
+
+        return forageResponse
+    }
+
+    override fun getVaultType(): VaultType {
+        return vaultType
+    }
+
+    // abstract methods
+    internal abstract fun parseEncryptionKey(encryptionKeys: EncryptionKeys): String
+    internal abstract suspend fun submitProxyRequest(vaultProxyRequest: VaultProxyRequest): ForageApiResponse<String>
+    internal abstract fun getVaultToken(paymentMethod: PaymentMethod): String?
+
+    internal abstract fun toVaultErrorOrNull(vaultResponse: VaultResponse): ForageApiResponse.Failure?
+    abstract fun toForageErrorOrNull(vaultResponse: VaultResponse): ForageApiResponse.Failure?
+    abstract fun toForageSuccessOrNull(vaultResponse: VaultResponse): ForageApiResponse.Success<String>?
+    abstract fun parseVaultError(vaultResponse: VaultResponse): String
+
+    // concrete methods
+    protected open fun buildProxyRequest(
+        encryptionKey: String,
+        idempotencyKey: String,
+        merchantId: String,
+        vaultToken: String
+    ) = VaultProxyRequest.emptyRequest()
+        .setHeader(ForageConstants.Headers.X_KEY, encryptionKey)
+        .setHeader(ForageConstants.Headers.MERCHANT_ACCOUNT, merchantId)
+        .setHeader(ForageConstants.Headers.IDEMPOTENCY_KEY, idempotencyKey)
+        .setHeader(ForageConstants.Headers.TRACE_ID, logger.getTraceIdValue())
+        .setToken(vaultToken)
+
+    protected fun pickVaultTokenByIndex(paymentMethod: PaymentMethod, index: Int): String? {
+        val tokensString = paymentMethod.card.token
+        val tokensList = tokensString.split(TOKEN_DELIMITER)
+
+        // VGS is always the first token in the string
+        val noTokenStoredInVault = tokensList.size <= index
+        if (noTokenStoredInVault) return null
+
+        // grab BasisTheory token
+        return tokensList[index]
+    }
+
+    protected fun vaultToForageResponse(vaultResponse: VaultResponse): ForageApiResponse<String> {
+        if (vaultResponse == null) {
+            logger.e("[$vaultType] Received null response from $vaultType")
+            return UnknownErrorApiResponse
+        }
+
+        val vaultApiError = toVaultErrorOrNull(vaultResponse)
+        if (vaultApiError != null) {
+            val forageErr = parseVaultError(vaultResponse)
+            logger.e("[$vaultType] Received error from $vaultType: $forageErr")
+            return vaultApiError
+        }
+
+        val forageApiErrorResponse = toForageErrorOrNull(vaultResponse)
+        if (forageApiErrorResponse != null) {
+            val firstError = forageApiErrorResponse.errors[0]
+            logger.e("[$vaultType] Received error from $vaultType: $firstError")
+            return forageApiErrorResponse
+        }
+
+        val forageApiSuccess = toForageSuccessOrNull(vaultResponse)
+        if (forageApiSuccess != null) {
+            logger.i("[$vaultType] Received successful response from $vaultType")
+            return forageApiSuccess
+        }
+
+        return UnknownErrorApiResponse
+    }
+
+    internal companion object {
+        const val TOKEN_DELIMITER = ","
+
+        internal fun balancePath(paymentMethodRef: String) =
+            "/api/payment_methods/$paymentMethodRef/balance/"
+
+        internal fun capturePaymentPath(paymentRef: String) =
+            "/api/payments/$paymentRef/capture/"
+
+        internal fun deferPaymentCapturePath(paymentRef: String) =
+            "/api/payments/$paymentRef/collect_pin/"
+    }
+}

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/BasisTheoryPinSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/BasisTheoryPinSubmitter.kt
@@ -1,0 +1,139 @@
+package com.joinforage.forage.android.collect
+
+import android.content.Context
+import com.basistheory.android.service.BasisTheoryElements
+import com.basistheory.android.service.ProxyRequest
+import com.joinforage.forage.android.VaultType
+import com.joinforage.forage.android.core.StopgapGlobalState
+import com.joinforage.forage.android.model.EncryptionKeys
+import com.joinforage.forage.android.model.PaymentMethod
+import com.joinforage.forage.android.network.ForageConstants
+import com.joinforage.forage.android.network.model.ForageApiError
+import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.network.model.ForageError
+import com.joinforage.forage.android.network.model.UnknownErrorApiResponse
+import com.joinforage.forage.android.ui.ForagePINEditText
+import org.json.JSONException
+
+internal typealias BasisTheoryResponse = Result<Any?>
+
+internal class BasisTheoryPinSubmitter(
+    context: Context,
+    foragePinEditText: ForagePINEditText
+) : AbstractVaultSubmitter<BasisTheoryResponse>(
+    context = context,
+    foragePinEditText = foragePinEditText,
+    vaultType = VaultType.BT_VAULT_TYPE
+) {
+    override fun parseEncryptionKey(encryptionKeys: EncryptionKeys): String {
+        return encryptionKeys.btAlias
+    }
+
+    // Basis Theory requires a few extra headers beyond the
+    // common headers to make proxy requests
+    override fun buildProxyRequest(
+        encryptionKey: String,
+        idempotencyKey: String,
+        merchantId: String,
+        vaultToken: String
+    ) = super
+        .buildProxyRequest(
+            encryptionKey = encryptionKey,
+            idempotencyKey = idempotencyKey,
+            merchantId = merchantId,
+            vaultToken = vaultToken
+        )
+        .setHeader(ForageConstants.Headers.BT_PROXY_KEY, PROXY_ID)
+        .setHeader(ForageConstants.Headers.CONTENT_TYPE, "application/json")
+
+    override suspend fun submitProxyRequest(vaultProxyRequest: VaultProxyRequest): ForageApiResponse<String> {
+        val bt = buildBt()
+
+        val proxyRequest: ProxyRequest = ProxyRequest().apply {
+            headers = vaultProxyRequest.headers
+            body = ProxyRequestObject(
+                pin = foragePinEditText.getTextElement(),
+                card_number_token = vaultProxyRequest.vaultToken
+            )
+            path = vaultProxyRequest.path
+        }
+
+        val vaultResponse = runCatching {
+            bt.proxy.post(proxyRequest)
+        }
+
+        return vaultToForageResponse(vaultResponse)
+    }
+
+    override fun parseVaultError(vaultResponse: BasisTheoryResponse): String {
+        return vaultResponse.exceptionOrNull().toString()
+    }
+
+    override fun toForageSuccessOrNull(vaultResponse: BasisTheoryResponse): ForageApiResponse.Success<String>? {
+        // for Basis Theory, a failed response is a Basis Theory Api Error
+        // and doesn't have anything to do with Forage
+        if (vaultResponse.isFailure) return null
+
+        val forageResponse = vaultResponse.getOrNull().toString()
+        return try {
+            // converting the response to a ForageApiError should throw
+            // if forageResponse was Successful
+            ForageApiError.ForageApiErrorMapper.from(forageResponse)
+
+            // if it does NOT throw, then it's a ForageApiError
+            // so we return null here
+            return null
+        } catch (_: JSONException) {
+            // if it DOES throw, then it was not a ForageApiError so
+            // is it can only be a successful response!
+            ForageApiResponse.Success(forageResponse)
+        }
+    }
+
+    override fun toForageErrorOrNull(vaultResponse: BasisTheoryResponse): ForageApiResponse.Failure? {
+        // is a Basis Theory error and doesn't have to do with Forage
+        if (vaultResponse.isFailure) return null
+
+        return try {
+            // if the response is a ForageApiError, then this block
+            // should not throw
+            val forageResponse = vaultResponse.getOrNull().toString()
+            val forageApiError = ForageApiError.ForageApiErrorMapper.from(forageResponse)
+            val error = forageApiError.errors[0]
+            ForageApiResponse.Failure.fromError(
+                ForageError(400, error.code, error.message)
+            )
+        } catch (_: JSONException) {
+            // if we throw when trying to extract the ForageApiError,
+            // that means the response is not a ForageApiError
+            null
+        }
+    }
+
+    override fun toVaultErrorOrNull(vaultResponse: BasisTheoryResponse): ForageApiResponse.Failure? {
+        // for basis theory, Success responses mean Basis Theory did not
+        // mess up. So, it will be a Forage Success or Forage Error
+        // but it won't be a Basis Theory Error
+        if (vaultResponse.isSuccess) return null
+
+        // if the result is a Failure, we need to fail gracefully and
+        // return a ForageApiError
+        return UnknownErrorApiResponse
+    }
+
+    override fun getVaultToken(paymentMethod: PaymentMethod): String? = pickVaultTokenByIndex(paymentMethod, 1)
+
+    companion object {
+        // this code assumes that .setForageConfig() has been called
+        // on a Forage***EditText before PROXY_ID or API_KEY get
+        // referenced
+        private val PROXY_ID = StopgapGlobalState.envConfig.btProxyID
+        private val API_KEY = StopgapGlobalState.envConfig.btAPIKey
+
+        private fun buildBt(): BasisTheoryElements {
+            return BasisTheoryElements.builder()
+                .apiKey(API_KEY)
+                .build()
+        }
+    }
+}

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/BasisTheoryPinSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/BasisTheoryPinSubmitter.kt
@@ -70,24 +70,15 @@ internal class BasisTheoryPinSubmitter(
     }
 
     override fun toForageSuccessOrNull(vaultResponse: BasisTheoryResponse): ForageApiResponse.Success<String>? {
-        // for Basis Theory, a failed response is a Basis Theory Api Error
-        // and doesn't have anything to do with Forage
-        if (vaultResponse.isFailure) return null
-
-        val forageResponse = vaultResponse.getOrNull().toString()
-        return try {
-            // converting the response to a ForageApiError should throw
-            // if forageResponse was Successful
-            ForageApiError.ForageApiErrorMapper.from(forageResponse)
-
-            // if it does NOT throw, then it's a ForageApiError
-            // so we return null here
+        // The caller should have already performed the error checks.
+        // We add these error checks as a safeguard, just in case.
+        if (toVaultErrorOrNull(vaultResponse) != null ||
+            toForageErrorOrNull(vaultResponse) != null
+        ) {
             return null
-        } catch (_: JSONException) {
-            // if it DOES throw, then it was not a ForageApiError so
-            // is it can only be a successful response!
-            ForageApiResponse.Success(forageResponse)
         }
+
+        return ForageApiResponse.Success(vaultResponse.getOrNull().toString())
     }
 
     override fun toForageErrorOrNull(vaultResponse: BasisTheoryResponse): ForageApiResponse.Failure? {

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/VaultProxyRequest.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/VaultProxyRequest.kt
@@ -1,0 +1,26 @@
+package com.joinforage.forage.android.collect
+
+internal open class VaultProxyRequest(
+    open val headers: Map<String, String>,
+    open val path: String,
+    open val vaultToken: String
+) {
+    fun setPath(path: String) = VaultProxyRequest(headers, path, vaultToken)
+    fun setHeader(header: String, value: String): VaultProxyRequest {
+        val mutableCopy = headers.toMutableMap()
+        mutableCopy[header] = value
+        return VaultProxyRequest(
+            headers = mutableCopy,
+            path = path,
+            vaultToken = vaultToken
+        )
+    }
+    fun setToken(vaultToken: String) = VaultProxyRequest(headers, path, vaultToken)
+    companion object {
+        fun emptyRequest() = VaultProxyRequest(
+            HashMap(),
+            "",
+            ""
+        )
+    }
+}

--- a/forage-android/src/main/java/com/joinforage/forage/android/collect/VgsPinSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/collect/VgsPinSubmitter.kt
@@ -1,0 +1,159 @@
+package com.joinforage.forage.android.collect
+
+import android.content.Context
+import com.joinforage.forage.android.VaultType
+import com.joinforage.forage.android.core.StopgapGlobalState
+import com.joinforage.forage.android.model.EncryptionKeys
+import com.joinforage.forage.android.model.PaymentMethod
+import com.joinforage.forage.android.network.ForageConstants
+import com.joinforage.forage.android.network.model.ForageApiError
+import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.network.model.ForageError
+import com.joinforage.forage.android.network.model.UnknownErrorApiResponse
+import com.joinforage.forage.android.pos.PosVaultProxyRequest
+import com.joinforage.forage.android.ui.ForagePINEditText
+import com.verygoodsecurity.vgscollect.VGSCollectLogger
+import com.verygoodsecurity.vgscollect.core.HTTPMethod
+import com.verygoodsecurity.vgscollect.core.VGSCollect
+import com.verygoodsecurity.vgscollect.core.VgsCollectResponseListener
+import com.verygoodsecurity.vgscollect.core.model.network.VGSRequest
+import com.verygoodsecurity.vgscollect.core.model.network.VGSResponse
+import org.json.JSONException
+import kotlin.coroutines.suspendCoroutine
+
+internal class VgsPinSubmitter(
+    context: Context,
+    foragePinEditText: ForagePINEditText
+) : AbstractVaultSubmitter<VGSResponse?>(
+    context = context,
+    foragePinEditText = foragePinEditText,
+    vaultType = VaultType.VGS_VAULT_TYPE
+) {
+    override suspend fun submitProxyRequest(
+        vaultProxyRequest: VaultProxyRequest
+    ): ForageApiResponse<String> = suspendCoroutine { continuation ->
+        val vgsCollect = buildVGSCollect(context)
+        vgsCollect.bindView(foragePinEditText.getTextInputEditText())
+        val vgsInputField = foragePinEditText.getTextInputEditText()
+
+        vgsCollect.addOnResponseListeners(object : VgsCollectResponseListener {
+            override fun onResponse(response: VGSResponse?) {
+                // VGS wants us to call onDestroy, unlike Basis Theory
+                vgsCollect.onDestroy()
+                vgsInputField.setText("")
+
+                continuation.resumeWith(
+                    Result.success(vaultToForageResponse(response))
+                )
+            }
+        })
+
+        val request: VGSRequest = VGSRequest.VGSRequestBuilder()
+            .setMethod(HTTPMethod.POST)
+            .setPath(vaultProxyRequest.path)
+            .setCustomHeader(vaultProxyRequest.headers)
+            .setCustomData(buildRequestBody(vaultProxyRequest))
+            .build()
+
+        vgsCollect.asyncSubmit(request)
+    }
+
+    override fun parseEncryptionKey(encryptionKeys: EncryptionKeys): String {
+        return encryptionKeys.vgsAlias
+    }
+
+    override fun getVaultToken(paymentMethod: PaymentMethod): String? =
+        pickVaultTokenByIndex(paymentMethod, 0)
+
+    companion object {
+        // this code assumes that .setForageConfig() has been called
+        // on a Forage***EditText before PROXY_ID or API_KEY get
+        // referenced
+        private val VAULT_ID = StopgapGlobalState.envConfig.vgsVaultId
+        private val VGS_ENVIRONMENT = StopgapGlobalState.envConfig.vgsVaultType
+
+        private fun buildVGSCollect(context: Context): VGSCollect {
+            VGSCollectLogger.isEnabled = false
+            return VGSCollect.Builder(context, VAULT_ID)
+                .setEnvironment(VGS_ENVIRONMENT)
+                .create()
+        }
+
+        internal fun buildRequestBody(vaultProxyRequest: VaultProxyRequest): HashMap<String, Any> {
+            return when (vaultProxyRequest) {
+                is PosVaultProxyRequest -> buildPosRequestBody(vaultProxyRequest)
+                else -> buildBaseRequestBody(vaultProxyRequest)
+            }
+        }
+
+        private fun buildPosRequestBody(vaultProxyRequest: PosVaultProxyRequest): HashMap<String, Any> {
+            val body = buildBaseRequestBody(vaultProxyRequest)
+            body[ForageConstants.RequestBody.POS_TERMINAL] = hashMapOf(
+                ForageConstants.RequestBody.PROVIDER_TERMINAL_ID to vaultProxyRequest.posTerminalId
+            )
+            return body
+        }
+
+        private fun buildBaseRequestBody(vaultProxyRequest: VaultProxyRequest): HashMap<String, Any> {
+            return hashMapOf(
+                ForageConstants.RequestBody.CARD_NUMBER_TOKEN to vaultProxyRequest.vaultToken
+            )
+        }
+    }
+
+    override fun toVaultErrorOrNull(vaultResponse: VGSResponse?): ForageApiResponse.Failure? {
+        if (vaultResponse == null) return null
+        if (vaultResponse is VGSResponse.SuccessResponse) return null
+
+        val errorResponse = vaultResponse as VGSResponse.ErrorResponse
+        return try {
+            // converting the response to a ForageApiError should throw
+            // in the case of a VGS error
+            ForageApiError.ForageApiErrorMapper.from(errorResponse.toString())
+
+            // if it does NOT throw, then it's a ForageApiError
+            // so we return null
+            return null
+        } catch (_: JSONException) {
+            // if it DOES throw, then it was not a ForageApiError so
+            // it must be a VGS error
+            UnknownErrorApiResponse
+        }
+    }
+
+    override fun toForageErrorOrNull(vaultResponse: VGSResponse?): ForageApiResponse.Failure? {
+        if (vaultResponse == null) return null
+        if (vaultResponse is VGSResponse.SuccessResponse) return null
+
+        val errorResponse = vaultResponse as VGSResponse.ErrorResponse
+        return try {
+            // if the response is a ForageApiError, then this block
+            // should not throw
+            val forageApiError = ForageApiError.ForageApiErrorMapper.from(errorResponse.toString())
+            val error = forageApiError.errors[0]
+            ForageApiResponse.Failure.fromError(
+                ForageError(
+                    errorResponse.errorCode,
+                    error.code,
+                    error.message
+                )
+            )
+        } catch (_: JSONException) {
+            // if we throw when trying to extract the ForageApiError,
+            // that means the response is not a ForageApiError
+            null
+        }
+    }
+
+    override fun toForageSuccessOrNull(vaultResponse: VGSResponse?): ForageApiResponse.Success<String>? {
+        if (vaultResponse == null) return null
+        if (vaultResponse is VGSResponse.ErrorResponse) return null
+
+        val successResponse = vaultResponse as VGSResponse.SuccessResponse
+        return ForageApiResponse.Success(successResponse.body.toString())
+    }
+
+    override fun parseVaultError(vaultResponse: VGSResponse?): String {
+        return vaultResponse?.body.toString()
+    }
+}

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/model/ForageApiResponse.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/model/ForageApiResponse.kt
@@ -2,10 +2,20 @@ package com.joinforage.forage.android.network.model
 
 import org.json.JSONObject
 
+internal val UnknownErrorApiResponse = ForageApiResponse.Failure.fromError(
+    ForageError(500, "unknown_server_error", "Unknown Server Error")
+)
+
 sealed class ForageApiResponse<out T> {
     data class Success<out T>(val data: T) : ForageApiResponse<T>()
 
-    data class Failure(val errors: List<ForageError>) : ForageApiResponse<Nothing>()
+    data class Failure(val errors: List<ForageError>) : ForageApiResponse<Nothing>() {
+        companion object {
+            fun fromError(error: ForageError): Failure {
+                return Failure(listOf(error))
+            }
+        }
+    }
 }
 
 // Learn more about `ForageError`s [here](https://docs.joinforage.app/reference/forage-js-errors#forageerror)

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/PosVaultRequestParams.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/PosVaultRequestParams.kt
@@ -1,5 +1,6 @@
 package com.joinforage.forage.android.pos
 
+import com.joinforage.forage.android.collect.VaultProxyRequest
 import com.joinforage.forage.android.network.data.BaseVaultRequestParams
 
 internal data class PosVaultRequestParams(
@@ -14,4 +15,22 @@ internal data class PosVaultRequestParams(
     override fun hashCode(): Int {
         return super.hashCode() + posTerminalId.hashCode()
     }
+}
+
+internal data class PosVaultProxyRequest(
+    override val headers: Map<String, String>,
+    override val path: String,
+    override val vaultToken: String,
+    val posTerminalId: String
+) : VaultProxyRequest(
+    headers = headers,
+    path = path,
+    vaultToken = vaultToken
+) {
+    fun setPosTerminalId(posTerminalId: String) = PosVaultProxyRequest(
+        headers = headers,
+        path = path,
+        vaultToken = vaultToken,
+        posTerminalId = posTerminalId
+    )
 }


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

- Introduce
  - `AbstractVaultSubmitter`
  - `VgsPinSubmitter`
  - `BasisTheoryPinSubmitter`

Sought inspiration from @devinmorgan's design doc and his draft PR #129 🎉 

## Why

- Improve maintainability of PIN submission logic (across capturePayment, deferPaymentCapture, checkBalance, refundPayment, and so on.)
- Lay foundation for new refund PIN submission
- Lay foundation for implementing `ForageVaultSubmitter`

## Test Plan

- ✅  Plugged into `CheckBalanceRepository` locally and tests (that cover VGS responses) passed
- Will add unit tests for the new code in either this PR or a follow-up one!

## How

This PR can be released as-is

The PR will be followed by an "Add `RefundPaymentRepository`" PR that handles the polling using the new `PollingService` from #157 and the abstract submitter from this PR

- I will eventually refactor the existing facilities (balance, capture payment, defer payment capture); I have a WIP branch where I started to do this) danilo/wip-use-abstract-vault-submitters