### PR TITLE
[FX-739] Create EBT payment method by manual pan entry

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -26,11 +26,15 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.joinforage.android.example.R
 import com.joinforage.android.example.ui.pos.screens.ActionSelectionScreen
+import com.joinforage.android.example.ui.pos.screens.BalanceInquiryScreen
+import com.joinforage.android.example.ui.pos.screens.ManualPANEntryScreen
 import com.joinforage.android.example.ui.pos.screens.MerchantSetupScreen
 
 enum class POSScreen(@StringRes val title: Int) {
     MerchantSetupScreen(title = R.string.title_pos_merchant_setup),
-    ActionSelectionScreen(title = R.string.title_pos_action_selection)
+    ActionSelectionScreen(title = R.string.title_pos_action_selection),
+    BalanceInquiryScreen(title = R.string.title_pos_balance_inquiry),
+    ManualPANEntryScreen(title = R.string.title_pos_manual_pan_entry)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -94,11 +98,27 @@ fun POSComposeApp(
                     onBackButtonClicked = {
                         navController.popBackStack(POSScreen.MerchantSetupScreen.name, inclusive = false)
                     },
-                    onBalanceButtonClicked = { /*TODO*/ },
+                    onBalanceButtonClicked = {
+                        navController.navigate(POSScreen.BalanceInquiryScreen.name)
+                    },
                     onPaymentButtonClicked = { /*TODO*/ },
                     onRefundButtonClicked = { /*TODO*/ }
                 ) {
                 }
+            }
+            composable(route = POSScreen.BalanceInquiryScreen.name) {
+                BalanceInquiryScreen(
+                    onManualEntryButtonClicked = { navController.navigate(POSScreen.ManualPANEntryScreen.name) },
+                    onSwipeButtonClicked = { /*TODO*/ },
+                    onBackButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
+                )
+            }
+            composable(route = POSScreen.ManualPANEntryScreen.name) {
+                ManualPANEntryScreen(
+                    merchantId = uiState.merchantId,
+                    onSubmitButtonClicked = { /*TODO*/ },
+                    onBackButtonClicked = { navController.popBackStack(POSScreen.BalanceInquiryScreen.name, inclusive = false) }
+                )
             }
         }
     }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -1,16 +1,26 @@
 package com.joinforage.android.example.ui.pos
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.joinforage.android.example.network.model.tokenize.PaymentMethod
+import com.joinforage.android.example.network.model.tokenize.PaymentMethodJsonAdapter
 import com.joinforage.android.example.ui.pos.data.Merchant
 import com.joinforage.android.example.ui.pos.data.POSUIState
 import com.joinforage.android.example.ui.pos.network.PosApi
+import com.joinforage.forage.android.ForageSDK
+import com.joinforage.forage.android.TokenizeEBTCardParams
+import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.ui.ForagePANEditText
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
+import java.util.UUID
 
 sealed interface MerchantDetailsState {
     object Idle : MerchantDetailsState
@@ -28,10 +38,6 @@ class POSViewModel : ViewModel() {
         getMerchantInfo(merchantId = merchantId, onSuccess)
     }
 
-    fun setCardPAN(cardPAN: String) {
-        _uiState.update { it.copy(cardPAN = cardPAN) }
-    }
-
     private fun getMerchantInfo(merchantId: String, onSuccess: () -> Unit) {
         viewModelScope.launch {
             _uiState.update { it.copy(merchantDetailsState = MerchantDetailsState.Loading) }
@@ -43,6 +49,31 @@ class POSViewModel : ViewModel() {
                 MerchantDetailsState.Error(e.toString())
             }
             _uiState.update { it.copy(merchantDetailsState = merchantDetailsState) }
+        }
+    }
+
+    fun tokenizeEBTCard(foragePANEditText: ForagePANEditText, onSuccess: (data: PaymentMethod?) -> Unit) {
+        viewModelScope.launch {
+            val response = ForageSDK().tokenizeEBTCard(
+                TokenizeEBTCardParams(
+                    foragePanEditText = foragePANEditText,
+                    reusable = true,
+                    customerId = UUID.randomUUID().toString()
+                )
+            )
+
+            when (response) {
+                is ForageApiResponse.Success -> {
+                    val moshi = Moshi.Builder().build()
+                    val jsonAdapter: JsonAdapter<PaymentMethod> = PaymentMethodJsonAdapter(moshi)
+                    val tokenizedPaymentMethod = jsonAdapter.fromJson(response.data)
+                    _uiState.update { it.copy(tokenizationResult = tokenizedPaymentMethod) }
+                    onSuccess(tokenizedPaymentMethod)
+                }
+                is ForageApiResponse.Failure -> {
+                    Log.e("POSViewModel", response.toString())
+                }
+            }
         }
     }
 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -1,9 +1,11 @@
 package com.joinforage.android.example.ui.pos.data
 
+import com.joinforage.android.example.network.model.tokenize.PaymentMethod
 import com.joinforage.android.example.ui.pos.MerchantDetailsState
 
 data class POSUIState(
     val merchantId: String = "",
     val cardPAN: String = "",
-    val merchantDetailsState: MerchantDetailsState = MerchantDetailsState.Idle
+    val merchantDetailsState: MerchantDetailsState = MerchantDetailsState.Idle,
+    val tokenizationResult: PaymentMethod? = null
 )

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
@@ -10,7 +10,7 @@ import retrofit2.http.Header
 import retrofit2.http.Headers
 
 private const val BASE_URL = "https://api.dev.joinforage.app"
-private const val AUTH_TOKEN = "AUTH_TOKEN"
+const val AUTH_TOKEN = "AUTH_TOKEN"
 
 private val moshi = Moshi.Builder()
     .addLast(KotlinJsonAdapterFactory())

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ActionSelectionScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ActionSelectionScreen.kt
@@ -48,15 +48,15 @@ fun ActionSelectionScreen(
                     Text("Balance Inquiry")
                 }
                 Spacer(modifier = Modifier.height(8.dp))
-                Button(onClick = onPaymentButtonClicked, modifier = Modifier.fillMaxWidth()) {
+                Button(onClick = onPaymentButtonClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
                     Text("Create a Payment / Purchase")
                 }
                 Spacer(modifier = Modifier.height(8.dp))
-                Button(onClick = onRefundButtonClicked, modifier = Modifier.fillMaxWidth()) {
+                Button(onClick = onRefundButtonClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
                     Text("Make a Refund / Return")
                 }
                 Spacer(modifier = Modifier.height(8.dp))
-                Button(onClick = onVoidButtonClicked, modifier = Modifier.fillMaxWidth()) {
+                Button(onClick = onVoidButtonClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
                     Text("Void / Reverse a Transaction")
                 }
             }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/BalanceInquiryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/BalanceInquiryScreen.kt
@@ -1,0 +1,50 @@
+package com.joinforage.android.example.ui.pos.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun BalanceInquiryScreen(
+    onManualEntryButtonClicked: () -> Unit,
+    onSwipeButtonClicked: () -> Unit,
+    onBackButtonClicked: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Column {
+            Text("How do you want to read your EBT card?")
+            Button(onClick = onManualEntryButtonClicked) {
+                Text("Manually Enter Card Number")
+            }
+            Button(onClick = onSwipeButtonClicked, enabled = false) {
+                Text("Swipe Card")
+            }
+        }
+        Row {
+            Button(onClick = onBackButtonClicked) {
+                Text("Back")
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun BalanceInquiryScreenPreview() {
+    BalanceInquiryScreen(
+        onManualEntryButtonClicked = {},
+        onSwipeButtonClicked = {},
+        onBackButtonClicked = {}
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/BalanceInquiryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/BalanceInquiryScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.tooling.preview.Preview
 fun BalanceInquiryScreen(
     onManualEntryButtonClicked: () -> Unit,
     onSwipeButtonClicked: () -> Unit,
-    onBackButtonClicked: () -> Unit,
+    onBackButtonClicked: () -> Unit
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ManualPANEntryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ManualPANEntryScreen.kt
@@ -18,7 +18,7 @@ import com.joinforage.android.example.ui.pos.ui.ComposableForagePANEditText
 fun ManualPANEntryScreen(
     merchantId: String,
     onSubmitButtonClicked: () -> Unit,
-    onBackButtonClicked: () -> Unit,
+    onBackButtonClicked: () -> Unit
 ) {
     Column(
         verticalArrangement = Arrangement.SpaceBetween,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ManualPANEntryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ManualPANEntryScreen.kt
@@ -1,0 +1,53 @@
+package com.joinforage.android.example.ui.pos.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.joinforage.android.example.ui.pos.ui.ComposableForagePANEditText
+
+@Composable
+fun ManualPANEntryScreen(
+    merchantId: String,
+    onSubmitButtonClicked: () -> Unit,
+    onBackButtonClicked: () -> Unit,
+) {
+    Column(
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text("Manually enter your card number")
+            Spacer(modifier = Modifier.height(8.dp))
+            ComposableForagePANEditText(merchantId)
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onSubmitButtonClicked) {
+                Text("Submit")
+            }
+        }
+        Button(onClick = onBackButtonClicked) {
+            Text("Back")
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ManualPANEntryScreenPreview() {
+    ManualPANEntryScreen(
+        merchantId = "",
+        onSubmitButtonClicked = {},
+        onBackButtonClicked = {}
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ManualPANEntryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ManualPANEntryScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -13,12 +15,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.joinforage.android.example.ui.pos.ui.ComposableForagePANEditText
+import com.joinforage.forage.android.ui.ForagePANEditText
 
 @Composable
 fun ManualPANEntryScreen(
     merchantId: String,
+    tokenizedCardData: String?,
     onSubmitButtonClicked: () -> Unit,
-    onBackButtonClicked: () -> Unit
+    onBackButtonClicked: () -> Unit,
+    withPanElementReference: (element: ForagePANEditText) -> Unit
 ) {
     Column(
         verticalArrangement = Arrangement.SpaceBetween,
@@ -30,10 +35,25 @@ fun ManualPANEntryScreen(
         ) {
             Text("Manually enter your card number")
             Spacer(modifier = Modifier.height(8.dp))
-            ComposableForagePANEditText(merchantId)
+            ComposableForagePANEditText(
+                merchantId,
+                withPanElementReference = withPanElementReference
+            )
             Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onSubmitButtonClicked) {
                 Text("Submit")
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            if (tokenizedCardData != null) {
+                Card(
+                    modifier = Modifier.padding(16.dp)
+                ) {
+                    Column {
+                        Text("—— temporary info for dev ——")
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text(tokenizedCardData)
+                    }
+                }
             }
         }
         Button(onClick = onBackButtonClicked) {
@@ -47,7 +67,9 @@ fun ManualPANEntryScreen(
 fun ManualPANEntryScreenPreview() {
     ManualPANEntryScreen(
         merchantId = "",
+        tokenizedCardData = "",
         onSubmitButtonClicked = {},
-        onBackButtonClicked = {}
+        onBackButtonClicked = {},
+        withPanElementReference = {}
     )
 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ComposableForagePANEditText.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ComposableForagePANEditText.kt
@@ -20,7 +20,7 @@ fun ComposableForagePANEditText(merchantId: String) {
                 )
                 this.requestFocus()
             }
-        },
+        }
     )
 }
 

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ComposableForagePANEditText.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ComposableForagePANEditText.kt
@@ -1,0 +1,31 @@
+package com.joinforage.android.example.ui.pos.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.viewinterop.AndroidView
+import com.joinforage.android.example.ui.pos.network.AUTH_TOKEN
+import com.joinforage.forage.android.ui.ForageConfig
+import com.joinforage.forage.android.ui.ForagePANEditText
+
+@Composable
+fun ComposableForagePANEditText(merchantId: String) {
+    AndroidView(
+        factory = { context ->
+            ForagePANEditText(context).apply {
+                this.setForageConfig(
+                    ForageConfig(
+                        merchantId = merchantId,
+                        sessionToken = AUTH_TOKEN
+                    )
+                )
+                this.requestFocus()
+            }
+        },
+    )
+}
+
+@Preview
+@Composable
+fun ComposableForagePANEditTextPreview() {
+    ComposableForagePANEditText(merchantId = "")
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ComposableForagePANEditText.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ComposableForagePANEditText.kt
@@ -8,7 +8,10 @@ import com.joinforage.forage.android.ui.ForageConfig
 import com.joinforage.forage.android.ui.ForagePANEditText
 
 @Composable
-fun ComposableForagePANEditText(merchantId: String) {
+fun ComposableForagePANEditText(
+    merchantId: String,
+    withPanElementReference: (element: ForagePANEditText) -> Unit
+) {
     AndroidView(
         factory = { context ->
             ForagePANEditText(context).apply {
@@ -19,6 +22,7 @@ fun ComposableForagePANEditText(merchantId: String) {
                     )
                 )
                 this.requestFocus()
+                withPanElementReference(this)
             }
         }
     )
@@ -27,5 +31,8 @@ fun ComposableForagePANEditText(merchantId: String) {
 @Preview
 @Composable
 fun ComposableForagePANEditTextPreview() {
-    ComposableForagePANEditText(merchantId = "")
+    ComposableForagePANEditText(
+        merchantId = "",
+        withPanElementReference = {}
+    )
 }

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -29,4 +29,6 @@
     <string name="title_pos_merchant_setup">Merchant Setup</string>
     <string name="title_pos_action_selection">Select an Action</string>
     <string name="pos_back_button">Back</string>
+    <string name="title_pos_manual_pan_entry">Manual Card Entry</string>
+    <string name="title_pos_balance_inquiry">Balance Inquiry</string>
 </resources>


### PR DESCRIPTION
## What
Adds a screen for manual PAN entry via the Balance Inquiry flow. We should be able to reuse this screen for the Payment Capture as well when we get there. The Submit button uses our SDK to tokenize the EBT card.

## Why
POS Certification App

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/16c8f1b2-4a1c-4018-884f-d8f1eca78250

## How
Can be merged as-is