### PR TITLE
[FX-831] Create Screen to select the type of payment/purchase to perform

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -30,11 +30,12 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.joinforage.android.example.R
 import com.joinforage.android.example.ui.pos.screens.ActionSelectionScreen
-import com.joinforage.android.example.ui.pos.screens.BalanceInquiryScreen
-import com.joinforage.android.example.ui.pos.screens.BalanceResultScreen
-import com.joinforage.android.example.ui.pos.screens.ManualPANEntryScreen
 import com.joinforage.android.example.ui.pos.screens.MerchantSetupScreen
-import com.joinforage.android.example.ui.pos.screens.PINEntryScreen
+import com.joinforage.android.example.ui.pos.screens.balance.BalanceInquiryScreen
+import com.joinforage.android.example.ui.pos.screens.balance.BalanceResultScreen
+import com.joinforage.android.example.ui.pos.screens.payment.PaymentTypeSelectionScreen
+import com.joinforage.android.example.ui.pos.screens.shared.ManualPANEntryScreen
+import com.joinforage.android.example.ui.pos.screens.shared.PINEntryScreen
 import com.joinforage.forage.android.ui.ForagePANEditText
 import com.joinforage.forage.android.ui.ForagePINEditText
 
@@ -44,7 +45,8 @@ enum class POSScreen(@StringRes val title: Int) {
     BalanceInquiryScreen(title = R.string.title_pos_balance_inquiry),
     BIManualPANEntryScreen(title = R.string.title_pos_manual_pan_entry),
     BIPINEntryScreen(title = R.string.title_pos_pin_entry),
-    BIResultScreen(title = R.string.title_pos_balance_inquiry_result)
+    BIResultScreen(title = R.string.title_pos_balance_inquiry_result),
+    PaymentTypeSelectionScreen(title = R.string.title_pos_payment_type_selection_screen)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -119,10 +121,10 @@ fun POSComposeApp(
                     onBalanceButtonClicked = {
                         navController.navigate(POSScreen.BalanceInquiryScreen.name)
                     },
-                    onPaymentButtonClicked = { /*TODO*/ },
-                    onRefundButtonClicked = { /*TODO*/ }
-                ) {
-                }
+                    onPaymentButtonClicked = { navController.navigate(POSScreen.PaymentTypeSelectionScreen.name) },
+                    onRefundButtonClicked = { /*TODO*/ },
+                    onVoidButtonClicked = { /*TODO*/ }
+                )
             }
             composable(route = POSScreen.BalanceInquiryScreen.name) {
                 BalanceInquiryScreen(
@@ -175,6 +177,15 @@ fun POSComposeApp(
                     balance = uiState.balance,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.BIPINEntryScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
+                )
+            }
+            composable(route = POSScreen.PaymentTypeSelectionScreen.name) {
+                PaymentTypeSelectionScreen(
+                    onSnapPurchaseClicked = { /*TODO*/ },
+                    onCashPurchaseClicked = { /*TODO*/ },
+                    onCashWithdrawalClicked = { /*TODO*/ },
+                    onCashPurchaseCashbackClicked = { /*TODO*/ },
+                    onCancelButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
                 )
             }
         }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ActionSelectionScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ActionSelectionScreen.kt
@@ -48,7 +48,7 @@ fun ActionSelectionScreen(
                     Text("Balance Inquiry")
                 }
                 Spacer(modifier = Modifier.height(8.dp))
-                Button(onClick = onPaymentButtonClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
+                Button(onClick = onPaymentButtonClicked, modifier = Modifier.fillMaxWidth()) {
                     Text("Create a Payment / Purchase")
                 }
                 Spacer(modifier = Modifier.height(8.dp))

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/balance/BalanceInquiryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/balance/BalanceInquiryScreen.kt
@@ -1,4 +1,4 @@
-package com.joinforage.android.example.ui.pos.screens
+package com.joinforage.android.example.ui.pos.screens.balance
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/balance/BalanceResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/balance/BalanceResultScreen.kt
@@ -1,4 +1,4 @@
-package com.joinforage.android.example.ui.pos.screens
+package com.joinforage.android.example.ui.pos.screens.balance
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentTypeSelectionScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentTypeSelectionScreen.kt
@@ -1,0 +1,73 @@
+package com.joinforage.android.example.ui.pos.screens.payment
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun PaymentTypeSelectionScreen(
+    onSnapPurchaseClicked: () -> Unit,
+    onCashPurchaseClicked: () -> Unit,
+    onCashWithdrawalClicked: () -> Unit,
+    onCashPurchaseCashbackClicked: () -> Unit,
+    onCancelButtonClicked: () -> Unit
+) {
+    Column(
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .width(300.dp)
+                .padding(vertical = 16.dp)
+        ) {
+            Text("Select a transaction type", fontSize = 18.sp)
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(onClick = onSnapPurchaseClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
+                Text("EBT SNAP Purchase")
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Button(onClick = onCashPurchaseClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
+                Text("EBT Cash Purchase")
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Button(onClick = onCashWithdrawalClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
+                Text("EBT Cash Withdrawal (no purchase)")
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Button(onClick = onCashPurchaseCashbackClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
+                Text("EBT Cash Purchase + Cashback")
+            }
+        }
+        Button(onClick = onCancelButtonClicked) {
+            Text("Cancel")
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PaymentTypeSelectionScreenPreview() {
+    PaymentTypeSelectionScreen(
+        onSnapPurchaseClicked = {},
+        onCashPurchaseClicked = {},
+        onCashWithdrawalClicked = {},
+        onCashPurchaseCashbackClicked = {},
+        onCancelButtonClicked = {}
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/ManualPANEntryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/ManualPANEntryScreen.kt
@@ -1,4 +1,4 @@
-package com.joinforage.android.example.ui.pos.screens
+package com.joinforage.android.example.ui.pos.screens.shared
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/PinEntryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/PinEntryScreen.kt
@@ -1,4 +1,4 @@
-package com.joinforage.android.example.ui.pos.screens
+package com.joinforage.android.example.ui.pos.screens.shared
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -33,4 +33,5 @@
     <string name="title_pos_balance_inquiry">Balance Inquiry</string>
     <string name="title_pos_pin_entry">PIN Entry</string>
     <string name="title_pos_balance_inquiry_result">Balance Inquiry</string>
+    <string name="title_pos_payment_type_selection_screen">Create a Payment / Purchase</string>
 </resources>


### PR DESCRIPTION
## What
Adds a screen where a user can select which type of payment/purchase to perform once they've chosen to create a payment/purchase from the main action screen

This also does some housekeeping on how screen files are organized since we're gonna have a lot of them

## Why
POS Cert app

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/00679f67-712f-4cb8-82e0-3d62632f7afd

## How
Can be merged as-is