### PR TITLE
[FX-987] & [FX-988] Use ForageTerminalSDK for PAN tokenization & PIN submission instead of ForageSDK

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -52,7 +52,7 @@ enum class POSScreen(@StringRes val title: Int) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun POSComposeApp(
-    viewModel: POSViewModel,
+    viewModel: POSViewModel = viewModel(),
     navController: NavHostController = rememberNavController()
 ) {
     val backStackEntry by navController.currentBackStackEntryAsState()
@@ -195,5 +195,5 @@ fun POSComposeApp(
 @Preview
 @Composable
 fun PosAppPreview() {
-    POSComposeApp(viewModel = viewModel())
+    POSComposeApp()
 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -52,7 +52,7 @@ enum class POSScreen(@StringRes val title: Int) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun POSComposeApp(
-    viewModel: POSViewModel = viewModel(),
+    viewModel: POSViewModel,
     navController: NavHostController = rememberNavController()
 ) {
     val backStackEntry by navController.currentBackStackEntryAsState()
@@ -97,7 +97,7 @@ fun POSComposeApp(
         ) {
             composable(route = POSScreen.MerchantSetupScreen.name) {
                 MerchantSetupScreen(
-                    terminalId = "fake terminal ID",
+                    terminalId = uiState.terminalId ?: "Unknown",
                     merchantId = uiState.merchantId,
                     merchantDetailsState = uiState.merchantDetailsState,
                     onSaveButtonClicked = {
@@ -195,5 +195,5 @@ fun POSComposeApp(
 @Preview
 @Composable
 fun PosAppPreview() {
-    POSComposeApp()
+    POSComposeApp(viewModel = viewModel())
 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
@@ -7,14 +7,17 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import com.joinforage.android.example.databinding.FragmentPosBinding
 import com.pos.sdk.DeviceManager
 import com.pos.sdk.DevicesFactory
 import com.pos.sdk.callback.ResultCallback
+import com.pos.sdk.sys.SystemDevice
 
 class POSFragment : Fragment() {
     private var _binding: FragmentPosBinding? = null
     private val binding get() = _binding!!
+    private val posViewModel by activityViewModels<POSViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -27,7 +30,7 @@ class POSFragment : Fragment() {
         binding.composeView.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                POSComposeApp()
+                POSComposeApp(viewModel = posViewModel)
             }
         }
 
@@ -43,10 +46,13 @@ class POSFragment : Fragment() {
             object : ResultCallback<DeviceManager> {
                 override fun onFinish(deviceManager: DeviceManager) {
                     Log.i("CPay SDK", "DeviceManager created successfully")
+                    val terminalId = deviceManager.systemDevice.getSystemInfo(SystemDevice.SystemInfoType.IMEI)
+                    posViewModel.setTerminalId(terminalId)
                 }
 
                 override fun onError(i: Int, s: String) {
                     Log.i("CPay SDK", "Failed to create DeviceManager: $i,$s")
+                    posViewModel.setTerminalId("fakeDevTerminalId")
                 }
             }
         )

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
@@ -1,23 +1,16 @@
 package com.joinforage.android.example.ui.pos
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
 import com.joinforage.android.example.databinding.FragmentPosBinding
-import com.pos.sdk.DeviceManager
-import com.pos.sdk.DevicesFactory
-import com.pos.sdk.callback.ResultCallback
-import com.pos.sdk.sys.SystemDevice
 
 class POSFragment : Fragment() {
     private var _binding: FragmentPosBinding? = null
     private val binding get() = _binding!!
-    private val posViewModel by activityViewModels<POSViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -30,31 +23,10 @@ class POSFragment : Fragment() {
         binding.composeView.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                POSComposeApp(viewModel = posViewModel)
+                POSComposeApp()
             }
         }
 
         return root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        // initialize the CPay SDK for later user
-        DevicesFactory.create(
-            requireContext(),
-            object : ResultCallback<DeviceManager> {
-                override fun onFinish(deviceManager: DeviceManager) {
-                    Log.i("CPay SDK", "DeviceManager created successfully")
-                    val terminalId = deviceManager.systemDevice.getSystemInfo(SystemDevice.SystemInfoType.SN)
-                    posViewModel.setTerminalId(terminalId)
-                }
-
-                override fun onError(i: Int, s: String) {
-                    Log.i("CPay SDK", "Failed to create DeviceManager: $i,$s")
-                    posViewModel.setTerminalId("fakeDevTerminalId")
-                }
-            }
-        )
     }
 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSFragment.kt
@@ -46,7 +46,7 @@ class POSFragment : Fragment() {
             object : ResultCallback<DeviceManager> {
                 override fun onFinish(deviceManager: DeviceManager) {
                     Log.i("CPay SDK", "DeviceManager created successfully")
-                    val terminalId = deviceManager.systemDevice.getSystemInfo(SystemDevice.SystemInfoType.IMEI)
+                    val terminalId = deviceManager.systemDevice.getSystemInfo(SystemDevice.SystemInfoType.SN)
                     posViewModel.setTerminalId(terminalId)
                 }
 

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -14,6 +14,7 @@ import com.joinforage.forage.android.CheckBalanceParams
 import com.joinforage.forage.android.ForageSDK
 import com.joinforage.forage.android.TokenizeEBTCardParams
 import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.pos.ForageTerminalSDK
 import com.joinforage.forage.android.ui.ForagePANEditText
 import com.joinforage.forage.android.ui.ForagePINEditText
 import com.squareup.moshi.JsonAdapter
@@ -89,8 +90,12 @@ class POSViewModel : ViewModel() {
     }
 
     fun checkEBTCardBalance(foragePINEditText: ForagePINEditText, paymentMethodRef: String, onSuccess: (response: BalanceCheck?) -> Unit) {
+        if (terminalId == null) {
+            throw Error("Invalid POS Terminal ID")
+        }
+
         viewModelScope.launch {
-            val response = ForageSDK().checkBalance(
+            val response = ForageTerminalSDK(terminalId!!).checkBalance(
                 CheckBalanceParams(
                     foragePinEditText = foragePINEditText,
                     paymentMethodRef = paymentMethodRef

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -11,8 +11,6 @@ import com.joinforage.android.example.ui.pos.data.Merchant
 import com.joinforage.android.example.ui.pos.data.POSUIState
 import com.joinforage.android.example.ui.pos.network.PosApi
 import com.joinforage.forage.android.CheckBalanceParams
-import com.joinforage.forage.android.ForageSDK
-import com.joinforage.forage.android.TokenizeEBTCardParams
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.pos.ForageTerminalSDK
 import com.joinforage.forage.android.ui.ForagePANEditText
@@ -25,7 +23,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
-import java.util.UUID
 
 sealed interface MerchantDetailsState {
     object Idle : MerchantDetailsState
@@ -64,14 +61,14 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun tokenizeEBTCard(foragePANEditText: ForagePANEditText, onSuccess: (data: PaymentMethod?) -> Unit) {
+    fun tokenizeEBTCard(foragePanEditText: ForagePANEditText, onSuccess: (data: PaymentMethod?) -> Unit) {
+        if (terminalId == null) {
+            throw Error("Invalid POS Terminal ID")
+        }
         viewModelScope.launch {
-            val response = ForageSDK().tokenizeEBTCard(
-                TokenizeEBTCardParams(
-                    foragePanEditText = foragePANEditText,
-                    reusable = true,
-                    customerId = UUID.randomUUID().toString()
-                )
+            val response = ForageTerminalSDK(terminalId!!).tokenizeCard(
+                foragePanEditText = foragePanEditText,
+                reusable = true
             )
 
             when (response) {
@@ -89,7 +86,7 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun checkEBTCardBalance(foragePINEditText: ForagePINEditText, paymentMethodRef: String, onSuccess: (response: BalanceCheck?) -> Unit) {
+    fun checkEBTCardBalance(foragePinEditText: ForagePINEditText, paymentMethodRef: String, onSuccess: (response: BalanceCheck?) -> Unit) {
         if (terminalId == null) {
             throw Error("Invalid POS Terminal ID")
         }
@@ -97,7 +94,7 @@ class POSViewModel : ViewModel() {
         viewModelScope.launch {
             val response = ForageTerminalSDK(terminalId!!).checkBalance(
                 CheckBalanceParams(
-                    foragePinEditText = foragePINEditText,
+                    foragePinEditText = foragePinEditText,
                     paymentMethodRef = paymentMethodRef
                 )
             )

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -37,6 +37,13 @@ class POSViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(POSUIState())
     val uiState: StateFlow<POSUIState> = _uiState.asStateFlow()
 
+    private var terminalId: String? = null
+
+    fun setTerminalId(id: String) {
+        terminalId = id
+        _uiState.update { it.copy(terminalId = id) }
+    }
+
     fun setMerchantId(merchantId: String, onSuccess: () -> Unit) {
         _uiState.update { it.copy(merchantId = merchantId) }
         getMerchantInfo(merchantId = merchantId, onSuccess)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -35,7 +35,7 @@ class POSViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(POSUIState())
     val uiState: StateFlow<POSUIState> = _uiState.asStateFlow()
 
-    private var terminalId: String? = null
+    private var terminalId: String? = "tempDevTerminalId"
 
     fun setTerminalId(id: String) {
         terminalId = id

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -4,7 +4,7 @@ import com.joinforage.android.example.network.model.tokenize.PaymentMethod
 import com.joinforage.android.example.ui.pos.MerchantDetailsState
 
 data class POSUIState(
-    val terminalId: String? = null,
+    val terminalId: String? = "tempDevTerminalId",
     val merchantId: String = "",
     val merchantDetailsState: MerchantDetailsState = MerchantDetailsState.Idle,
     val tokenizedPaymentMethod: PaymentMethod? = null,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -4,6 +4,7 @@ import com.joinforage.android.example.network.model.tokenize.PaymentMethod
 import com.joinforage.android.example.ui.pos.MerchantDetailsState
 
 data class POSUIState(
+    val terminalId: String? = null,
     val merchantId: String = "",
     val merchantDetailsState: MerchantDetailsState = MerchantDetailsState.Idle,
     val tokenizedPaymentMethod: PaymentMethod? = null,


### PR DESCRIPTION
## What
Switches to use `ForageTerminalSDK` for pan tokenization and pin submission instead of `ForageSDK`. This required hoisting the view model up to the Fragment (previously it was created by the POSComposeApp and thus not available in the Fragment) so we could store the terminal ID in the view model and UI state in the success/error callbacks when setting up the CPay SDK.

## Why
POS Cert App

## Demo
No visual changes other than you should see the terminal ID on the main POS screen if there is a terminal attached

## How
Needs verification on terminal, but assuming it works, can be merged as-is