### PR TITLE
[FX-976] Add Vault pin submitter tests

### DIFF
--- a/forage-android/build.gradle
+++ b/forage-android/build.gradle
@@ -143,6 +143,7 @@ dependencies {
     // Use Mockito judiciously (mainly for mocking views)!
     // Opt for dependency injection and inheritance over Mockito
     testImplementation 'org.mockito:mockito-core:5.8.0'
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:4.1.0'
 
     ksp 'com.squareup.moshi:moshi-kotlin-codegen:1.14.0'
 

--- a/forage-android/consumer-rules.pro
+++ b/forage-android/consumer-rules.pro
@@ -1,3 +1,3 @@
--keepclassmembers class com.joinforage.forage.android.collect.ProxyRequestObject {
+-keepclassmembers class com.joinforage.forage.android.vault.ProxyRequestObject {
     *;
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ForageSDK.kt
@@ -1,6 +1,5 @@
 package com.joinforage.forage.android
 
-import com.joinforage.forage.android.collect.AbstractVaultSubmitter
 import com.joinforage.forage.android.core.EnvConfig
 import com.joinforage.forage.android.core.element.state.ElementState
 import com.joinforage.forage.android.core.telemetry.CustomerPerceivedResponseMonitor
@@ -23,6 +22,7 @@ import com.joinforage.forage.android.pos.PosRefundService
 import com.joinforage.forage.android.ui.AbstractForageElement
 import com.joinforage.forage.android.ui.ForageConfig
 import com.joinforage.forage.android.ui.ForagePINEditText
+import com.joinforage.forage.android.vault.AbstractVaultSubmitter
 
 /**
  * Entry point to the Forage SDK.

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CapturePaymentRepository.kt
@@ -1,6 +1,5 @@
 package com.joinforage.forage.android.network.data
 
-import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.model.Payment
 import com.joinforage.forage.android.model.PaymentMethod
@@ -10,6 +9,7 @@ import com.joinforage.forage.android.network.PaymentService
 import com.joinforage.forage.android.network.PollingService
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.Message
+import com.joinforage.forage.android.vault.PinCollector
 
 internal class CapturePaymentRepository(
     private val pinCollector: PinCollector,

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/CheckBalanceRepository.kt
@@ -1,6 +1,5 @@
 package com.joinforage.forage.android.network.data
 
-import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.core.telemetry.Log
 import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.model.PaymentMethod
@@ -10,6 +9,7 @@ import com.joinforage.forage.android.network.PollingService
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.Message
 import com.joinforage.forage.android.pos.PosVaultRequestParams
+import com.joinforage.forage.android.vault.PinCollector
 
 internal class CheckBalanceRepository(
     private val pinCollector: PinCollector,

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/DeferPaymentCaptureRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/DeferPaymentCaptureRepository.kt
@@ -1,6 +1,5 @@
 package com.joinforage.forage.android.network.data
 
-import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.model.Payment
 import com.joinforage.forage.android.model.PaymentMethod
@@ -8,6 +7,7 @@ import com.joinforage.forage.android.network.EncryptionKeyService
 import com.joinforage.forage.android.network.PaymentMethodService
 import com.joinforage.forage.android.network.PaymentService
 import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.vault.PinCollector
 
 internal class DeferPaymentCaptureRepository(
     private val pinCollector: PinCollector,

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/PosRefundPaymentRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/PosRefundPaymentRepository.kt
@@ -1,8 +1,5 @@
 package com.joinforage.forage.android.pos
 
-import com.joinforage.forage.android.collect.AbstractVaultSubmitter
-import com.joinforage.forage.android.collect.VaultSubmitter
-import com.joinforage.forage.android.collect.VaultSubmitterParams
 import com.joinforage.forage.android.core.telemetry.Log
 import com.joinforage.forage.android.core.telemetry.UserAction
 import com.joinforage.forage.android.model.EncryptionKeys
@@ -13,6 +10,9 @@ import com.joinforage.forage.android.network.PaymentMethodService
 import com.joinforage.forage.android.network.PaymentService
 import com.joinforage.forage.android.network.PollingService
 import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.vault.AbstractVaultSubmitter
+import com.joinforage.forage.android.vault.VaultSubmitter
+import com.joinforage.forage.android.vault.VaultSubmitterParams
 
 internal class PosRefundPaymentRepository(
     private val vaultSubmitter: VaultSubmitter,

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/PosVaultRequestParams.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/PosVaultRequestParams.kt
@@ -1,7 +1,7 @@
 package com.joinforage.forage.android.pos
 
-import com.joinforage.forage.android.collect.VaultSubmitterParams
 import com.joinforage.forage.android.network.data.BaseVaultRequestParams
+import com.joinforage.forage.android.vault.VaultSubmitterParams
 
 internal data class PosVaultRequestParams(
     override val cardNumberToken: String,

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -12,14 +12,14 @@ import com.joinforage.forage.android.ForageConfigNotSetException
 import com.joinforage.forage.android.LDManager
 import com.joinforage.forage.android.R
 import com.joinforage.forage.android.VaultType
-import com.joinforage.forage.android.collect.BTPinCollector
-import com.joinforage.forage.android.collect.PinCollector
-import com.joinforage.forage.android.collect.VGSPinCollector
 import com.joinforage.forage.android.core.EnvConfig
 import com.joinforage.forage.android.core.element.SimpleElementListener
 import com.joinforage.forage.android.core.element.StatefulElementListener
 import com.joinforage.forage.android.core.element.state.PinElementState
 import com.joinforage.forage.android.core.telemetry.Log
+import com.joinforage.forage.android.vault.BTPinCollector
+import com.joinforage.forage.android.vault.PinCollector
+import com.joinforage.forage.android.vault.VGSPinCollector
 import com.launchdarkly.sdk.android.LDConfig
 import com.verygoodsecurity.vgscollect.widget.VGSEditText
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/vault/AbstractVaultSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/vault/AbstractVaultSubmitter.kt
@@ -1,4 +1,4 @@
-package com.joinforage.forage.android.collect
+package com.joinforage.forage.android.vault
 
 import android.content.Context
 import com.joinforage.forage.android.VaultType
@@ -104,10 +104,13 @@ internal abstract class AbstractVaultSubmitter<VaultResponse>(
     internal abstract suspend fun submitProxyRequest(vaultProxyRequest: VaultProxyRequest): ForageApiResponse<String>
     internal abstract fun getVaultToken(paymentMethod: PaymentMethod): String?
 
+    /**
+     * @return [UnknownErrorApiResponse] if the response is a vault error, or null if it is not
+     */
     internal abstract fun toVaultErrorOrNull(vaultResponse: VaultResponse): ForageApiResponse.Failure?
-    abstract fun toForageErrorOrNull(vaultResponse: VaultResponse): ForageApiResponse.Failure?
-    abstract fun toForageSuccessOrNull(vaultResponse: VaultResponse): ForageApiResponse.Success<String>?
-    abstract fun parseVaultError(vaultResponse: VaultResponse): String
+    internal abstract fun toForageErrorOrNull(vaultResponse: VaultResponse): ForageApiResponse.Failure?
+    internal abstract fun toForageSuccessOrNull(vaultResponse: VaultResponse): ForageApiResponse.Success<String>?
+    internal abstract fun parseVaultError(vaultResponse: VaultResponse): String
 
     // concrete methods
     protected open fun buildProxyRequest(
@@ -140,15 +143,15 @@ internal abstract class AbstractVaultSubmitter<VaultResponse>(
 
         val vaultError = toVaultErrorOrNull(vaultResponse)
         if (vaultError != null) {
-            val forageErr = parseVaultError(vaultResponse)
-            logger.e("[$vaultType] Received error from $vaultType: $forageErr")
+            val rawVaultError = parseVaultError(vaultResponse)
+            logger.e("[$vaultType] Received error from $vaultType: $rawVaultError")
             return vaultError
         }
 
         val forageApiErrorResponse = toForageErrorOrNull(vaultResponse)
         if (forageApiErrorResponse != null) {
             val firstError = forageApiErrorResponse.errors[0]
-            logger.e("[$vaultType] Received error from $vaultType: $firstError")
+            logger.e("[$vaultType] Received ForageError from $vaultType: $firstError")
             return forageApiErrorResponse
         }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/vault/AbstractVaultSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/vault/AbstractVaultSubmitter.kt
@@ -110,7 +110,12 @@ internal abstract class AbstractVaultSubmitter<VaultResponse>(
     internal abstract fun toVaultErrorOrNull(vaultResponse: VaultResponse): ForageApiResponse.Failure?
     internal abstract fun toForageErrorOrNull(vaultResponse: VaultResponse): ForageApiResponse.Failure?
     internal abstract fun toForageSuccessOrNull(vaultResponse: VaultResponse): ForageApiResponse.Success<String>?
-    internal abstract fun parseVaultError(vaultResponse: VaultResponse): String
+
+    /**
+     * @return A string containing the raw error details of the vault error.
+     * To be used for internal error reporting.
+     */
+    internal abstract fun parseVaultErrorMessage(vaultResponse: VaultResponse): String
 
     // concrete methods
     protected open fun buildProxyRequest(
@@ -143,7 +148,7 @@ internal abstract class AbstractVaultSubmitter<VaultResponse>(
 
         val vaultError = toVaultErrorOrNull(vaultResponse)
         if (vaultError != null) {
-            val rawVaultError = parseVaultError(vaultResponse)
+            val rawVaultError = parseVaultErrorMessage(vaultResponse)
             logger.e("[$vaultType] Received error from $vaultType: $rawVaultError")
             return vaultError
         }
@@ -160,7 +165,7 @@ internal abstract class AbstractVaultSubmitter<VaultResponse>(
             logger.i("[$vaultType] Received successful response from $vaultType")
             return forageApiSuccess
         }
-        logger.e("[$vaultType] Received malformed response from $vaultType")
+        logger.e("[$vaultType] Received malformed response from $vaultType: $vaultResponse")
 
         return UnknownErrorApiResponse
     }

--- a/forage-android/src/main/java/com/joinforage/forage/android/vault/BTPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/vault/BTPinCollector.kt
@@ -1,4 +1,4 @@
-package com.joinforage.forage.android.collect
+package com.joinforage.forage.android.vault
 
 import com.basistheory.android.service.BasisTheoryElements
 import com.basistheory.android.service.ProxyRequest

--- a/forage-android/src/main/java/com/joinforage/forage/android/vault/BasisTheoryPinSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/vault/BasisTheoryPinSubmitter.kt
@@ -1,4 +1,4 @@
-package com.joinforage.forage.android.collect
+package com.joinforage.forage.android.vault
 
 import android.content.Context
 import com.basistheory.android.service.BasisTheoryElements
@@ -21,7 +21,8 @@ internal typealias BasisTheoryResponse = Result<Any?>
 internal class BasisTheoryPinSubmitter(
     context: Context,
     foragePinEditText: ForagePINEditText,
-    logger: Log
+    logger: Log,
+    private val buildVaultProvider: () -> BasisTheoryElements = { buildBt() }
 ) : AbstractVaultSubmitter<BasisTheoryResponse>(
     context = context,
     foragePinEditText = foragePinEditText,
@@ -48,7 +49,7 @@ internal class BasisTheoryPinSubmitter(
         .setHeader(ForageConstants.Headers.CONTENT_TYPE, "application/json")
 
     override suspend fun submitProxyRequest(vaultProxyRequest: VaultProxyRequest): ForageApiResponse<String> {
-        val bt = buildBt()
+        val bt = buildVaultProvider()
 
         val proxyRequest: ProxyRequest = ProxyRequest().apply {
             headers = vaultProxyRequest.headers

--- a/forage-android/src/main/java/com/joinforage/forage/android/vault/BasisTheoryPinSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/vault/BasisTheoryPinSubmitter.kt
@@ -3,6 +3,7 @@ package com.joinforage.forage.android.vault
 import android.content.Context
 import com.basistheory.android.service.BasisTheoryElements
 import com.basistheory.android.service.ProxyRequest
+import com.basistheory.android.service.getValue
 import com.joinforage.forage.android.VaultType
 import com.joinforage.forage.android.core.StopgapGlobalState
 import com.joinforage.forage.android.core.telemetry.Log
@@ -14,7 +15,6 @@ import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.network.model.UnknownErrorApiResponse
 import com.joinforage.forage.android.ui.ForagePINEditText
-import org.json.JSONException
 
 internal typealias BasisTheoryResponse = Result<Any?>
 
@@ -67,51 +67,57 @@ internal class BasisTheoryPinSubmitter(
         return vaultToForageResponse(vaultResponse)
     }
 
-    override fun parseVaultError(vaultResponse: BasisTheoryResponse): String {
+    override fun parseVaultErrorMessage(vaultResponse: BasisTheoryResponse): String {
         return vaultResponse.exceptionOrNull().toString()
     }
 
     override fun toForageSuccessOrNull(vaultResponse: BasisTheoryResponse): ForageApiResponse.Success<String>? {
         // The caller should have already performed the error checks.
         // We add these error checks as a safeguard, just in case.
-        if (toVaultErrorOrNull(vaultResponse) != null ||
+        if (vaultResponse.isFailure ||
+            toVaultErrorOrNull(vaultResponse) != null ||
             toForageErrorOrNull(vaultResponse) != null
         ) {
             return null
         }
 
+        // note: Result.toString() wraps the actual response as
+        // "Success(<actual-value-here>)"
         return ForageApiResponse.Success(vaultResponse.getOrNull().toString())
     }
 
     override fun toForageErrorOrNull(vaultResponse: BasisTheoryResponse): ForageApiResponse.Failure? {
-        // is a Basis Theory error and doesn't have to do with Forage
-        if (vaultResponse.isFailure) return null
-
         return try {
-            // if the response is a ForageApiError, then this block
-            // should not throw
-            val forageResponse = vaultResponse.getOrNull().toString()
-            val forageApiError = ForageApiError.ForageApiErrorMapper.from(forageResponse)
-            val error = forageApiError.errors[0]
-            ForageApiResponse.Failure.fromError(
-                ForageError(400, error.code, error.message)
+            val matchedStatusCode = getBasisTheoryExceptionStatusCode(vaultResponse)!!
+            val basisTheoryExceptionBody = getBasisTheoryExceptionBody(vaultResponse)!!
+
+            val forageApiError = ForageApiError.ForageApiErrorMapper.from(basisTheoryExceptionBody)
+            val firstError = forageApiError.errors[0]
+
+            return ForageApiResponse.Failure.fromError(
+                ForageError(matchedStatusCode, firstError.code, firstError.message)
             )
-        } catch (_: JSONException) {
-            // if we throw when trying to extract the ForageApiError,
+        } catch (_: Exception) {
+            // if we throw (likely a NullPointerException) when trying to extract the ForageApiError,
             // that means the response is not a ForageApiError
             null
         }
     }
 
     override fun toVaultErrorOrNull(vaultResponse: BasisTheoryResponse): ForageApiResponse.Failure? {
-        // for basis theory, Success responses mean Basis Theory did not
-        // mess up. So, it will be a Forage Success or Forage Error
-        // but it won't be a Basis Theory Error
         if (vaultResponse.isSuccess) return null
 
-        // if the result is a Failure, we need to fail gracefully and
-        // return a ForageApiError
-        return UnknownErrorApiResponse
+        try {
+            // try to parse as an error from Basis Theory, indicated by the presence
+            // of a "proxy_error" in the raw response body.
+            val basisTheoryExceptionBody = getBasisTheoryExceptionBody(vaultResponse)
+            if (basisTheoryExceptionBody!!.contains("proxy_error")) {
+                return UnknownErrorApiResponse
+            }
+            return null
+        } catch (_: Exception) {
+            return null
+        }
     }
 
     override fun getVaultToken(paymentMethod: PaymentMethod): String? = pickVaultTokenByIndex(paymentMethod, 1)
@@ -127,6 +133,31 @@ internal class BasisTheoryPinSubmitter(
             return BasisTheoryElements.builder()
                 .apiKey(API_KEY)
                 .build()
+        }
+
+        /**
+         * com.basistheory.ApiException isn't currently
+         * publicly-exposed by the basis-theory-android package
+         * so we parse the raw exception message to retrieve the body of the BasisTheory
+         * errors
+         *
+         * @return the BasisTheory JSON response body string if the response is a BasisTheory error,
+         * or null if it is not
+         */
+        private fun getBasisTheoryExceptionBody(vaultResponse: BasisTheoryResponse): String? {
+            val rawBasisTheoryError = vaultResponse.exceptionOrNull()?.message ?: return null
+            val bodyRegex = "HTTP response body: (.+?)\\n".toRegex()
+            return bodyRegex.find(rawBasisTheoryError)?.groupValues?.get(1)
+        }
+
+        /**
+         * @return the BasisTheory exception HTTP status code (Int) if the response is a BasisTheory error,
+         * or null if it is not
+         */
+        private fun getBasisTheoryExceptionStatusCode(vaultResponse: BasisTheoryResponse): Int? {
+            val rawBasisTheoryError = vaultResponse.exceptionOrNull()?.message ?: return null
+            val statusCodeRegex = "HTTP response code: (\\d+)".toRegex()
+            return statusCodeRegex.find(rawBasisTheoryError)?.groupValues?.get(1)?.toIntOrNull()
         }
     }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/vault/PinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/vault/PinCollector.kt
@@ -1,4 +1,4 @@
-package com.joinforage.forage.android.collect
+package com.joinforage.forage.android.vault
 
 import com.joinforage.forage.android.VaultType
 import com.joinforage.forage.android.model.EncryptionKeys

--- a/forage-android/src/main/java/com/joinforage/forage/android/vault/PinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/vault/PinCollector.kt
@@ -14,7 +14,7 @@ internal object CollectorConstants {
     message = "Use VaultSubmitter instead",
     replaceWith = ReplaceWith(
         expression = "VaultSubmitter",
-        imports = ["com.joinforage.forage.android.collect.VaultSubmitter"]
+        imports = ["com.joinforage.forage.android.vault.VaultSubmitter"]
     ),
     level = DeprecationLevel.WARNING
 )

--- a/forage-android/src/main/java/com/joinforage/forage/android/vault/VGSPinCollector.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/vault/VGSPinCollector.kt
@@ -1,4 +1,4 @@
-package com.joinforage.forage.android.collect
+package com.joinforage.forage.android.vault
 
 import android.content.Context
 import com.joinforage.forage.android.VaultType

--- a/forage-android/src/main/java/com/joinforage/forage/android/vault/VaultProxyRequest.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/vault/VaultProxyRequest.kt
@@ -1,4 +1,4 @@
-package com.joinforage.forage.android.collect
+package com.joinforage.forage.android.vault
 
 internal open class VaultProxyRequest(
     open val headers: Map<String, String>,

--- a/forage-android/src/main/java/com/joinforage/forage/android/vault/VgsPinSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/vault/VgsPinSubmitter.kt
@@ -143,7 +143,7 @@ internal class VgsPinSubmitter(
         return ForageApiResponse.Success(successResponse.body.toString())
     }
 
-    override fun parseVaultError(vaultResponse: VGSResponse?): String {
+    override fun parseVaultErrorMessage(vaultResponse: VGSResponse?): String {
         return vaultResponse?.body.toString()
     }
 }

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/BTPinCollectorTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/BTPinCollectorTest.kt
@@ -1,9 +1,9 @@
 package com.joinforage.forage.android.network.data
 
-import com.joinforage.forage.android.collect.BTPinCollector
 import com.joinforage.forage.android.mock.MockLogger
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
+import com.joinforage.forage.android.vault.BTPinCollector
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import me.jorgecastillo.hiroaki.internal.MockServerSuite

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/TestPinCollector.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/TestPinCollector.kt
@@ -1,12 +1,12 @@
 package com.joinforage.forage.android.network.data
 
 import com.joinforage.forage.android.VaultType
-import com.joinforage.forage.android.collect.CollectorConstants
-import com.joinforage.forage.android.collect.PinCollector
 import com.joinforage.forage.android.model.EncryptionKeys
 import com.joinforage.forage.android.model.PaymentMethod
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
+import com.joinforage.forage.android.vault.CollectorConstants
+import com.joinforage.forage.android.vault.PinCollector
 
 /**
  * Fake test implementation of PinCollector that could be used to replace VGS on tests

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/VGSPinCollectorTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/VGSPinCollectorTest.kt
@@ -1,10 +1,10 @@
 package com.joinforage.forage.android.network.data
 
-import com.joinforage.forage.android.collect.VGSPinCollector
 import com.joinforage.forage.android.core.telemetry.metrics.TestResponseMonitor
 import com.joinforage.forage.android.mock.MockLogger
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
+import com.joinforage.forage.android.vault.VGSPinCollector
 import com.verygoodsecurity.vgscollect.core.model.network.VGSResponse
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest

--- a/forage-android/src/test/java/com/joinforage/forage/android/vault/BasisTheoryPinSubmitterTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/vault/BasisTheoryPinSubmitterTest.kt
@@ -1,0 +1,198 @@
+package com.joinforage.forage.android.vault
+
+import android.content.Context
+import com.basistheory.android.service.BasisTheoryElements
+import com.basistheory.android.service.ProxyApi
+import com.basistheory.android.service.ProxyRequest
+import com.basistheory.android.view.TextElement
+import com.joinforage.forage.android.core.StopgapGlobalState
+import com.joinforage.forage.android.mock.MockLogger
+import com.joinforage.forage.android.network.ForageConstants
+import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.ui.ForageConfig
+import com.joinforage.forage.android.ui.ForagePINEditText
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import me.jorgecastillo.hiroaki.internal.MockServerSuite
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+
+class BasisTheoryPinSubmitterTest() : MockServerSuite() {
+    private lateinit var mockLogger: MockLogger
+    private lateinit var mockForagePinEditText: ForagePINEditText
+    private lateinit var submitter: BasisTheoryPinSubmitter
+    private lateinit var mockBasisTheory: BasisTheoryElements
+    private lateinit var mockBasisTheoryTextElement: TextElement
+    private lateinit var mockApiProxy: ProxyApi
+
+    @Before
+    fun setUp() {
+        super.setup()
+
+        mockLogger = MockLogger()
+
+        // Use Mockito judiciously (mainly for mocking views)!
+        // Opt for dependency injection and inheritance over Mockito
+        mockForagePinEditText = mock(ForagePINEditText::class.java)
+        val mockContext = mock(Context::class.java)
+        mockBasisTheory = mock(BasisTheoryElements::class.java)
+        mockBasisTheoryTextElement = mock(TextElement::class.java)
+        `when`(mockForagePinEditText.getTextElement()).thenReturn(mockBasisTheoryTextElement)
+
+        // ensure we don't make any live requests!
+        mockBasisTheoryResponse(Result.success("success"))
+
+        submitter = BasisTheoryPinSubmitter(
+            context = mockContext,
+            foragePinEditText = mockForagePinEditText,
+            logger = mockLogger,
+            buildVaultProvider = { mockBasisTheory }
+        )
+    }
+
+    private fun mockBasisTheoryResponse(response: BasisTheoryResponse) {
+        mockApiProxy = mock(ProxyApi::class.java)
+        `when`(mockBasisTheory.proxy).thenReturn(mockApiProxy)
+        runBlocking {
+            if (response.isSuccess) {
+                `when`(mockApiProxy.post(anyOrNull(), anyOrNull())).thenReturn(response.getOrNull()!!)
+            } else {
+                `when`(mockApiProxy.post(anyOrNull(), anyOrNull())).thenThrow(response.exceptionOrNull()!!)
+            }
+        }
+    }
+
+    @Test
+    fun `Basis Theory request receives expected params`() = runTest {
+        StopgapGlobalState.forageConfig = ForageConfig("1234567", "sandbox_abcdefg123")
+
+        val vaultProxyRequest = VaultProxyRequest.emptyRequest()
+            .setHeader(ForageConstants.Headers.X_KEY, "12320ce0-1a3c-4c64-970c-51ed7db34548")
+            .setHeader(ForageConstants.Headers.MERCHANT_ACCOUNT, "1234567")
+            .setHeader(ForageConstants.Headers.IDEMPOTENCY_KEY, "abcdef123")
+            .setHeader(ForageConstants.Headers.TRACE_ID, "65639248-03f2-498d-8aa8-9ebd1c60ee65")
+            .setToken("45320ce0-1a3c-4c64-970c-51ed7db34548")
+            .setPath("/api/payment_methods/defghij123/balance/")
+            .setHeader(ForageConstants.Headers.BT_PROXY_KEY, StopgapGlobalState.envConfig.btProxyID)
+            .setHeader(ForageConstants.Headers.CONTENT_TYPE, "application/json")
+
+        runBlocking {
+            submitter.submitProxyRequest(vaultProxyRequest)
+        }
+
+        val captor = argumentCaptor<ProxyRequest>()
+        verify(mockApiProxy).post(captor.capture(), eq(null))
+        val capturedRequest = captor.firstValue
+
+        assertEquals(
+            ProxyRequestObject(
+                pin = mockBasisTheoryTextElement,
+                card_number_token = "45320ce0-1a3c-4c64-970c-51ed7db34548"
+            ),
+            capturedRequest.body
+        )
+        assertEquals(
+            hashMapOf(
+                "X-KEY" to "12320ce0-1a3c-4c64-970c-51ed7db34548",
+                "Merchant-Account" to "1234567",
+                "IDEMPOTENCY-KEY" to "abcdef123",
+                "x-datadog-trace-id" to "65639248-03f2-498d-8aa8-9ebd1c60ee65",
+                "BT-PROXY-KEY" to "R1CNiogSdhnHeNq6ZFWrG1", // sandbox value of btProxyID
+                "Content-Type" to "application/json"
+            ),
+            capturedRequest.headers
+        )
+        assertEquals("/api/payment_methods/defghij123/balance/", capturedRequest.path)
+    }
+
+    @Test
+    fun `submitProxyRequest with valid input should return success`() = runTest {
+        val responseStr = """{"content_id":"32489e7e-13d9-499c-b017-f68a0122da95","message_type":"0200","status":"sent_to_proxy","failed":false,"errors":[]}"""
+        mockBasisTheoryResponse(Result.success(responseStr))
+
+        val result = submitter.submitProxyRequest(VaultProxyRequest.emptyRequest())
+
+        assertTrue(result is ForageApiResponse.Success)
+        assertEquals("[basis_theory] Received successful response from basis_theory", mockLogger.infoLogs.last().getMessage())
+        assertEquals(responseStr, (result as ForageApiResponse.Success).data)
+    }
+
+    @Test
+    fun `Basis Theory returns a vault error`() = runTest {
+        val basisTheoryErrorMessage = """
+            Message: 
+            HTTP response code: 400
+            HTTP response body: {"proxy_error":{"errors":{"error":["Basis Theory Validation Error"]},"title":"One or more validation errors occurred.","status":400,"detail":"Bad Request"}}
+            HTTP response headers: ...
+        """.trimIndent()
+        mockBasisTheoryResponse(Result.failure(RuntimeException(basisTheoryErrorMessage)))
+
+        val result = submitter.submitProxyRequest(VaultProxyRequest.emptyRequest())
+
+        assertTrue(result is ForageApiResponse.Failure)
+        val firstError = (result as ForageApiResponse.Failure).errors[0]
+        assertEquals("[basis_theory] Received error from basis_theory: java.lang.RuntimeException: $basisTheoryErrorMessage", mockLogger.errorLogs.last().getMessage())
+        assertEquals("Unknown Server Error", firstError.message)
+        assertEquals(500, firstError.httpStatusCode)
+        assertEquals("unknown_server_error", firstError.code)
+    }
+
+    @Test
+    fun `Basis Theory returns a ForageError`() = runTest {
+        val responseStr = """
+        Message:
+        HTTP response code: 400
+        HTTP response body: {"path": "/api/payments/abcdefg123/collect_pin/","errors": [{"code": "too_many_requests","message": "Request was throttled, please try again later."}]}
+        HTTP response headers: {"some": "header"}
+        """.trimIndent()
+
+        mockBasisTheoryResponse(Result.failure(RuntimeException(responseStr)))
+
+        val result = submitter.submitProxyRequest(VaultProxyRequest.emptyRequest())
+
+        assertTrue(result is ForageApiResponse.Failure)
+        val firstError = (result as ForageApiResponse.Failure).errors[0]
+        assertEquals(
+            """
+        [basis_theory] Received ForageError from basis_theory: Code: too_many_requests
+        Message: Request was throttled, please try again later.
+        Status Code: 400
+        Error Details (below):
+        null
+            """.trimIndent(),
+            mockLogger.errorLogs.last().getMessage()
+        )
+        assertEquals("Request was throttled, please try again later.", firstError.message)
+        assertEquals(400, firstError.httpStatusCode)
+        assertEquals("too_many_requests", firstError.code)
+    }
+
+    @Test
+    fun `Basis Theory responds with a malformed error`() = runTest {
+        val responseStr = """
+        Malformed error!
+        """.trimIndent()
+
+        mockBasisTheoryResponse(Result.failure(RuntimeException(responseStr)))
+
+        val result = submitter.submitProxyRequest(VaultProxyRequest.emptyRequest())
+
+        assertTrue(result is ForageApiResponse.Failure)
+        val firstError = (result as ForageApiResponse.Failure).errors[0]
+        assertEquals(
+            "[basis_theory] Received malformed response from basis_theory: Failure(java.lang.RuntimeException: Malformed error!)",
+            mockLogger.errorLogs.last().getMessage()
+        )
+        assertEquals("Unknown Server Error", firstError.message)
+        assertEquals(500, firstError.httpStatusCode)
+        assertEquals("unknown_server_error", firstError.code)
+    }
+}

--- a/forage-android/src/test/java/com/joinforage/forage/android/vault/VgsPinSubmitterTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/vault/VgsPinSubmitterTest.kt
@@ -13,7 +13,6 @@ import com.verygoodsecurity.vgscollect.core.model.network.VGSResponse
 import com.verygoodsecurity.vgscollect.widget.VGSEditText
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import me.jorgecastillo.hiroaki.internal.MockServerSuite
 import org.junit.Before
@@ -24,7 +23,6 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class VgsPinSubmitterTest() : MockServerSuite() {
     private lateinit var mockLogger: MockLogger
     private lateinit var mockForagePinEditText: ForagePINEditText
@@ -135,7 +133,6 @@ class VgsPinSubmitterTest() : MockServerSuite() {
             ]
         }
         """.trimIndent()
-
         mockVgsCollectResponse(VGSResponse.ErrorResponse(errorCode = 400, rawResponse = responseStr))
 
         val result = vgsPinSubmitter.submitProxyRequest(VaultProxyRequest.emptyRequest())

--- a/forage-android/src/test/java/com/joinforage/forage/android/vault/VgsPinSubmitterTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/vault/VgsPinSubmitterTest.kt
@@ -1,0 +1,159 @@
+package com.joinforage.forage.android.vault
+
+import android.content.Context
+import com.joinforage.forage.android.mock.MockLogger
+import com.joinforage.forage.android.network.ForageConstants
+import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.ui.ForagePINEditText
+import com.verygoodsecurity.vgscollect.core.HTTPMethod
+import com.verygoodsecurity.vgscollect.core.VGSCollect
+import com.verygoodsecurity.vgscollect.core.VgsCollectResponseListener
+import com.verygoodsecurity.vgscollect.core.model.network.VGSRequest
+import com.verygoodsecurity.vgscollect.core.model.network.VGSResponse
+import com.verygoodsecurity.vgscollect.widget.VGSEditText
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import me.jorgecastillo.hiroaki.internal.MockServerSuite
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.anyOrNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class VgsPinSubmitterTest() : MockServerSuite() {
+    private lateinit var mockLogger: MockLogger
+    private lateinit var mockForagePinEditText: ForagePINEditText
+    private lateinit var vgsPinSubmitter: VgsPinSubmitter
+    private lateinit var mockVgsCollect: VGSCollect
+
+    @Before
+    fun setUp() {
+        super.setup()
+
+        mockLogger = MockLogger()
+
+        // Use Mockito judiciously (mainly for mocking views)!
+        // Opt for dependency injection and inheritance over Mockito
+        mockForagePinEditText = mock(ForagePINEditText::class.java)
+        val mockContext = mock(Context::class.java)
+        mockVgsCollect = mock(VGSCollect::class.java)
+        `when`(mockForagePinEditText.getTextInputEditText()).thenReturn(mock(VGSEditText::class.java))
+        `when`(mockVgsCollect.asyncSubmit(anyOrNull())).thenAnswer {}
+
+        vgsPinSubmitter = VgsPinSubmitter(
+            context = mockContext,
+            foragePinEditText = mockForagePinEditText,
+            logger = mockLogger,
+            buildVaultProvider = { _ -> mockVgsCollect }
+        )
+    }
+
+    private fun mockVgsCollectResponse(response: VGSResponse) {
+        `when`(mockVgsCollect.addOnResponseListeners(any())).thenAnswer {
+            val listener = it.arguments[0] as VgsCollectResponseListener
+            listener.onResponse(response)
+            null
+        }
+    }
+
+    @Test
+    fun `VGS request receives expected params`() = runTest {
+        mockVgsCollectResponse(VGSResponse.SuccessResponse(successCode = 200, rawResponse = ""))
+
+        val vaultProxyRequest = VaultProxyRequest.emptyRequest()
+            .setHeader(ForageConstants.Headers.X_KEY, "tok_sandbox_sYiPe9Q249qQ5wQyUPP5f7")
+            .setHeader(ForageConstants.Headers.MERCHANT_ACCOUNT, "1234567")
+            .setHeader(ForageConstants.Headers.IDEMPOTENCY_KEY, "abcdef123")
+            .setHeader(ForageConstants.Headers.TRACE_ID, "65639248-03f2-498d-8aa8-9ebd1c60ee65")
+            .setToken("tok_sandbox_sYiPe9Q249qQ5wQyUPP5f7")
+            .setPath("/api/payments/abcdefg123/capture/")
+
+        vgsPinSubmitter.submitProxyRequest(vaultProxyRequest)
+
+        verify(mockVgsCollect).asyncSubmit(
+            VGSRequest.VGSRequestBuilder()
+                .setMethod(HTTPMethod.POST)
+                .setPath("/api/payments/abcdefg123/capture/")
+                .setCustomHeader(
+                    mapOf(
+                        ForageConstants.Headers.X_KEY to "tok_sandbox_sYiPe9Q249qQ5wQyUPP5f7",
+                        ForageConstants.Headers.MERCHANT_ACCOUNT to "1234567",
+                        ForageConstants.Headers.IDEMPOTENCY_KEY to "abcdef123",
+                        ForageConstants.Headers.TRACE_ID to "65639248-03f2-498d-8aa8-9ebd1c60ee65"
+                    )
+                )
+                .setCustomData(
+                    hashMapOf(
+                        "card_number_token" to "tok_sandbox_sYiPe9Q249qQ5wQyUPP5f7"
+                    )
+                )
+                .build()
+        )
+    }
+
+    @Test
+    fun `submitProxyRequest with valid input should return success`() = runTest {
+        val responseStr = """{"content_id":"32489e7e-13d9-499c-b017-f68a0122da95","message_type":"0200","status":"sent_to_proxy","failed":false,"errors":[]}"""
+        mockVgsCollectResponse(VGSResponse.SuccessResponse(successCode = 200, rawResponse = responseStr))
+
+        val result = vgsPinSubmitter.submitProxyRequest(VaultProxyRequest.emptyRequest())
+
+        assertTrue(result is ForageApiResponse.Success)
+        assertEquals("[vgs] Received successful response from vgs", mockLogger.infoLogs.last().getMessage())
+        assertEquals(responseStr, (result as ForageApiResponse.Success).data)
+    }
+
+    @Test
+    fun `VGS returns a vault error`() = runTest {
+        mockVgsCollectResponse(VGSResponse.ErrorResponse(errorCode = 403, rawResponse = "VGS connection error"))
+
+        val result = vgsPinSubmitter.submitProxyRequest(VaultProxyRequest.emptyRequest())
+
+        assertTrue(result is ForageApiResponse.Failure)
+        val firstError = (result as ForageApiResponse.Failure).errors[0]
+        assertEquals("[vgs] Received error from vgs: VGS connection error", mockLogger.errorLogs.last().getMessage())
+        assertEquals("Unknown Server Error", firstError.message)
+        assertEquals(500, firstError.httpStatusCode)
+        assertEquals("unknown_server_error", firstError.code)
+    }
+
+    @Test
+    fun `VGS returns a ForageError`() = runTest {
+        val responseStr = """
+        {
+            "path": "/api/payments/abcdefg123/capture/",
+            "errors": [
+                {
+                    "code": "cannot_capture_payment",
+                    "message": "Payment with ref abcdefg123 is either processing, succeeded, or canceled and therefore cannot be captured."
+                }
+            ]
+        }
+        """.trimIndent()
+
+        mockVgsCollectResponse(VGSResponse.ErrorResponse(errorCode = 400, rawResponse = responseStr))
+
+        val result = vgsPinSubmitter.submitProxyRequest(VaultProxyRequest.emptyRequest())
+
+        assertTrue(result is ForageApiResponse.Failure)
+        val firstError = (result as ForageApiResponse.Failure).errors[0]
+        assertEquals(
+            """
+        [vgs] Received ForageError from vgs: Code: cannot_capture_payment
+        Message: Payment with ref abcdefg123 is either processing, succeeded, or canceled and therefore cannot be captured.
+        Status Code: 400
+        Error Details (below):
+        null
+            """.trimIndent(),
+            mockLogger.errorLogs.last().getMessage()
+        )
+        assertEquals("Payment with ref abcdefg123 is either processing, succeeded, or canceled and therefore cannot be captured.", firstError.message)
+        assertEquals(400, firstError.httpStatusCode)
+        assertEquals("cannot_capture_payment", firstError.code)
+    }
+}


### PR DESCRIPTION
## What

- [x] Add unit tests for `VgsPinSubmitter.kt` and `BasisTheoryPinSubmitter.kt`
  - [x] This required including a test mockito dependency to use `anyOrNull` 
- [x] Rename `collect` package to `vault` package
- [x] Fix ForageError (from VGS proxy) unpacking ([more info](https://github.com/teamforage/forage-android-sdk/pull/169/files#r1464003479)); this issue exists in the `VGSPinCollector` as well
- [x] Fix vault + forage error handling in `BasisTheoryPinSubmitter.kt`

## How

Can serve as reference for writing `ForagePinSubmitter` tests @dleis612 

Will follow-up with PRs for `AbstractVaultSubmitter.kt` and `RefundPaymentRepository.kt`
