### PR TITLE
House ForageConfig info in POSUIState

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -135,7 +135,7 @@ fun POSComposeApp(
             }
             composable(route = POSScreen.BIManualPANEntryScreen.name) {
                 ManualPANEntryScreen(
-                    merchantId = uiState.merchantId,
+                    forageConfig = uiState.forageConfig,
                     onSubmitButtonClicked = {
                         if (panElement != null) {
                             viewModel.tokenizeEBTCard(panElement as ForagePANEditText, onSuccess = {
@@ -152,7 +152,7 @@ fun POSComposeApp(
             }
             composable(route = POSScreen.BIPINEntryScreen.name) {
                 PINEntryScreen(
-                    merchantId = uiState.merchantId,
+                    forageConfig = uiState.forageConfig,
                     paymentMethodRef = uiState.tokenizedPaymentMethod?.ref,
                     onSubmitButtonClicked = {
                         if (pinElement != null && uiState.tokenizedPaymentMethod?.ref != null) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -10,6 +10,7 @@ import com.joinforage.android.example.ui.pos.data.BalanceCheckJsonAdapter
 import com.joinforage.android.example.ui.pos.data.Merchant
 import com.joinforage.android.example.ui.pos.data.POSUIState
 import com.joinforage.android.example.ui.pos.network.PosApi
+import com.joinforage.android.example.ui.pos.network.formatAuthHeader
 import com.joinforage.forage.android.CheckBalanceParams
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.pos.ForageTerminalSDK
@@ -51,7 +52,10 @@ class POSViewModel : ViewModel() {
         viewModelScope.launch {
             _uiState.update { it.copy(merchantDetailsState = MerchantDetailsState.Loading) }
             val merchantDetailsState = try {
-                val result = PosApi.retrofitService.getMerchantInfo(merchantId)
+                val result = PosApi.retrofitService.getMerchantInfo(
+                    formatAuthHeader(uiState.value.sessionToken),
+                    merchantId
+                )
                 onSuccess()
                 MerchantDetailsState.Success(result)
             } catch (e: HttpException) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -2,11 +2,16 @@ package com.joinforage.android.example.ui.pos.data
 
 import com.joinforage.android.example.network.model.tokenize.PaymentMethod
 import com.joinforage.android.example.ui.pos.MerchantDetailsState
+import com.joinforage.forage.android.ui.ForageConfig
 
 data class POSUIState(
     val terminalId: String? = "tempDevTerminalId",
     val merchantId: String = "",
+    val sessionToken: String = "<your_oath_or_session_token>", // <your_oath_or_session_token>,
     val merchantDetailsState: MerchantDetailsState = MerchantDetailsState.Idle,
     val tokenizedPaymentMethod: PaymentMethod? = null,
     val balance: BalanceCheck? = null
-)
+) {
+    val forageConfig: ForageConfig
+        get() = ForageConfig(merchantId, sessionToken)
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
@@ -7,10 +7,8 @@ import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Header
-import retrofit2.http.Headers
 
 private const val BASE_URL = "https://api.dev.joinforage.app"
-const val AUTH_TOKEN = "AUTH_TOKEN"
 
 private val moshi = Moshi.Builder()
     .addLast(KotlinJsonAdapterFactory())
@@ -22,9 +20,12 @@ private val retrofit = Retrofit.Builder()
     .build()
 
 interface PosApiService {
-    @Headers("Authorization: Bearer $AUTH_TOKEN")
     @GET("api/merchants/")
-    suspend fun getMerchantInfo(@Header("Merchant-Account") merchantId: String): Merchant
+    suspend fun getMerchantInfo(
+        @Header("Authorization") authorization: String,
+        @Header("Merchant-Account") merchantId: String
+    ): Merchant
+
 }
 
 object PosApi {
@@ -32,3 +33,4 @@ object PosApi {
         retrofit.create(PosApiService::class.java)
     }
 }
+fun formatAuthHeader(sessionToken: String) = "Bearer $sessionToken"

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
@@ -25,7 +25,6 @@ interface PosApiService {
         @Header("Authorization") authorization: String,
         @Header("Merchant-Account") merchantId: String
     ): Merchant
-
 }
 
 object PosApi {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/ManualPANEntryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/ManualPANEntryScreen.kt
@@ -13,11 +13,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.joinforage.android.example.ui.pos.ui.ComposableForagePANEditText
+import com.joinforage.forage.android.ui.ForageConfig
 import com.joinforage.forage.android.ui.ForagePANEditText
 
 @Composable
 fun ManualPANEntryScreen(
-    merchantId: String,
+    forageConfig: ForageConfig,
     onSubmitButtonClicked: () -> Unit,
     onBackButtonClicked: () -> Unit,
     withPanElementReference: (element: ForagePANEditText) -> Unit
@@ -33,7 +34,7 @@ fun ManualPANEntryScreen(
             Text("Manually enter your card number")
             Spacer(modifier = Modifier.height(8.dp))
             ComposableForagePANEditText(
-                merchantId,
+                forageConfig,
                 withPanElementReference = withPanElementReference
             )
             Spacer(modifier = Modifier.height(16.dp))
@@ -52,7 +53,7 @@ fun ManualPANEntryScreen(
 @Composable
 fun ManualPANEntryScreenPreview() {
     ManualPANEntryScreen(
-        merchantId = "",
+        forageConfig = ForageConfig("", ""),
         onSubmitButtonClicked = {},
         onBackButtonClicked = {},
         withPanElementReference = {}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/PinEntryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/PinEntryScreen.kt
@@ -10,11 +10,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.joinforage.android.example.ui.pos.ui.ComposableForagePINEditText
+import com.joinforage.forage.android.ui.ForageConfig
 import com.joinforage.forage.android.ui.ForagePINEditText
 
 @Composable
 fun PINEntryScreen(
-    merchantId: String,
+    forageConfig: ForageConfig,
     paymentMethodRef: String?,
     onSubmitButtonClicked: () -> Unit,
     onBackButtonClicked: () -> Unit,
@@ -31,7 +32,7 @@ fun PINEntryScreen(
             if (paymentMethodRef != null) {
                 Text("Enter your card PIN")
                 ComposableForagePINEditText(
-                    merchantId = merchantId,
+                    forageConfig = forageConfig,
                     withPinElementReference = withPinElementReference
                 )
                 Button(onClick = onSubmitButtonClicked) {
@@ -55,7 +56,7 @@ fun PINEntryScreen(
 @Composable
 fun PINEntryScreenPreview() {
     PINEntryScreen(
-        merchantId = "",
+        forageConfig = ForageConfig("", ""),
         paymentMethodRef = "",
         onSubmitButtonClicked = {},
         onBackButtonClicked = {},

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ComposableForagePANEditText.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ComposableForagePANEditText.kt
@@ -3,24 +3,18 @@ package com.joinforage.android.example.ui.pos.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
-import com.joinforage.android.example.ui.pos.network.AUTH_TOKEN
 import com.joinforage.forage.android.ui.ForageConfig
 import com.joinforage.forage.android.ui.ForagePANEditText
 
 @Composable
 fun ComposableForagePANEditText(
-    merchantId: String,
+    forageConfig: ForageConfig,
     withPanElementReference: (element: ForagePANEditText) -> Unit
 ) {
     AndroidView(
         factory = { context ->
             ForagePANEditText(context).apply {
-                this.setForageConfig(
-                    ForageConfig(
-                        merchantId = merchantId,
-                        sessionToken = AUTH_TOKEN
-                    )
-                )
+                this.setForageConfig(forageConfig)
                 this.requestFocus()
                 withPanElementReference(this)
             }
@@ -32,7 +26,7 @@ fun ComposableForagePANEditText(
 @Composable
 fun ComposableForagePANEditTextPreview() {
     ComposableForagePANEditText(
-        merchantId = "",
+        forageConfig = ForageConfig("", ""),
         withPanElementReference = {}
     )
 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ComposableForagePINEditText.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ComposableForagePINEditText.kt
@@ -3,24 +3,18 @@ package com.joinforage.android.example.ui.pos.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
-import com.joinforage.android.example.ui.pos.network.AUTH_TOKEN
 import com.joinforage.forage.android.ui.ForageConfig
 import com.joinforage.forage.android.ui.ForagePINEditText
 
 @Composable
 fun ComposableForagePINEditText(
-    merchantId: String,
+    forageConfig: ForageConfig,
     withPinElementReference: (element: ForagePINEditText) -> Unit
 ) {
     AndroidView(
         factory = { context ->
             ForagePINEditText(context).apply {
-                this.setForageConfig(
-                    ForageConfig(
-                        merchantId = merchantId,
-                        sessionToken = AUTH_TOKEN
-                    )
-                )
+                this.setForageConfig(forageConfig)
                 this.requestFocus()
                 withPinElementReference(this)
             }
@@ -32,7 +26,7 @@ fun ComposableForagePINEditText(
 @Composable
 fun ComposableForagePINEditTextPreview() {
     ComposableForagePINEditText(
-        merchantId = "",
+        forageConfig = ForageConfig("",""),
         withPinElementReference = {}
     )
 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ComposableForagePINEditText.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ComposableForagePINEditText.kt
@@ -26,7 +26,7 @@ fun ComposableForagePINEditText(
 @Composable
 fun ComposableForagePINEditTextPreview() {
     ComposableForagePINEditText(
-        forageConfig = ForageConfig("",""),
+        forageConfig = ForageConfig("", ""),
         withPinElementReference = {}
     )
 }


### PR DESCRIPTION
[House ForageConfig info](https://github.com/teamforage/forage-android-sdk/pull/171/commits/ff3579d5ee96cddcb1024686707d9a826f59474d)


I think the `POSUIState` could be a good home for the `merchantId`
and the `sessionToken`, which together constitute the
`ForageConfig` info. The wins that I see are:
1. easier to work with the `forageConfig` because a single method
    / getting on `POSUIState` will house the `forageConfig`
    Previously, to pass `forageConfig` to the `ForageTerminalSDK`,
    we needed to assemble the `ForageConfig` object ourselves
2. now there is a single file that developers can copy/paste the
    the `sessionToken` and `merchantId` into instead of needing
    to change values across two files