### PR TITLE
Move terminalId to POSComposeApp

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/pos/k9sdk/K9SDK.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/k9sdk/K9SDK.kt
@@ -1,0 +1,98 @@
+package com.joinforage.android.example.pos.k9sdk
+
+import com.pos.sdk.DevicesFactory
+import android.content.Context
+import android.os.RemoteException
+import android.util.Log
+import com.pos.sdk.DeviceManager
+import com.pos.sdk.callback.ResultCallback
+import com.pos.sdk.magcard.IMagCardListener
+import com.pos.sdk.magcard.MagCardDevice
+import com.pos.sdk.magcard.TrackData
+import com.pos.sdk.printer.PrinterDevice
+import com.pos.sdk.sys.SystemDevice
+import okio.ByteString.Companion.decodeHex
+
+enum class DeviceType {
+    K9_TERMINAL,
+    EMULATOR,
+    UNKNOWN
+}
+
+fun hexToAscii(hex: String) = String(hex.decodeHex().toByteArray())
+
+class K9SDK() {
+    private var _deviceManager: DeviceManager? = null
+    private val _printDevice: PrinterDevice?
+        get() = _deviceManager?.printDevice
+    private val _magCardDevice: MagCardDevice?
+        get() = _deviceManager?.magneticDevice
+    private val _systemDevice: SystemDevice?
+        get() = _deviceManager?.systemDevice
+
+    val terminalId: String
+        get() = _systemDevice?.getSystemInfo(SystemDevice.SystemInfoType.SN) ?: "Android Emulator"
+
+    var currentDeviceType: DeviceType = DeviceType.UNKNOWN
+    val isUsable
+        get() = currentDeviceType == DeviceType.K9_TERMINAL
+
+    fun init (context: Context) : K9SDK {
+        DevicesFactory.create(
+            context,
+            object : ResultCallback<DeviceManager> {
+                override fun onFinish(deviceManager: DeviceManager) {
+                    _deviceManager = deviceManager
+                    currentDeviceType = DeviceType.K9_TERMINAL
+                    Log.i("CPay SDK","initialized successfully")
+                }
+
+                override fun onError(i: Int, s: String) {
+                    Log.i("CPay SDK","failed to initialize successfully")
+                    currentDeviceType = DeviceType.EMULATOR
+                }
+            }
+        )
+        return this
+    }
+
+    fun listenForMagneticCardSwipe(
+        onSwipeCardSuccess: (track2Data: String) -> Unit
+    ) : Boolean {
+        // CPay SDK methods should only run if they are supported
+        // by the current runtime env (i.e. the app is being run
+        // on Centerm K9 POS terminal). Otherwise don't run this
+        if (!isUsable) return false
+
+        _magCardDevice?.swipeCard(20000, true, object : IMagCardListener.Stub() {
+            @Throws(RemoteException::class)
+            override fun onSwipeCardTimeout() {
+                Log.i("CPay SDK", "Swipe card time out")
+            }
+
+            @Throws(RemoteException::class)
+            override fun onSwipeCardException(i: Int) {
+                Log.i("CPay SDK", "Swipe card error $i")
+            }
+
+            @Throws(RemoteException::class)
+            override fun onSwipeCardSuccess(trackData: TrackData) {
+                val track2Data = hexToAscii(trackData.secondTrackData)
+                Log.i("CPay SDK", "Parsed track2Data: $track2Data")
+                onSwipeCardSuccess(track2Data)
+            }
+
+            @Throws(RemoteException::class)
+            override fun onSwipeCardFail() {
+                Log.i("CPay SDK", "Swipe card failed ")
+            }
+
+            @Throws(RemoteException::class)
+            override fun onCancelSwipeCard() {
+                Log.i("CPay SDK", "Swipe card canceled")
+            }
+        })
+
+        return true
+    }
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/k9sdk/K9SDK.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/k9sdk/K9SDK.kt
@@ -1,10 +1,10 @@
 package com.joinforage.android.example.pos.k9sdk
 
-import com.pos.sdk.DevicesFactory
 import android.content.Context
 import android.os.RemoteException
 import android.util.Log
 import com.pos.sdk.DeviceManager
+import com.pos.sdk.DevicesFactory
 import com.pos.sdk.callback.ResultCallback
 import com.pos.sdk.magcard.IMagCardListener
 import com.pos.sdk.magcard.MagCardDevice
@@ -37,18 +37,18 @@ class K9SDK() {
     val isUsable
         get() = currentDeviceType == DeviceType.K9_TERMINAL
 
-    fun init (context: Context) : K9SDK {
+    fun init(context: Context): K9SDK {
         DevicesFactory.create(
             context,
             object : ResultCallback<DeviceManager> {
                 override fun onFinish(deviceManager: DeviceManager) {
                     _deviceManager = deviceManager
                     currentDeviceType = DeviceType.K9_TERMINAL
-                    Log.i("CPay SDK","initialized successfully")
+                    Log.i("CPay SDK", "initialized successfully")
                 }
 
                 override fun onError(i: Int, s: String) {
-                    Log.i("CPay SDK","failed to initialize successfully")
+                    Log.i("CPay SDK", "failed to initialize successfully")
                     currentDeviceType = DeviceType.EMULATOR
                 }
             }
@@ -58,40 +58,44 @@ class K9SDK() {
 
     fun listenForMagneticCardSwipe(
         onSwipeCardSuccess: (track2Data: String) -> Unit
-    ) : Boolean {
+    ): Boolean {
         // CPay SDK methods should only run if they are supported
         // by the current runtime env (i.e. the app is being run
         // on Centerm K9 POS terminal). Otherwise don't run this
         if (!isUsable) return false
 
-        _magCardDevice?.swipeCard(20000, true, object : IMagCardListener.Stub() {
-            @Throws(RemoteException::class)
-            override fun onSwipeCardTimeout() {
-                Log.i("CPay SDK", "Swipe card time out")
-            }
+        _magCardDevice?.swipeCard(
+            20000,
+            true,
+            object : IMagCardListener.Stub() {
+                @Throws(RemoteException::class)
+                override fun onSwipeCardTimeout() {
+                    Log.i("CPay SDK", "Swipe card time out")
+                }
 
-            @Throws(RemoteException::class)
-            override fun onSwipeCardException(i: Int) {
-                Log.i("CPay SDK", "Swipe card error $i")
-            }
+                @Throws(RemoteException::class)
+                override fun onSwipeCardException(i: Int) {
+                    Log.i("CPay SDK", "Swipe card error $i")
+                }
 
-            @Throws(RemoteException::class)
-            override fun onSwipeCardSuccess(trackData: TrackData) {
-                val track2Data = hexToAscii(trackData.secondTrackData)
-                Log.i("CPay SDK", "Parsed track2Data: $track2Data")
-                onSwipeCardSuccess(track2Data)
-            }
+                @Throws(RemoteException::class)
+                override fun onSwipeCardSuccess(trackData: TrackData) {
+                    val track2Data = hexToAscii(trackData.secondTrackData)
+                    Log.i("CPay SDK", "Parsed track2Data: $track2Data")
+                    onSwipeCardSuccess(track2Data)
+                }
 
-            @Throws(RemoteException::class)
-            override fun onSwipeCardFail() {
-                Log.i("CPay SDK", "Swipe card failed ")
-            }
+                @Throws(RemoteException::class)
+                override fun onSwipeCardFail() {
+                    Log.i("CPay SDK", "Swipe card failed ")
+                }
 
-            @Throws(RemoteException::class)
-            override fun onCancelSwipeCard() {
-                Log.i("CPay SDK", "Swipe card canceled")
+                @Throws(RemoteException::class)
+                override fun onCancelSwipeCard() {
+                    Log.i("CPay SDK", "Swipe card canceled")
+                }
             }
-        })
+        )
 
         return true
     }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -150,11 +150,12 @@ fun POSComposeApp(
                                 panElement as ForagePANEditText,
                                 k9SDK.terminalId,
                                 onSuccess = {
-                                if (it?.ref != null) {
-                                    Log.i("POSComposeApp", "Successfully tokenized EBT card with ref: $it.ref")
-                                    navController.navigate(POSScreen.BIPINEntryScreen.name)
+                                    if (it?.ref != null) {
+                                        Log.i("POSComposeApp", "Successfully tokenized EBT card with ref: $it.ref")
+                                        navController.navigate(POSScreen.BIPINEntryScreen.name)
+                                    }
                                 }
-                            })
+                            )
                         }
                     },
                     onBackButtonClicked = { navController.popBackStack(POSScreen.BalanceInquiryScreen.name, inclusive = false) },

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -36,13 +36,6 @@ class POSViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(POSUIState())
     val uiState: StateFlow<POSUIState> = _uiState.asStateFlow()
 
-    private var terminalId: String? = "tempDevTerminalId"
-
-    fun setTerminalId(id: String) {
-        terminalId = id
-        _uiState.update { it.copy(terminalId = id) }
-    }
-
     fun setMerchantId(merchantId: String, onSuccess: () -> Unit) {
         _uiState.update { it.copy(merchantId = merchantId) }
         getMerchantInfo(merchantId = merchantId, onSuccess)
@@ -65,12 +58,9 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun tokenizeEBTCard(foragePanEditText: ForagePANEditText, onSuccess: (data: PaymentMethod?) -> Unit) {
-        if (terminalId == null) {
-            throw Error("Invalid POS Terminal ID")
-        }
+    fun tokenizeEBTCard(foragePanEditText: ForagePANEditText, terminalId: String, onSuccess: (data: PaymentMethod?) -> Unit) {
         viewModelScope.launch {
-            val response = ForageTerminalSDK(terminalId!!).tokenizeCard(
+            val response = ForageTerminalSDK(terminalId).tokenizeCard(
                 foragePanEditText = foragePanEditText,
                 reusable = true
             )
@@ -90,13 +80,9 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun checkEBTCardBalance(foragePinEditText: ForagePINEditText, paymentMethodRef: String, onSuccess: (response: BalanceCheck?) -> Unit) {
-        if (terminalId == null) {
-            throw Error("Invalid POS Terminal ID")
-        }
-
+    fun checkEBTCardBalance(foragePinEditText: ForagePINEditText, paymentMethodRef: String, terminalId: String, onSuccess: (response: BalanceCheck?) -> Unit) {
         viewModelScope.launch {
-            val response = ForageTerminalSDK(terminalId!!).checkBalance(
+            val response = ForageTerminalSDK(terminalId).checkBalance(
                 CheckBalanceParams(
                     foragePinEditText = foragePinEditText,
                     paymentMethodRef = paymentMethodRef

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -5,7 +5,6 @@ import com.joinforage.android.example.ui.pos.MerchantDetailsState
 import com.joinforage.forage.android.ui.ForageConfig
 
 data class POSUIState(
-    val terminalId: String? = "tempDevTerminalId",
     val merchantId: String = "",
     val sessionToken: String = "<your_oath_or_session_token>", // <your_oath_or_session_token>,
     val merchantDetailsState: MerchantDetailsState = MerchantDetailsState.Idle,


### PR DESCRIPTION
[Move terminalId to POSComposeApp](https://github.com/teamforage/forage-android-sdk/pull/172/commits/0ea4a6af8ef9cad2db8b8267db2992becb803a40) 

`terminalId` is similar to `sessionToken` and `merchantId` in that
it likely only gets set once with the initial fetch of merchant
details and then, afterwards, will not need to be set again. It
could follow from this that `terminalId` should live alongside
`merchantId` and `sessionToken` inside `POSUIState`.

I am not opposed to `terminalId` ultimately living in
`POSUIState`. However, reading the `terminalId` from the K9SDK
is an asynchronous process because we need to wait for the
K9SDK to finish initializing before we can read the `terminalId`
value.

It was not readily apparent to me how we would request the K9SDK
to initialize once and only once from within `POSComposeApp` and
then after the async initialization has completed, read the value
of `terminalId`. I do believe it's possible to do this and once we
figure this out, this would probably be the better way to go.

In the interest of speed, I opted for using `remember` and then
reading the value of `k9SDK.terminalId` as needed throughout
`POSComposeApp`