### PR TITLE
[FX-742] Create MagSwipe PAN Reader Component (adds to Balance Inquiry flow)

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -166,16 +166,17 @@ fun POSComposeApp(
             }
             composable(route = POSScreen.BIMagSwipePANEntryScreen.name) {
                 MagSwipePANEntryScreen(
-                    onLaunch = { k9SDK.listenForMagneticCardSwipe{ track2Data ->
-                        println("track2Data: $track2Data")
-                        viewModel.tokenizeEBTCard(track2Data, k9SDK.terminalId) {
-                            if (it?.ref != null) {
-                                Log.i("POSComposeApp", "Successfully tokenized EBT card with ref: $it.ref")
-                                navController.navigate(POSScreen.BIPINEntryScreen.name)
+                    onLaunch = {
+                        k9SDK.listenForMagneticCardSwipe { track2Data ->
+                            viewModel.tokenizeEBTCard(track2Data, k9SDK.terminalId) {
+                                if (it?.ref != null) {
+                                    Log.i("POSComposeApp", "Successfully tokenized EBT card with ref: $it.ref")
+                                    navController.navigate(POSScreen.BIPINEntryScreen.name)
+                                }
                             }
                         }
-                    } },
-                    onBackButtonClicked = { navController.popBackStack(POSScreen.BalanceInquiryScreen.name, inclusive = false) },
+                    },
+                    onBackButtonClicked = { navController.popBackStack(POSScreen.BalanceInquiryScreen.name, inclusive = false) }
                 )
             }
             composable(route = POSScreen.BIPINEntryScreen.name) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -37,6 +37,7 @@ import com.joinforage.android.example.ui.pos.screens.MerchantSetupScreen
 import com.joinforage.android.example.ui.pos.screens.balance.BalanceInquiryScreen
 import com.joinforage.android.example.ui.pos.screens.balance.BalanceResultScreen
 import com.joinforage.android.example.ui.pos.screens.payment.PaymentTypeSelectionScreen
+import com.joinforage.android.example.ui.pos.screens.shared.MagSwipePANEntryScreen
 import com.joinforage.android.example.ui.pos.screens.shared.ManualPANEntryScreen
 import com.joinforage.android.example.ui.pos.screens.shared.PINEntryScreen
 import com.joinforage.forage.android.ui.ForagePANEditText
@@ -47,6 +48,7 @@ enum class POSScreen(@StringRes val title: Int) {
     ActionSelectionScreen(title = R.string.title_pos_action_selection),
     BalanceInquiryScreen(title = R.string.title_pos_balance_inquiry),
     BIManualPANEntryScreen(title = R.string.title_pos_manual_pan_entry),
+    BIMagSwipePANEntryScreen(title = R.string.title_pos_mag_swipe_pan_entry),
     BIPINEntryScreen(title = R.string.title_pos_pin_entry),
     BIResultScreen(title = R.string.title_pos_balance_inquiry_result),
     PaymentTypeSelectionScreen(title = R.string.title_pos_payment_type_selection_screen)
@@ -137,7 +139,7 @@ fun POSComposeApp(
             composable(route = POSScreen.BalanceInquiryScreen.name) {
                 BalanceInquiryScreen(
                     onManualEntryButtonClicked = { navController.navigate(POSScreen.BIManualPANEntryScreen.name) },
-                    onSwipeButtonClicked = { /*TODO*/ },
+                    onSwipeButtonClicked = { navController.navigate(POSScreen.BIMagSwipePANEntryScreen.name) },
                     onBackButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
                 )
             }
@@ -160,6 +162,20 @@ fun POSComposeApp(
                     },
                     onBackButtonClicked = { navController.popBackStack(POSScreen.BalanceInquiryScreen.name, inclusive = false) },
                     withPanElementReference = { panElement = it }
+                )
+            }
+            composable(route = POSScreen.BIMagSwipePANEntryScreen.name) {
+                MagSwipePANEntryScreen(
+                    onLaunch = { k9SDK.listenForMagneticCardSwipe{ track2Data ->
+                        println("track2Data: $track2Data")
+                        viewModel.tokenizeEBTCard(track2Data, k9SDK.terminalId) {
+                            if (it?.ref != null) {
+                                Log.i("POSComposeApp", "Successfully tokenized EBT card with ref: $it.ref")
+                                navController.navigate(POSScreen.BIPINEntryScreen.name)
+                            }
+                        }
+                    } },
+                    onBackButtonClicked = { navController.popBackStack(POSScreen.BalanceInquiryScreen.name, inclusive = false) },
                 )
             }
             composable(route = POSScreen.BIPINEntryScreen.name) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/balance/BalanceInquiryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/balance/BalanceInquiryScreen.kt
@@ -27,7 +27,7 @@ fun BalanceInquiryScreen(
             Button(onClick = onManualEntryButtonClicked) {
                 Text("Manually Enter Card Number")
             }
-            Button(onClick = onSwipeButtonClicked, enabled = false) {
+            Button(onClick = onSwipeButtonClicked) {
                 Text("Swipe Card")
             }
         }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/MagSwipePANEntryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/MagSwipePANEntryScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 @Composable
 fun MagSwipePANEntryScreen(
     onLaunch: () -> Unit,
-    onBackButtonClicked: () -> Unit,
+    onBackButtonClicked: () -> Unit
 ) {
     LaunchedEffect(Unit) {
         onLaunch()
@@ -37,6 +37,6 @@ fun MagSwipePANEntryScreen(
 fun MagSwipePANEntryScreenPreview() {
     MagSwipePANEntryScreen(
         onLaunch = {},
-        onBackButtonClicked = {},
+        onBackButtonClicked = {}
     )
 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/MagSwipePANEntryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/MagSwipePANEntryScreen.kt
@@ -1,0 +1,42 @@
+package com.joinforage.android.example.ui.pos.screens.shared
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun MagSwipePANEntryScreen(
+    onLaunch: () -> Unit,
+    onBackButtonClicked: () -> Unit,
+) {
+    LaunchedEffect(Unit) {
+        onLaunch()
+    }
+
+    Column(
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text("Swipe your EBT card now...")
+        Button(onClick = onBackButtonClicked) {
+            Text("Back")
+        }
+    }
+}
+
+@Preview
+@Composable
+fun MagSwipePANEntryScreenPreview() {
+    MagSwipePANEntryScreen(
+        onLaunch = {},
+        onBackButtonClicked = {},
+    )
+}

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="title_pos_action_selection">Select an Action</string>
     <string name="pos_back_button">Back</string>
     <string name="title_pos_manual_pan_entry">Manual Card Entry</string>
+    <string name="title_pos_mag_swipe_pan_entry">Swipe Card Entry</string>
     <string name="title_pos_balance_inquiry">Balance Inquiry</string>
     <string name="title_pos_pin_entry">PIN Entry</string>
     <string name="title_pos_balance_inquiry_result">Balance Inquiry</string>


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Introduces the `MagSwipePANEntryScreen.kt` composable and modifies `POSComposeApp.kt` to use the `MagSwipePANEntryScreen.kt` in order to support magnetic swiping for PAN entry in Balance Inquiries

## Why
https://linear.app/joinforage/issue/FX-742/scene-create-ebt-payment-method-by-swiping-card
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- ❌ <!-- If not, why? --> Mostly manipulated UI and CPay SDK. Plus the end to end flow works so didn't feel the time spent writing tests was urgent for now
- ❌ The combination of passing CI + the demo is sufficient for this. Feel free to try locally if you want though! <!-- If so, please describe how to test below. -->

## Demo

https://github.com/teamforage/forage-android-sdk/assets/12377418/c4b492ac-392a-44a1-8352-005257fd4652


<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
This needs to be merged in after #172 
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
