### PR TITLE
[FX-744] Story: SNAP purchase flow on a created EBT card

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -306,7 +306,7 @@ fun POSComposeApp(
                         if (pinElement != null && uiState.serverPayment?.ref != null) {
                             viewModel.capturePayment(
                                 foragePinEditText = pinElement as ForagePINEditText,
-                                terminalId = K9SDK().terminalId,
+                                terminalId = k9SDK.terminalId,
                                 paymentRef = uiState.serverPayment!!.ref!!,
                                 onSuccess = {
                                     if (it?.ref != null) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -32,9 +32,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.joinforage.android.example.R
 import com.joinforage.android.example.pos.k9sdk.K9SDK
-import com.joinforage.android.example.ui.pos.data.FundingType
 import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
-import com.joinforage.android.example.ui.pos.data.PosTerminal
 import com.joinforage.android.example.ui.pos.screens.ActionSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.MerchantSetupScreen
 import com.joinforage.android.example.ui.pos.screens.balance.BalanceResultScreen
@@ -228,14 +226,7 @@ fun POSComposeApp(
             composable(route = POSScreen.PAYSnapPurchaseScreen.name) {
                 EBTSnapPurchaseScreen(
                     onConfirmButtonClicked = { snapAmount ->
-                        val payment = PosPaymentRequest(
-                            amount = snapAmount,
-                            description = "Testing POS certification app payments (SNAP Purchase)",
-                            fundingType = FundingType.EBTSnap.value,
-                            paymentMethodRef = "",
-                            posTerminal = PosTerminal(providerTerminalId = k9SDK.terminalId),
-                            metadata = mapOf()
-                        )
+                        val payment = PosPaymentRequest.forSnapPayment(snapAmount, k9SDK.terminalId)
                         viewModel.setLocalPayment(payment = payment)
                         navController.navigate(POSScreen.PAYChoosePANMethodScreen.name)
                     },

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -31,18 +31,18 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.joinforage.android.example.R
+import com.joinforage.android.example.pos.k9sdk.K9SDK
 import com.joinforage.android.example.ui.pos.data.FundingType
 import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
 import com.joinforage.android.example.ui.pos.data.PosTerminal
-import com.joinforage.android.example.pos.k9sdk.K9SDK
 import com.joinforage.android.example.ui.pos.screens.ActionSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.MerchantSetupScreen
-import com.joinforage.android.example.ui.pos.screens.shared.PANMethodSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.balance.BalanceResultScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTSnapPurchaseScreen
 import com.joinforage.android.example.ui.pos.screens.payment.PaymentTypeSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.shared.MagSwipePANEntryScreen
 import com.joinforage.android.example.ui.pos.screens.shared.ManualPANEntryScreen
+import com.joinforage.android.example.ui.pos.screens.shared.PANMethodSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.shared.PINEntryScreen
 import com.joinforage.forage.android.ui.ForagePANEditText
 import com.joinforage.forage.android.ui.ForagePINEditText
@@ -250,7 +250,8 @@ fun POSComposeApp(
                 PANMethodSelectionScreen(
                     onManualEntryButtonClicked = { navController.navigate(POSScreen.PAYManualPANEntryScreen.name) },
                     onSwipeButtonClicked = { /*TODO*/ },
-                    onBackButtonClicked = { navController.popBackStack(POSScreen.PaymentTypeSelectionScreen.name, inclusive = false) })
+                    onBackButtonClicked = { navController.popBackStack(POSScreen.PaymentTypeSelectionScreen.name, inclusive = false) }
+                )
             }
             composable(route = POSScreen.PAYManualPANEntryScreen.name) {
                 ManualPANEntryScreen(
@@ -263,7 +264,7 @@ fun POSComposeApp(
                                 panElement as ForagePANEditText,
                                 k9SDK.terminalId,
                                 onSuccess = {
-                                    Log.i("POSComposeApp", "payment method? — ${it.toString()}")
+                                    Log.i("POSComposeApp", "payment method? — $it")
                                     if (it?.ref != null) {
                                         Log.i("POSComposeApp", "Successfully tokenized EBT card with ref: $it.ref")
                                         navController.navigate(POSScreen.PaymentTypeSelectionScreen.name)
@@ -284,6 +285,7 @@ fun POSComposeApp(
                         if (pinElement != null && uiState.payment?.ref != null) {
                             viewModel.capturePayment(
                                 foragePinEditText = pinElement as ForagePINEditText,
+                                terminalId = K9SDK().terminalId,
                                 paymentRef = uiState.payment!!.ref!!
                             )
                         }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -301,13 +301,13 @@ fun POSComposeApp(
             composable(route = POSScreen.PAYPINEntryScreen.name) {
                 PINEntryScreen(
                     forageConfig = uiState.forageConfig,
-                    paymentMethodRef = uiState.serverPayment?.paymentMethod,
+                    paymentMethodRef = uiState.createPaymentResponse?.paymentMethod,
                     onSubmitButtonClicked = {
-                        if (pinElement != null && uiState.serverPayment?.ref != null) {
+                        if (pinElement != null && uiState.createPaymentResponse?.ref != null) {
                             viewModel.capturePayment(
                                 foragePinEditText = pinElement as ForagePINEditText,
                                 terminalId = k9SDK.terminalId,
-                                paymentRef = uiState.serverPayment!!.ref!!,
+                                paymentRef = uiState.createPaymentResponse!!.ref!!,
                                 onSuccess = {
                                     if (it?.ref != null) {
                                         navController.navigate(POSScreen.PAYResultScreen.name)
@@ -322,7 +322,7 @@ fun POSComposeApp(
             }
             composable(route = POSScreen.PAYResultScreen.name) {
                 PaymentResultScreen(
-                    data = uiState.paymentResponse.toString()
+                    data = uiState.capturePaymentResponse.toString()
                 )
             }
         }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -69,15 +69,16 @@ class POSViewModel : ViewModel() {
         viewModelScope.launch {
             try {
                 val response = PosApi.retrofitService.createPayment(
+                    authorization = uiState.value.sessionToken,
                     merchantId = merchantId,
                     idempotencyKey = idempotencyKey,
                     payment = payment
                 )
                 _uiState.update { it.copy(payment = response) }
                 onSuccess(response)
-                Log.i("POSViewModel", "Create payment call succeeded: ${response.toString()}")
+                Log.i("POSViewModel", "Create payment call succeeded: $response")
             } catch (e: HttpException) {
-                Log.e("POSViewModel", "Create payment call failed: ${e.toString()}")
+                Log.e("POSViewModel", "Create payment call failed: $e")
             }
         }
     }
@@ -153,7 +154,7 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun capturePayment(foragePinEditText: ForagePINEditText, paymentRef: String) {
+    fun capturePayment(foragePinEditText: ForagePINEditText, terminalId: String, paymentRef: String) {
         viewModelScope.launch {
             val response = ForageTerminalSDK(terminalId).capturePayment(
                 CapturePaymentParams(

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -79,7 +79,7 @@ class POSViewModel : ViewModel() {
                     idempotencyKey = idempotencyKey,
                     payment = payment
                 )
-                _uiState.update { it.copy(serverPayment = response) }
+                _uiState.update { it.copy(createPaymentResponse = response) }
                 onSuccess(response)
                 Log.i("POSViewModel", "Create payment call succeeded: $response")
             } catch (e: HttpException) {
@@ -173,7 +173,7 @@ class POSViewModel : ViewModel() {
                     val moshi = Moshi.Builder().build()
                     val jsonAdapter: JsonAdapter<PaymentResponse> = PaymentResponseJsonAdapter(moshi)
                     val paymentResponse = jsonAdapter.fromJson(response.data)
-                    _uiState.update { it.copy(paymentResponse = paymentResponse) }
+                    _uiState.update { it.copy(capturePaymentResponse = paymentResponse) }
                     onSuccess(paymentResponse)
                 }
                 is ForageApiResponse.Failure -> {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -11,7 +11,9 @@ data class POSUIState(
     val merchantDetailsState: MerchantDetailsState = MerchantDetailsState.Idle,
     val tokenizedPaymentMethod: PaymentMethod? = null,
     val balance: BalanceCheck? = null,
-    val payment: PaymentResponse? = null
+    val localPayment: PosPaymentRequest? = null,
+    val serverPayment: PaymentResponse? = null,
+    val paymentResponse: PaymentResponse? = null
 ) {
     val forageConfig: ForageConfig
         get() = ForageConfig(merchantId, sessionToken)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -1,5 +1,6 @@
 package com.joinforage.android.example.ui.pos.data
 
+import com.joinforage.android.example.network.model.PaymentResponse
 import com.joinforage.android.example.network.model.tokenize.PaymentMethod
 import com.joinforage.android.example.ui.pos.MerchantDetailsState
 import com.joinforage.forage.android.ui.ForageConfig
@@ -9,7 +10,8 @@ data class POSUIState(
     val sessionToken: String = "<your_oath_or_session_token>", // <your_oath_or_session_token>,
     val merchantDetailsState: MerchantDetailsState = MerchantDetailsState.Idle,
     val tokenizedPaymentMethod: PaymentMethod? = null,
-    val balance: BalanceCheck? = null
+    val balance: BalanceCheck? = null,
+    val payment: PaymentResponse? = null,
 ) {
     val forageConfig: ForageConfig
         get() = ForageConfig(merchantId, sessionToken)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -11,7 +11,7 @@ data class POSUIState(
     val merchantDetailsState: MerchantDetailsState = MerchantDetailsState.Idle,
     val tokenizedPaymentMethod: PaymentMethod? = null,
     val balance: BalanceCheck? = null,
-    val payment: PaymentResponse? = null,
+    val payment: PaymentResponse? = null
 ) {
     val forageConfig: ForageConfig
         get() = ForageConfig(merchantId, sessionToken)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -12,8 +12,8 @@ data class POSUIState(
     val tokenizedPaymentMethod: PaymentMethod? = null,
     val balance: BalanceCheck? = null,
     val localPayment: PosPaymentRequest? = null,
-    val serverPayment: PaymentResponse? = null,
-    val paymentResponse: PaymentResponse? = null
+    val createPaymentResponse: PaymentResponse? = null,
+    val capturePaymentResponse: PaymentResponse? = null
 ) {
     val forageConfig: ForageConfig
         get() = ForageConfig(merchantId, sessionToken)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
@@ -3,7 +3,6 @@ package com.joinforage.android.example.ui.pos.data
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
-
 @JsonClass(generateAdapter = true)
 data class PosPaymentRequest(
     val amount: Double,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
@@ -11,7 +11,18 @@ data class PosPaymentRequest(
     val description: String,
     @Json(name = "pos_terminal") val posTerminal: PosTerminal,
     val metadata: Map<String, String>
-)
+) {
+    companion object {
+        fun forSnapPayment(snapAmount: Double, terminalId: String) = PosPaymentRequest(
+            amount = snapAmount,
+            description = "Testing POS certification app payments (SNAP Purchase)",
+            fundingType = FundingType.EBTSnap.value,
+            paymentMethodRef = "",
+            posTerminal = PosTerminal(providerTerminalId = terminalId),
+            metadata = mapOf()
+        )
+    }
+}
 
 enum class FundingType(val value: String) {
     EBTSnap(value = "ebt_snap"),

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
@@ -1,0 +1,35 @@
+package com.joinforage.android.example.ui.pos.data
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+
+val tempDevAddress = Address(
+    line1 = "",
+    line2 = "",
+    city = "",
+    state = "",
+    country = "",
+    zipcode = ""
+)
+
+@JsonClass(generateAdapter = true)
+data class PosPaymentRequest(
+    val amount: Double,
+    @Json(name = "funding_type") val fundingType: String,
+    @Json(name = "payment_method") val paymentMethodRef: String,
+    val description: String,
+    @Json(name = "pos_terminal") val posTerminal: PosTerminal,
+    val metadata: Map<String, String>
+)
+
+enum class FundingType(val value: String) {
+    EBTSnap(value = "ebt_snap"),
+    EBTCash(value = "ebt_cash"),
+    CreditTPP(value = "credit_tpp"),
+}
+
+@JsonClass(generateAdapter = true)
+data class PosTerminal(
+    @Json(name = "provider_terminal_id") val providerTerminalId: String,
+)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
@@ -4,15 +4,6 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 
-val tempDevAddress = Address(
-    line1 = "",
-    line2 = "",
-    city = "",
-    state = "",
-    country = "",
-    zipcode = ""
-)
-
 @JsonClass(generateAdapter = true)
 data class PosPaymentRequest(
     val amount: Double,
@@ -26,10 +17,10 @@ data class PosPaymentRequest(
 enum class FundingType(val value: String) {
     EBTSnap(value = "ebt_snap"),
     EBTCash(value = "ebt_cash"),
-    CreditTPP(value = "credit_tpp"),
+    CreditTPP(value = "credit_tpp")
 }
 
 @JsonClass(generateAdapter = true)
 data class PosTerminal(
-    @Json(name = "provider_terminal_id") val providerTerminalId: String,
+    @Json(name = "provider_terminal_id") val providerTerminalId: String
 )

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
@@ -1,12 +1,16 @@
 package com.joinforage.android.example.ui.pos.network
 
+import com.joinforage.android.example.network.model.PaymentResponse
 import com.joinforage.android.example.ui.pos.data.Merchant
+import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.POST
 
 private const val BASE_URL = "https://api.dev.joinforage.app"
 
@@ -25,6 +29,14 @@ interface PosApiService {
         @Header("Authorization") authorization: String,
         @Header("Merchant-Account") merchantId: String
     ): Merchant
+
+    @POST("api/payments/")
+    suspend fun createPayment(
+        @Header("Authorization") authorization: String,
+        @Header("Merchant-Account") merchantId: String,
+        @Header("Idempotency-Key") idempotencyKey: String,
+        @Body payment: PosPaymentRequest
+    ): PaymentResponse
 }
 
 object PosApi {
@@ -32,4 +44,5 @@ object PosApi {
         retrofit.create(PosApiService::class.java)
     }
 }
+
 fun formatAuthHeader(sessionToken: String) = "Bearer $sessionToken"

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/EBTSnapPurchaseScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/EBTSnapPurchaseScreen.kt
@@ -1,0 +1,66 @@
+package com.joinforage.android.example.ui.pos.screens.payment
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
+
+@Composable
+fun EBTSnapPurchaseScreen(
+    onConfirmButtonClicked: (snapAmount: Double) -> Unit,
+    onCancelButtonClicked: () -> Unit
+) {
+    var snapAmount by rememberSaveable {
+        mutableStateOf("")
+    }
+
+    ScreenWithBottomRow(
+        mainContent = {
+            Text("SNAP Purchase", fontSize = 18.sp)
+            OutlinedTextField(
+                value = snapAmount,
+                onValueChange = { snapAmount = it },
+                label = { Text("SNAP Dollar Amount") },
+                prefix = { Text("$") },
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
+                )
+            )
+        },
+        bottomRowContent = {
+            Button(onClick = onCancelButtonClicked, colors = ButtonDefaults.elevatedButtonColors()) {
+                Text("Cancel")
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Button(onClick = { onConfirmButtonClicked(snapAmount.toDouble()) }) {
+                Text("Confirm")
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+fun EBTSnapPurchaseScreenPreview() {
+    EBTSnapPurchaseScreen(
+        onConfirmButtonClicked = {},
+        onCancelButtonClicked = {}
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/EBTSnapPurchaseScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/EBTSnapPurchaseScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentResultScreen.kt
@@ -1,0 +1,23 @@
+package com.joinforage.android.example.ui.pos.screens.payment
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun PaymentResultScreen(
+    data: String
+) {
+    Column {
+        Text(data)
+    }
+}
+
+@Preview
+@Composable
+fun PaymentResultScreenPreview() {
+    PaymentResultScreen(
+        data = "some data"
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentTypeSelectionScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentTypeSelectionScreen.kt
@@ -38,7 +38,7 @@ fun PaymentTypeSelectionScreen(
         ) {
             Text("Select a transaction type", fontSize = 18.sp)
             Spacer(modifier = Modifier.height(12.dp))
-            Button(onClick = onSnapPurchaseClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
+            Button(onClick = onSnapPurchaseClicked, modifier = Modifier.fillMaxWidth()) {
                 Text("EBT SNAP Purchase")
             }
             Spacer(modifier = Modifier.height(4.dp))

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/PANMethodSelectionScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/PANMethodSelectionScreen.kt
@@ -1,4 +1,4 @@
-package com.joinforage.android.example.ui.pos.screens.balance
+package com.joinforage.android.example.ui.pos.screens.shared
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -12,7 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
-fun BalanceInquiryScreen(
+fun PANMethodSelectionScreen(
     onManualEntryButtonClicked: () -> Unit,
     onSwipeButtonClicked: () -> Unit,
     onBackButtonClicked: () -> Unit
@@ -41,8 +41,8 @@ fun BalanceInquiryScreen(
 
 @Preview
 @Composable
-fun BalanceInquiryScreenPreview() {
-    BalanceInquiryScreen(
+fun PANMethodSelectionScreenPreview() {
+    PANMethodSelectionScreen(
         onManualEntryButtonClicked = {},
         onSwipeButtonClicked = {},
         onBackButtonClicked = {}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ScreenWithBottomRow.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/ui/ScreenWithBottomRow.kt
@@ -1,0 +1,35 @@
+package com.joinforage.android.example.ui.pos.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+inline fun ScreenWithBottomRow(
+    mainContent: @Composable ColumnScope.() -> Unit,
+    bottomRowContent: @Composable RowScope.() -> Unit
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            mainContent()
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            bottomRowContent()
+        }
+    }
+}

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -39,4 +39,6 @@
     <string name="title_pos_payment_choose_pan_method">Create a Payment / Purchase</string>
     <string name="title_pos_payment_manual_pan_entry">Manual Card Entry</string>
     <string name="title_pos_payment_pin_entry">PIN Entry</string>
+    <string name="title_pos_payment_swipe_card_entry">Swipe Card Entry</string>
+    <string name="title_pos_payment_receipt">Payment Receipt</string>
 </resources>

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -35,4 +35,8 @@
     <string name="title_pos_pin_entry">PIN Entry</string>
     <string name="title_pos_balance_inquiry_result">Balance Inquiry</string>
     <string name="title_pos_payment_type_selection_screen">Create a Payment / Purchase</string>
+    <string name="title_pos_payment_snap_purchase_screen">Create a Payment / Purchase</string>
+    <string name="title_pos_payment_choose_pan_method">Create a Payment / Purchase</string>
+    <string name="title_pos_payment_manual_pan_entry">Manual Card Entry</string>
+    <string name="title_pos_payment_pin_entry">PIN Entry</string>
 </resources>


### PR DESCRIPTION
## What
Supports a SNAP payment on a manually entered or swiped EBT card. Just dumps the response data into a text field for now. We'll need to connect it up to the receipt code in a future PR.

## Why
https://linear.app/joinforage/issue/FX-744/story-snap-purchase-flow-on-a-created-ebt-card

## Test Plan

- ❌ Just getting basic functionality built out
- ❌ Demo video should be sufficient for manual entry, but we might want to confirm it on the terminal to make sure swiped entry works

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/55670622-9f78-455d-a361-04928da10ce1

## How
Can be merged as-is