### PR TITLE
[FX-745] Story: EBT Cash purchase flow on a created EBT card

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -36,6 +36,7 @@ import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
 import com.joinforage.android.example.ui.pos.screens.ActionSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.MerchantSetupScreen
 import com.joinforage.android.example.ui.pos.screens.balance.BalanceResultScreen
+import com.joinforage.android.example.ui.pos.screens.payment.EBTCashPurchaseScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTSnapPurchaseScreen
 import com.joinforage.android.example.ui.pos.screens.payment.PaymentResultScreen
 import com.joinforage.android.example.ui.pos.screens.payment.PaymentTypeSelectionScreen
@@ -56,9 +57,10 @@ enum class POSScreen(@StringRes val title: Int) {
     BIResultScreen(title = R.string.title_pos_balance_inquiry_result),
     PAYTransactionTypeSelectionScreen(title = R.string.title_pos_payment_type_selection_screen),
     PAYChoosePANMethodScreen(title = R.string.title_pos_payment_choose_pan_method),
+    PAYSnapPurchaseScreen(title = R.string.title_pos_payment_snap_purchase_screen),
+    PAYEBTCashPurchaseScreen(title = R.string.title_pos_payment_ebt_cash),
     PAYManualPANEntryScreen(title = R.string.title_pos_payment_manual_pan_entry),
     PAYMagSwipePANEntryScreen(title = R.string.title_pos_payment_swipe_card_entry),
-    PAYSnapPurchaseScreen(title = R.string.title_pos_payment_snap_purchase_screen),
     PAYPINEntryScreen(title = R.string.title_pos_payment_pin_entry),
     PAYResultScreen(title = R.string.title_pos_payment_receipt)
 }
@@ -217,7 +219,7 @@ fun POSComposeApp(
             composable(route = POSScreen.PAYTransactionTypeSelectionScreen.name) {
                 PaymentTypeSelectionScreen(
                     onSnapPurchaseClicked = { navController.navigate(POSScreen.PAYSnapPurchaseScreen.name) },
-                    onCashPurchaseClicked = { /*TODO*/ },
+                    onCashPurchaseClicked = { navController.navigate(POSScreen.PAYEBTCashPurchaseScreen.name) },
                     onCashWithdrawalClicked = { /*TODO*/ },
                     onCashPurchaseCashbackClicked = { /*TODO*/ },
                     onCancelButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
@@ -228,6 +230,16 @@ fun POSComposeApp(
                     onConfirmButtonClicked = { snapAmount ->
                         val payment = PosPaymentRequest.forSnapPayment(snapAmount, k9SDK.terminalId)
                         viewModel.setLocalPayment(payment = payment)
+                        navController.navigate(POSScreen.PAYChoosePANMethodScreen.name)
+                    },
+                    onCancelButtonClicked = { navController.popBackStack(POSScreen.PAYTransactionTypeSelectionScreen.name, inclusive = false) }
+                )
+            }
+            composable(route = POSScreen.PAYEBTCashPurchaseScreen.name) {
+                EBTCashPurchaseScreen(
+                    onConfirmButtonClicked = { ebtCashAmount ->
+                        val payment = PosPaymentRequest.forEbtCashPayment(ebtCashAmount, k9SDK.terminalId)
+                        viewModel.setLocalPayment(payment)
                         navController.navigate(POSScreen.PAYChoosePANMethodScreen.name)
                     },
                     onCancelButtonClicked = { navController.popBackStack(POSScreen.PAYTransactionTypeSelectionScreen.name, inclusive = false) }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
@@ -21,6 +21,14 @@ data class PosPaymentRequest(
             posTerminal = PosTerminal(providerTerminalId = terminalId),
             metadata = mapOf()
         )
+        fun forEbtCashPayment(ebtCashAmount: Double, terminalId: String) = PosPaymentRequest(
+            amount = ebtCashAmount,
+            description = "Testing POS certification app payments (EBT Cash Purchase)",
+            fundingType = FundingType.EBTCash.value,
+            paymentMethodRef = "",
+            posTerminal = PosTerminal(providerTerminalId = terminalId),
+            metadata = mapOf()
+        )
     }
 }
 

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/EBTCashPurchaseScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/EBTCashPurchaseScreen.kt
@@ -1,0 +1,65 @@
+package com.joinforage.android.example.ui.pos.screens.payment
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
+
+@Composable
+fun EBTCashPurchaseScreen(
+    onConfirmButtonClicked: (amount: Double) -> Unit,
+    onCancelButtonClicked: () -> Unit
+) {
+    var ebtCashAmount by rememberSaveable {
+        mutableStateOf("")
+    }
+
+    ScreenWithBottomRow(
+        mainContent = {
+            Text("EBT Cash Purchase (no cashback)", fontSize = 18.sp)
+            OutlinedTextField(
+                value = ebtCashAmount,
+                onValueChange = { ebtCashAmount = it },
+                label = { Text("EBT Cash Dollar Amount") },
+                prefix = { Text("$") },
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
+                )
+            )
+        },
+        bottomRowContent = {
+            Button(onClick = onCancelButtonClicked, colors = ButtonDefaults.elevatedButtonColors()) {
+                Text("Cancel")
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Button(onClick = { onConfirmButtonClicked(ebtCashAmount.toDouble()) }) {
+                Text("Confirm")
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+fun EBTCashPurchaseScreenPreview() {
+    EBTCashPurchaseScreen(
+        onConfirmButtonClicked = {},
+        onCancelButtonClicked = {}
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentTypeSelectionScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentTypeSelectionScreen.kt
@@ -42,7 +42,7 @@ fun PaymentTypeSelectionScreen(
                 Text("EBT SNAP Purchase")
             }
             Spacer(modifier = Modifier.height(4.dp))
-            Button(onClick = onCashPurchaseClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
+            Button(onClick = onCashPurchaseClicked, modifier = Modifier.fillMaxWidth()) {
                 Text("EBT Cash Purchase")
             }
             Spacer(modifier = Modifier.height(4.dp))

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -41,4 +41,5 @@
     <string name="title_pos_payment_pin_entry">PIN Entry</string>
     <string name="title_pos_payment_swipe_card_entry">Swipe Card Entry</string>
     <string name="title_pos_payment_receipt">Payment Receipt</string>
+    <string name="title_pos_payment_ebt_cash">Create a Payment / Purchase</string>
 </resources>


### PR DESCRIPTION
## What
Adds support for an EBT Cash purchase to the POS Cert app

## Why
https://linear.app/joinforage/issue/FX-745/story-cash-purchase-flow-on-a-created-ebt-card

## Test Plan
- ❌ Just building out the basic functionality
- ❌ Demo should be sufficient for manual entry but we may want to test swiped entry on the actual terminal

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/c6423a5f-4dad-40de-bbc9-030e296a5daa

## How
Can be merged as-is