### PR TITLE
Infer api baseUrl from sessionToken

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -6,8 +6,8 @@ import com.joinforage.android.example.ui.pos.MerchantDetailsState
 import com.joinforage.forage.android.ui.ForageConfig
 
 data class POSUIState(
-    val merchantId: String = "",
-    val sessionToken: String = "<your_oath_or_session_token>", // <your_oath_or_session_token>,
+    val merchantId: String = "<your_merchant_id>", // <your_merchant_id>
+    val sessionToken: String = "<your_oath_or_session_token>", // <your_oath_or_session_token>
     val merchantDetailsState: MerchantDetailsState = MerchantDetailsState.Idle,
     val tokenizedPaymentMethod: PaymentMethod? = null,
     val balance: BalanceCheck? = null,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
@@ -16,7 +16,6 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
 
-
 private val moshi = Moshi.Builder()
     .addLast(KotlinJsonAdapterFactory())
     .build()
@@ -32,7 +31,7 @@ interface PosApiService {
     ): PaymentResponse
 
     companion object {
-        internal fun from(forageConfig: ForageConfig) : PosApiService {
+        internal fun from(forageConfig: ForageConfig): PosApiService {
             val commonHeadersInterceptor = Interceptor { chain ->
                 val newRequest = chain.request().newBuilder()
                     .addHeader("Authorization", "Bearer ${forageConfig.sessionToken}")

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
@@ -1,10 +1,14 @@
 package com.joinforage.android.example.ui.pos.network
 
+import com.joinforage.android.example.network.model.EnvConfig
 import com.joinforage.android.example.network.model.PaymentResponse
 import com.joinforage.android.example.ui.pos.data.Merchant
 import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
+import com.joinforage.forage.android.ui.ForageConfig
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.Body
@@ -12,37 +16,44 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
 
-private const val BASE_URL = "https://api.dev.joinforage.app"
 
 private val moshi = Moshi.Builder()
     .addLast(KotlinJsonAdapterFactory())
     .build()
 
-private val retrofit = Retrofit.Builder()
-    .baseUrl(BASE_URL)
-    .addConverterFactory(MoshiConverterFactory.create(moshi))
-    .build()
-
 interface PosApiService {
     @GET("api/merchants/")
-    suspend fun getMerchantInfo(
-        @Header("Authorization") authorization: String,
-        @Header("Merchant-Account") merchantId: String
-    ): Merchant
+    suspend fun getMerchantInfo(): Merchant
 
     @POST("api/payments/")
     suspend fun createPayment(
-        @Header("Authorization") authorization: String,
-        @Header("Merchant-Account") merchantId: String,
         @Header("Idempotency-Key") idempotencyKey: String,
         @Body payment: PosPaymentRequest
     ): PaymentResponse
-}
 
-object PosApi {
-    val retrofitService: PosApiService by lazy {
-        retrofit.create(PosApiService::class.java)
+    companion object {
+        internal fun from(forageConfig: ForageConfig) : PosApiService {
+            val commonHeadersInterceptor = Interceptor { chain ->
+                val newRequest = chain.request().newBuilder()
+                    .addHeader("Authorization", "Bearer ${forageConfig.sessionToken}")
+                    .addHeader("Merchant-Account", forageConfig.merchantId)
+                    .build()
+                chain.proceed(newRequest)
+            }
+
+            val okHttpClient = OkHttpClient.Builder()
+                .addInterceptor(commonHeadersInterceptor)
+                .build()
+
+            val env = EnvConfig.fromSessionToken(forageConfig.sessionToken)
+
+            val retrofit = Retrofit.Builder()
+                .baseUrl(env.baseUrl)
+                .client(okHttpClient)
+                .addConverterFactory(MoshiConverterFactory.create(moshi))
+                .build()
+
+            return retrofit.create(PosApiService::class.java)
+        }
     }
 }
-
-fun formatAuthHeader(sessionToken: String) = "Bearer $sessionToken"


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Modify the `PosApiService` so that the baseUrl is determined at runtime based on the value of the `sessionToken` or `authToken` passed.

<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
 Previously the baseUrl was hardcoded to `dev`, which was fine for local Android development. However, we also need the ability to test the Sample App in the `cert` environment for the actual FIS Cert testing as well as preparing for that.

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
The CI tests passing + the demo below give sufficient confidence for now.

## Demo
(will attach via github)

<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
Can be released as is
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
