### PR TITLE
[FX-748] Story: EBT cash withdrawal flow

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -37,6 +37,7 @@ import com.joinforage.android.example.ui.pos.screens.ActionSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.MerchantSetupScreen
 import com.joinforage.android.example.ui.pos.screens.balance.BalanceResultScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTCashPurchaseScreen
+import com.joinforage.android.example.ui.pos.screens.payment.EBTCashWithdrawalScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTCashPurchaseWithCashBackScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTSnapPurchaseScreen
 import com.joinforage.android.example.ui.pos.screens.payment.PaymentResultScreen
@@ -60,6 +61,7 @@ enum class POSScreen(@StringRes val title: Int) {
     PAYChoosePANMethodScreen(title = R.string.title_pos_payment_choose_pan_method),
     PAYSnapPurchaseScreen(title = R.string.title_pos_payment_snap_purchase_screen),
     PAYEBTCashPurchaseScreen(title = R.string.title_pos_payment_ebt_cash),
+    PAYEBTCashWithdrawalScreen(title = R.string.title_pos_payment_cash_withdrawal),
     PAYEBTCashPurchaseWithCashBackScreen(title = R.string.title_pos_payment_with_cashback),
     PAYManualPANEntryScreen(title = R.string.title_pos_payment_manual_pan_entry),
     PAYMagSwipePANEntryScreen(title = R.string.title_pos_payment_swipe_card_entry),
@@ -222,7 +224,7 @@ fun POSComposeApp(
                 PaymentTypeSelectionScreen(
                     onSnapPurchaseClicked = { navController.navigate(POSScreen.PAYSnapPurchaseScreen.name) },
                     onCashPurchaseClicked = { navController.navigate(POSScreen.PAYEBTCashPurchaseScreen.name) },
-                    onCashWithdrawalClicked = { /*TODO*/ },
+                    onCashWithdrawalClicked = { navController.navigate(POSScreen.PAYEBTCashWithdrawalScreen.name) },
                     onCashPurchaseCashbackClicked = { navController.navigate(POSScreen.PAYEBTCashPurchaseWithCashBackScreen.name) },
                     onCancelButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
                 )
@@ -241,6 +243,16 @@ fun POSComposeApp(
                 EBTCashPurchaseScreen(
                     onConfirmButtonClicked = { ebtCashAmount ->
                         val payment = PosPaymentRequest.forEbtCashPayment(ebtCashAmount, k9SDK.terminalId)
+                        viewModel.setLocalPayment(payment)
+                        navController.navigate(POSScreen.PAYChoosePANMethodScreen.name)
+                    },
+                    onCancelButtonClicked = { navController.popBackStack(POSScreen.PAYTransactionTypeSelectionScreen.name, inclusive = false) }
+                )
+            }
+            composable(route = POSScreen.PAYEBTCashWithdrawalScreen.name) {
+                EBTCashWithdrawalScreen(
+                    onConfirmButtonClicked = { ebtCashWithdrawalAmount ->
+                        val payment = PosPaymentRequest.forEbtCashWithdrawal(ebtCashWithdrawalAmount, k9SDK.terminalId)
                         viewModel.setLocalPayment(payment)
                         navController.navigate(POSScreen.PAYChoosePANMethodScreen.name)
                     },

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -37,8 +37,8 @@ import com.joinforage.android.example.ui.pos.screens.ActionSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.MerchantSetupScreen
 import com.joinforage.android.example.ui.pos.screens.balance.BalanceResultScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTCashPurchaseScreen
-import com.joinforage.android.example.ui.pos.screens.payment.EBTCashWithdrawalScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTCashPurchaseWithCashBackScreen
+import com.joinforage.android.example.ui.pos.screens.payment.EBTCashWithdrawalScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTSnapPurchaseScreen
 import com.joinforage.android.example.ui.pos.screens.payment.PaymentResultScreen
 import com.joinforage.android.example.ui.pos.screens.payment.PaymentTypeSelectionScreen

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
@@ -31,6 +31,15 @@ data class PosPaymentRequest(
             posTerminal = PosTerminal(providerTerminalId = terminalId),
             metadata = mapOf()
         )
+        fun forEbtCashWithdrawal(ebtCashWithdrawalAmount: Double, terminalId: String) = PosPaymentRequest(
+            amount = ebtCashWithdrawalAmount,
+            description = "Testing POS certification app payments (EBT Cash Withdrawal)",
+            fundingType = FundingType.EBTCash.value,
+            paymentMethodRef = "",
+            posTerminal = PosTerminal(providerTerminalId = terminalId),
+            metadata = mapOf(),
+            transactionType = TransactionType.Withdrawal.value
+        )
         fun forEbtCashPaymentWithCashBack(ebtCashAmount: Double, cashBackAmount: Double, terminalId: String) = PosPaymentRequest(
             amount = ebtCashAmount + cashBackAmount,
             cashBackAmount = cashBackAmount,
@@ -51,6 +60,7 @@ enum class FundingType(val value: String) {
 }
 
 enum class TransactionType(val value: String) {
+    Withdrawal(value = "withdrawal"),
     PurchaseWithCashBack(value = "purchase_with_cash_back")
 }
 

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/EBTCashWithdrawalScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/EBTCashWithdrawalScreen.kt
@@ -35,7 +35,7 @@ fun EBTCashWithdrawalScreen(
             OutlinedTextField(
                 value = ebtCashWithdrawalAmount,
                 onValueChange = { ebtCashWithdrawalAmount = it },
-                label = { Text("EBT Cash Withdrawal Dollar Amount") },
+                label = { Text("Withdrawal Amount") },
                 prefix = { Text("$") },
                 keyboardOptions = KeyboardOptions.Default.copy(
                     keyboardType = KeyboardType.Number,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/EBTCashWithdrawalScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/EBTCashWithdrawalScreen.kt
@@ -1,0 +1,65 @@
+package com.joinforage.android.example.ui.pos.screens.payment
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
+
+@Composable
+fun EBTCashWithdrawalScreen(
+    onConfirmButtonClicked: (amount: Double) -> Unit,
+    onCancelButtonClicked: () -> Unit
+) {
+    var ebtCashWithdrawalAmount by rememberSaveable {
+        mutableStateOf("")
+    }
+
+    ScreenWithBottomRow(
+        mainContent = {
+            Text("EBT Cash Purchase (no cashback)", fontSize = 18.sp)
+            OutlinedTextField(
+                value = ebtCashWithdrawalAmount,
+                onValueChange = { ebtCashWithdrawalAmount = it },
+                label = { Text("EBT Cash Withdrawal Dollar Amount") },
+                prefix = { Text("$") },
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
+                )
+            )
+        },
+        bottomRowContent = {
+            Button(onClick = onCancelButtonClicked, colors = ButtonDefaults.elevatedButtonColors()) {
+                Text("Cancel")
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Button(onClick = { onConfirmButtonClicked(ebtCashWithdrawalAmount.toDouble()) }) {
+                Text("Confirm")
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+fun EBTCashWithdrawalScreenPreview() {
+    EBTCashWithdrawalScreen(
+        onConfirmButtonClicked = {},
+        onCancelButtonClicked = {}
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentTypeSelectionScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentTypeSelectionScreen.kt
@@ -46,7 +46,7 @@ fun PaymentTypeSelectionScreen(
                 Text("EBT Cash Purchase")
             }
             Spacer(modifier = Modifier.height(4.dp))
-            Button(onClick = onCashWithdrawalClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
+            Button(onClick = onCashWithdrawalClicked, modifier = Modifier.fillMaxWidth()) {
                 Text("EBT Cash Withdrawal (no purchase)")
             }
             Spacer(modifier = Modifier.height(4.dp))

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -42,5 +42,6 @@
     <string name="title_pos_payment_swipe_card_entry">Swipe Card Entry</string>
     <string name="title_pos_payment_receipt">Payment Receipt</string>
     <string name="title_pos_payment_ebt_cash">Create a Payment / Purchase</string>
+    <string name="title_pos_payment_cash_withdrawal">Create a Payment / Purchase</string>
     <string name="title_pos_payment_with_cashback">Create a Payment / Purchase</string>
 </resources>


### PR DESCRIPTION
## What
Adds support for initiating an EBT Cash Withdrawal transaction to the POS Cert App. _Note:_ This currently doesn't succeed due to backend changes needed, but the call appears to be correct based on the Linear ticket.

## Why
https://linear.app/joinforage/issue/FX-748/story-cash-withdrawal-flow

## Test Plan
- ❌ Just getting basic functionality in place
- ❌ We'll need to verify this succeeds once the backend changes are in place

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/d8c0895c-742f-4648-8912-2cc716f45955

## How
Can be merged as-is since the call failing doesn't affect the other flows and we catch the error