### PR TITLE
[FX-749] Story: Cash purchase with cash back flow

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -37,6 +37,7 @@ import com.joinforage.android.example.ui.pos.screens.ActionSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.MerchantSetupScreen
 import com.joinforage.android.example.ui.pos.screens.balance.BalanceResultScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTCashPurchaseScreen
+import com.joinforage.android.example.ui.pos.screens.payment.EBTCashPurchaseWithCashBackScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTSnapPurchaseScreen
 import com.joinforage.android.example.ui.pos.screens.payment.PaymentResultScreen
 import com.joinforage.android.example.ui.pos.screens.payment.PaymentTypeSelectionScreen
@@ -59,6 +60,7 @@ enum class POSScreen(@StringRes val title: Int) {
     PAYChoosePANMethodScreen(title = R.string.title_pos_payment_choose_pan_method),
     PAYSnapPurchaseScreen(title = R.string.title_pos_payment_snap_purchase_screen),
     PAYEBTCashPurchaseScreen(title = R.string.title_pos_payment_ebt_cash),
+    PAYEBTCashPurchaseWithCashBackScreen(title = R.string.title_pos_payment_with_cashback),
     PAYManualPANEntryScreen(title = R.string.title_pos_payment_manual_pan_entry),
     PAYMagSwipePANEntryScreen(title = R.string.title_pos_payment_swipe_card_entry),
     PAYPINEntryScreen(title = R.string.title_pos_payment_pin_entry),
@@ -221,7 +223,7 @@ fun POSComposeApp(
                     onSnapPurchaseClicked = { navController.navigate(POSScreen.PAYSnapPurchaseScreen.name) },
                     onCashPurchaseClicked = { navController.navigate(POSScreen.PAYEBTCashPurchaseScreen.name) },
                     onCashWithdrawalClicked = { /*TODO*/ },
-                    onCashPurchaseCashbackClicked = { /*TODO*/ },
+                    onCashPurchaseCashbackClicked = { navController.navigate(POSScreen.PAYEBTCashPurchaseWithCashBackScreen.name) },
                     onCancelButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
                 )
             }
@@ -239,6 +241,16 @@ fun POSComposeApp(
                 EBTCashPurchaseScreen(
                     onConfirmButtonClicked = { ebtCashAmount ->
                         val payment = PosPaymentRequest.forEbtCashPayment(ebtCashAmount, k9SDK.terminalId)
+                        viewModel.setLocalPayment(payment)
+                        navController.navigate(POSScreen.PAYChoosePANMethodScreen.name)
+                    },
+                    onCancelButtonClicked = { navController.popBackStack(POSScreen.PAYTransactionTypeSelectionScreen.name, inclusive = false) }
+                )
+            }
+            composable(route = POSScreen.PAYEBTCashPurchaseWithCashBackScreen.name) {
+                EBTCashPurchaseWithCashBackScreen(
+                    onConfirmButtonClicked = { ebtCashAmount, cashBackAmount ->
+                        val payment = PosPaymentRequest.forEbtCashPaymentWithCashBack(ebtCashAmount, cashBackAmount, k9SDK.terminalId)
                         viewModel.setLocalPayment(payment)
                         navController.navigate(POSScreen.PAYChoosePANMethodScreen.name)
                     },

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
@@ -10,7 +10,9 @@ data class PosPaymentRequest(
     @Json(name = "payment_method") val paymentMethodRef: String,
     val description: String,
     @Json(name = "pos_terminal") val posTerminal: PosTerminal,
-    val metadata: Map<String, String>
+    val metadata: Map<String, String>,
+    @Json(name = "transaction_type") val transactionType: String? = null,
+    @Json(name = "cash_back_amount") val cashBackAmount: Double? = null
 ) {
     companion object {
         fun forSnapPayment(snapAmount: Double, terminalId: String) = PosPaymentRequest(
@@ -29,6 +31,16 @@ data class PosPaymentRequest(
             posTerminal = PosTerminal(providerTerminalId = terminalId),
             metadata = mapOf()
         )
+        fun forEbtCashPaymentWithCashBack(ebtCashAmount: Double, cashBackAmount: Double, terminalId: String) = PosPaymentRequest(
+            amount = ebtCashAmount + cashBackAmount,
+            cashBackAmount = cashBackAmount,
+            transactionType = TransactionType.PurchaseWithCashBack.value,
+            description = "Testing POS certification app payments (EBT Cash Purchase with Cash Back)",
+            fundingType = FundingType.EBTCash.value,
+            paymentMethodRef = "",
+            posTerminal = PosTerminal(providerTerminalId = terminalId),
+            metadata = mapOf()
+        )
     }
 }
 
@@ -36,6 +48,10 @@ enum class FundingType(val value: String) {
     EBTSnap(value = "ebt_snap"),
     EBTCash(value = "ebt_cash"),
     CreditTPP(value = "credit_tpp")
+}
+
+enum class TransactionType(val value: String) {
+    PurchaseWithCashBack(value = "purchase_with_cash_back")
 }
 
 @JsonClass(generateAdapter = true)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/EBTCashPurchaseWithCashBackScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/EBTCashPurchaseWithCashBackScreen.kt
@@ -1,0 +1,79 @@
+package com.joinforage.android.example.ui.pos.screens.payment
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
+
+@Composable
+fun EBTCashPurchaseWithCashBackScreen(
+    onConfirmButtonClicked: (ebtCashAmount: Double, cashBackAmount: Double) -> Unit,
+    onCancelButtonClicked: () -> Unit
+) {
+    var ebtCashAmount by rememberSaveable {
+        mutableStateOf("")
+    }
+
+    var cashBackAmount by rememberSaveable {
+        mutableStateOf("")
+    }
+
+    ScreenWithBottomRow(
+        mainContent = {
+            Text("EBT Cash Purchase (with cashback)", fontSize = 18.sp)
+            OutlinedTextField(
+                value = ebtCashAmount,
+                onValueChange = { ebtCashAmount = it },
+                label = { Text("EBT Cash Amount") },
+                prefix = { Text("$") },
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Next
+                )
+            )
+            OutlinedTextField(
+                value = cashBackAmount,
+                onValueChange = { cashBackAmount = it },
+                label = { Text("Cash Back Amount") },
+                prefix = { Text("$") },
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
+                )
+            )
+        },
+        bottomRowContent = {
+            Button(onClick = onCancelButtonClicked, colors = ButtonDefaults.elevatedButtonColors()) {
+                Text("Cancel")
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Button(onClick = { onConfirmButtonClicked(ebtCashAmount.toDouble(), cashBackAmount.toDouble()) }) {
+                Text("Confirm")
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+fun EBTCashPurchaseWithCashBackScreenPreview() {
+    EBTCashPurchaseWithCashBackScreen(
+        onConfirmButtonClicked = { _, _ -> },
+        onCancelButtonClicked = {}
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentTypeSelectionScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentTypeSelectionScreen.kt
@@ -50,7 +50,7 @@ fun PaymentTypeSelectionScreen(
                 Text("EBT Cash Withdrawal (no purchase)")
             }
             Spacer(modifier = Modifier.height(4.dp))
-            Button(onClick = onCashPurchaseCashbackClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
+            Button(onClick = onCashPurchaseCashbackClicked, modifier = Modifier.fillMaxWidth()) {
                 Text("EBT Cash Purchase + Cashback")
             }
         }

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -42,4 +42,5 @@
     <string name="title_pos_payment_swipe_card_entry">Swipe Card Entry</string>
     <string name="title_pos_payment_receipt">Payment Receipt</string>
     <string name="title_pos_payment_ebt_cash">Create a Payment / Purchase</string>
+    <string name="title_pos_payment_with_cashback">Create a Payment / Purchase</string>
 </resources>


### PR DESCRIPTION
## What
Adds the ability to initiate a cash purchase with cash back transaction in the POS Cert App. _Note:_ This currently doesn't succeed due to backend changes needed, but the call appears to be correct based on the Linear ticket.

## Why
https://linear.app/joinforage/issue/FX-749/story-cash-purchase-with-cash-back-flow

## Test Plan
- ❌ Just getting basic functionality in place
- ❌ We'll need to verify this succeeds once the backend changes are in place

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/d5f7c966-33bb-4206-9901-658c36c91b45

## How
Can be merged as-is since the call failing doesn't affect the other flows and we catch the error