### PR TITLE
[FX-820] Scene: Choose to void a payment or a refund

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -315,7 +315,7 @@ fun POSComposeApp(
                     },
                     onBackButtonClicked = { navController.popBackStack(POSScreen.PAYChoosePANMethodScreen.name, inclusive = false) },
                     withPanElementReference = { panElement = it },
-                    errorText = uiState.tokenizationError ?: uiState.paymentCreationError
+                    errorText = uiState.tokenizationError ?: uiState.createPaymentError
                 )
             }
             composable(route = POSScreen.PAYMagSwipePANEntryScreen.name) {
@@ -336,19 +336,19 @@ fun POSComposeApp(
                         }
                     },
                     onBackButtonClicked = { navController.popBackStack(POSScreen.PAYChoosePANMethodScreen.name, inclusive = false) },
-                    errorText = uiState.tokenizationError ?: uiState.paymentCreationError
+                    errorText = uiState.tokenizationError ?: uiState.createPaymentError
                 )
             }
             composable(route = POSScreen.PAYPINEntryScreen.name) {
                 PINEntryScreen(
                     forageConfig = uiState.forageConfig,
-                    paymentMethodRef = uiState.createdPayment?.paymentMethod,
+                    paymentMethodRef = uiState.createPaymentResponse?.paymentMethod,
                     onSubmitButtonClicked = {
-                        if (pinElement != null && uiState.createdPayment?.ref != null) {
+                        if (pinElement != null && uiState.createPaymentResponse?.ref != null) {
                             viewModel.capturePayment(
                                 foragePinEditText = pinElement as ForagePINEditText,
                                 terminalId = k9SDK.terminalId,
-                                paymentRef = uiState.createdPayment!!.ref!!,
+                                paymentRef = uiState.createPaymentResponse!!.ref!!,
                                 onSuccess = {
                                     if (it?.ref != null) {
                                         navController.navigate(POSScreen.PAYResultScreen.name)
@@ -359,12 +359,12 @@ fun POSComposeApp(
                     },
                     onBackButtonClicked = { navController.popBackStack(POSScreen.PAYTransactionTypeSelectionScreen.name, inclusive = false) },
                     withPinElementReference = { pinElement = it },
-                    errorText = uiState.paymentCaptureError
+                    errorText = uiState.capturePaymentError
                 )
             }
             composable(route = POSScreen.PAYResultScreen.name) {
                 PaymentResultScreen(
-                    data = uiState.capturedPayment.toString()
+                    data = uiState.capturePaymentResponse.toString()
                 )
             }
             composable(route = POSScreen.VOIDTransactionTypeSelectionScreen.name) {
@@ -385,7 +385,8 @@ fun POSComposeApp(
                     },
                     onCancelButtonClicked = {
                         navController.popBackStack(POSScreen.VOIDTransactionTypeSelectionScreen.name, inclusive = false)
-                    }
+                    },
+                    errorText = uiState.voidPaymentError
                 )
             }
             composable(route = POSScreen.VOIDRefundScreen.name) {
@@ -399,7 +400,8 @@ fun POSComposeApp(
                     },
                     onCancelButtonClicked = {
                         navController.popBackStack(POSScreen.VOIDTransactionTypeSelectionScreen.name, inclusive = false)
-                    }
+                    },
+                    errorText = uiState.voidRefundError
                 )
             }
             composable(route = POSScreen.VOIDPaymentResultScreen.name) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -46,6 +46,10 @@ import com.joinforage.android.example.ui.pos.screens.shared.MagSwipePANEntryScre
 import com.joinforage.android.example.ui.pos.screens.shared.ManualPANEntryScreen
 import com.joinforage.android.example.ui.pos.screens.shared.PANMethodSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.shared.PINEntryScreen
+import com.joinforage.android.example.ui.pos.screens.voids.VoidPaymentScreen
+import com.joinforage.android.example.ui.pos.screens.voids.VoidRefundScreen
+import com.joinforage.android.example.ui.pos.screens.voids.VoidResultScreen
+import com.joinforage.android.example.ui.pos.screens.voids.VoidTypeSelectionScreen
 import com.joinforage.forage.android.ui.ForagePANEditText
 import com.joinforage.forage.android.ui.ForagePINEditText
 
@@ -66,7 +70,12 @@ enum class POSScreen(@StringRes val title: Int) {
     PAYManualPANEntryScreen(title = R.string.title_pos_payment_manual_pan_entry),
     PAYMagSwipePANEntryScreen(title = R.string.title_pos_payment_swipe_card_entry),
     PAYPINEntryScreen(title = R.string.title_pos_payment_pin_entry),
-    PAYResultScreen(title = R.string.title_pos_payment_receipt)
+    PAYResultScreen(title = R.string.title_pos_payment_receipt),
+    VOIDTransactionTypeSelectionScreen(title = R.string.title_pos_void_flow),
+    VOIDPaymentScreen(title = R.string.title_pos_void_flow),
+    VOIDRefundScreen(title = R.string.title_pos_void_flow),
+    VOIDPaymentResultScreen(title = R.string.title_pos_void_flow),
+    VOIDRefundResultScreen(title = R.string.title_pos_void_flow)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -144,7 +153,7 @@ fun POSComposeApp(
                     onBalanceButtonClicked = { navController.navigate(POSScreen.BIChoosePANMethodScreen.name) },
                     onPaymentButtonClicked = { navController.navigate(POSScreen.PAYTransactionTypeSelectionScreen.name) },
                     onRefundButtonClicked = { /*TODO*/ },
-                    onVoidButtonClicked = { /*TODO*/ }
+                    onVoidButtonClicked = { navController.navigate(POSScreen.VOIDTransactionTypeSelectionScreen.name) }
                 )
             }
             composable(route = POSScreen.BIChoosePANMethodScreen.name) {
@@ -357,6 +366,47 @@ fun POSComposeApp(
                 PaymentResultScreen(
                     data = uiState.capturedPayment.toString()
                 )
+            }
+            composable(route = POSScreen.VOIDTransactionTypeSelectionScreen.name) {
+                VoidTypeSelectionScreen(
+                    onPaymentButtonClicked = { navController.navigate(POSScreen.VOIDPaymentScreen.name) },
+                    onRefundButtonClicked = { navController.navigate(POSScreen.VOIDRefundScreen.name) },
+                    onCancelButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
+                )
+            }
+            composable(route = POSScreen.VOIDPaymentScreen.name) {
+                VoidPaymentScreen(
+                    onConfirmButtonClicked = { paymentRef ->
+                        Log.i("POSComposeApp", "Voiding payment: $paymentRef")
+                        viewModel.voidPayment(paymentRef) {
+                            Log.i("POSComposeApp", "Voided payment: $it")
+                            navController.navigate(POSScreen.VOIDPaymentResultScreen.name)
+                        }
+                    },
+                    onCancelButtonClicked = {
+                        navController.popBackStack(POSScreen.VOIDTransactionTypeSelectionScreen.name, inclusive = false)
+                    }
+                )
+            }
+            composable(route = POSScreen.VOIDRefundScreen.name) {
+                VoidRefundScreen(
+                    onConfirmButtonClicked = { paymentRef, refundRef ->
+                        Log.i("POSComposeApp", "Voiding refund: $refundRef")
+                        viewModel.voidRefund(paymentRef, refundRef) {
+                            Log.i("POSComposeApp", "Voided refund: $it")
+                            navController.navigate(POSScreen.VOIDRefundResultScreen.name)
+                        }
+                    },
+                    onCancelButtonClicked = {
+                        navController.popBackStack(POSScreen.VOIDTransactionTypeSelectionScreen.name, inclusive = false)
+                    }
+                )
+            }
+            composable(route = POSScreen.VOIDPaymentResultScreen.name) {
+                VoidResultScreen(data = uiState.voidPaymentResponse.toString())
+            }
+            composable(route = POSScreen.VOIDRefundResultScreen.name) {
+                VoidResultScreen(data = uiState.voidRefundResponse.toString())
             }
         }
     }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -80,11 +80,11 @@ class POSViewModel : ViewModel() {
                     idempotencyKey = idempotencyKey,
                     payment = payment
                 )
-                _uiState.update { it.copy(createdPayment = response, paymentCreationError = null) }
+                _uiState.update { it.copy(createPaymentResponse = response, createPaymentError = null) }
                 onSuccess(response)
             } catch (e: HttpException) {
                 Log.e("POSViewModel", "Create payment call failed: $e")
-                _uiState.update { it.copy(paymentCreationError = e.toString(), createdPayment = null) }
+                _uiState.update { it.copy(createPaymentError = e.toString(), createPaymentResponse = null) }
             }
         }
     }
@@ -177,12 +177,12 @@ class POSViewModel : ViewModel() {
                     val moshi = Moshi.Builder().build()
                     val jsonAdapter: JsonAdapter<PaymentResponse> = PaymentResponseJsonAdapter(moshi)
                     val paymentResponse = jsonAdapter.fromJson(response.data)
-                    _uiState.update { it.copy(capturedPayment = paymentResponse, paymentCaptureError = null) }
+                    _uiState.update { it.copy(capturePaymentResponse = paymentResponse, capturePaymentError = null) }
                     onSuccess(paymentResponse)
                 }
                 is ForageApiResponse.Failure -> {
                     Log.e("POSViewModel", response.toString())
-                    _uiState.update { it.copy(paymentCaptureError = response.toString(), capturedPayment = null) }
+                    _uiState.update { it.copy(capturePaymentError = response.toString(), capturePaymentResponse = null) }
                 }
             }
         }
@@ -202,6 +202,7 @@ class POSViewModel : ViewModel() {
                 Log.i("POSViewModel", "Void payment call succeeded: $response")
             } catch (e: HttpException) {
                 Log.e("POSViewModel", "Void payment call failed: $e")
+                _uiState.update { it.copy(voidPaymentError = e.toString(), voidPaymentResponse = null) }
             }
         }
     }
@@ -221,6 +222,7 @@ class POSViewModel : ViewModel() {
                 Log.i("POSViewModel", "Void refund call succeeded: $response")
             } catch (e: HttpException) {
                 Log.e("POSViewModel", "Void refund call failed: $e")
+                _uiState.update { it.copy(voidRefundError = e.toString(), voidRefundResponse = null) }
             }
         }
     }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -187,4 +187,41 @@ class POSViewModel : ViewModel() {
             }
         }
     }
+
+    fun voidPayment(paymentRef: String, onSuccess: (response: PaymentResponse) -> Unit) {
+        val idempotencyKey = UUID.randomUUID().toString()
+
+        viewModelScope.launch {
+            try {
+                val response = api.voidPayment(
+                    idempotencyKey = idempotencyKey,
+                    paymentRef = paymentRef
+                )
+                _uiState.update { it.copy(voidPaymentResponse = response) }
+                onSuccess(response)
+                Log.i("POSViewModel", "Void payment call succeeded: $response")
+            } catch (e: HttpException) {
+                Log.e("POSViewModel", "Void payment call failed: $e")
+            }
+        }
+    }
+
+    fun voidRefund(paymentRef: String, refundRef: String, onSuccess: (response: PaymentResponse) -> Unit) {
+        val idempotencyKey = UUID.randomUUID().toString()
+
+        viewModelScope.launch {
+            try {
+                val response = api.voidRefund(
+                    idempotencyKey = idempotencyKey,
+                    paymentRef = paymentRef,
+                    refundRef = refundRef
+                )
+                _uiState.update { it.copy(voidRefundResponse = response) }
+                onSuccess(response)
+                Log.i("POSViewModel", "Void refund call succeeded: $response")
+            } catch (e: HttpException) {
+                Log.e("POSViewModel", "Void refund call failed: $e")
+            }
+        }
+    }
 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -21,17 +21,19 @@ data class POSUIState(
     // Creating a payment
     val localPayment: PosPaymentRequest? = null, // Used to build up the payment object before we send it
     val createPaymentResponse: PaymentResponse? = null,
-    val paymentCreationError: String? = null,
+    val createPaymentError: String? = null,
 
     // Capturing that payment
     val capturePaymentResponse: PaymentResponse? = null,
-    val paymentCaptureError: String? = null,
+    val capturePaymentError: String? = null,
 
     // Voiding a payment
     val voidPaymentResponse: PaymentResponse? = null,
+    val voidPaymentError: String? = null,
 
     // Voiding a refund
-    val voidRefundResponse: PaymentResponse? = null
+    val voidRefundResponse: PaymentResponse? = null,
+    val voidRefundError: String? = null
 ) {
     val forageConfig: ForageConfig
         get() = ForageConfig(merchantId, sessionToken)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -20,12 +20,18 @@ data class POSUIState(
 
     // Creating a payment
     val localPayment: PosPaymentRequest? = null, // Used to build up the payment object before we send it
-    val createdPayment: PaymentResponse? = null,
+    val createPaymentResponse: PaymentResponse? = null,
     val paymentCreationError: String? = null,
 
     // Capturing that payment
-    val capturedPayment: PaymentResponse? = null,
-    val paymentCaptureError: String? = null
+    val capturePaymentResponse: PaymentResponse? = null,
+    val paymentCaptureError: String? = null,
+
+    // Voiding a payment
+    val voidPaymentResponse: PaymentResponse? = null,
+
+    // Voiding a refund
+    val voidRefundResponse: PaymentResponse? = null
 ) {
     val forageConfig: ForageConfig
         get() = ForageConfig(merchantId, sessionToken)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
@@ -15,6 +15,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 private val moshi = Moshi.Builder()
     .addLast(KotlinJsonAdapterFactory())
@@ -28,6 +29,19 @@ interface PosApiService {
     suspend fun createPayment(
         @Header("Idempotency-Key") idempotencyKey: String,
         @Body payment: PosPaymentRequest
+    ): PaymentResponse
+
+    @POST("api/payments/{paymentRef}/void/")
+    suspend fun voidPayment(
+        @Header("Idempotency-Key") idempotencyKey: String,
+        @Path("paymentRef") paymentRef: String
+    ): PaymentResponse
+
+    @POST("api/payments/{paymentRef}/refunds/{refundRef}/void/")
+    suspend fun voidRefund(
+        @Header("Idempotency-Key") idempotencyKey: String,
+        @Path("paymentRef") paymentRef: String,
+        @Path("refundRef") refundRef: String
     ): PaymentResponse
 
     companion object {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ActionSelectionScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ActionSelectionScreen.kt
@@ -48,7 +48,7 @@ fun ActionSelectionScreen(
                     Text("Make a Refund / Return")
                 }
                 Spacer(modifier = Modifier.height(8.dp))
-                Button(onClick = onVoidButtonClicked, modifier = Modifier.fillMaxWidth(), enabled = false) {
+                Button(onClick = onVoidButtonClicked, modifier = Modifier.fillMaxWidth()) {
                     Text("Void / Reverse a Transaction")
                 }
             }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidPaymentScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidPaymentScreen.kt
@@ -17,12 +17,14 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.joinforage.android.example.ui.pos.ui.ErrorText
 import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
 
 @Composable
 fun VoidPaymentScreen(
     onConfirmButtonClicked: (paymentRef: String) -> Unit,
-    onCancelButtonClicked: () -> Unit
+    onCancelButtonClicked: () -> Unit,
+    errorText: String? = null
 ) {
     var paymentRefInput by rememberSaveable {
         mutableStateOf("")
@@ -39,6 +41,7 @@ fun VoidPaymentScreen(
                     imeAction = ImeAction.Done
                 )
             )
+            ErrorText(errorText)
         },
         bottomRowContent = {
             Button(onClick = onCancelButtonClicked, colors = ButtonDefaults.elevatedButtonColors()) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidPaymentScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidPaymentScreen.kt
@@ -1,0 +1,62 @@
+package com.joinforage.android.example.ui.pos.screens.voids
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
+
+@Composable
+fun VoidPaymentScreen(
+    onConfirmButtonClicked: (paymentRef: String) -> Unit,
+    onCancelButtonClicked: () -> Unit
+) {
+    var paymentRefInput by rememberSaveable {
+        mutableStateOf("")
+    }
+
+    ScreenWithBottomRow(
+        mainContent = {
+            Text("Enter the ref of the payment to void", fontSize = 18.sp)
+            OutlinedTextField(
+                value = paymentRefInput,
+                onValueChange = { paymentRefInput = it },
+                label = { Text("Payment ref") },
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    imeAction = ImeAction.Done
+                )
+            )
+        },
+        bottomRowContent = {
+            Button(onClick = onCancelButtonClicked, colors = ButtonDefaults.elevatedButtonColors()) {
+                Text("Cancel")
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Button(onClick = { onConfirmButtonClicked(paymentRefInput) }) {
+                Text("Confirm")
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+fun VoidPaymentScreenPreview() {
+    VoidPaymentScreen(
+        onConfirmButtonClicked = {},
+        onCancelButtonClicked = {}
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidRefundScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidRefundScreen.kt
@@ -1,0 +1,74 @@
+package com.joinforage.android.example.ui.pos.screens.voids
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
+
+@Composable
+fun VoidRefundScreen(
+    onConfirmButtonClicked: (paymentRef: String, refundRef: String) -> Unit,
+    onCancelButtonClicked: () -> Unit
+) {
+    var refundRefInput by rememberSaveable {
+        mutableStateOf("")
+    }
+
+    var paymentRefInput by rememberSaveable {
+        mutableStateOf("")
+    }
+
+    ScreenWithBottomRow(
+        mainContent = {
+            Text("Enter the ref of the refund to void and the ref of the payment that was refunded", fontSize = 18.sp)
+            OutlinedTextField(
+                value = refundRefInput,
+                onValueChange = { refundRefInput = it },
+                label = { Text("Refund ref") },
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    imeAction = ImeAction.Next
+                )
+            )
+            OutlinedTextField(
+                value = paymentRefInput,
+                onValueChange = { paymentRefInput = it },
+                label = { Text("Payment ref") },
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    imeAction = ImeAction.Done
+                )
+            )
+        },
+        bottomRowContent = {
+            Button(onClick = onCancelButtonClicked, colors = ButtonDefaults.elevatedButtonColors()) {
+                Text("Cancel")
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Button(onClick = { onConfirmButtonClicked(paymentRefInput, refundRefInput) }) {
+                Text("Confirm")
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+fun VoidRefundScreenPreview() {
+    VoidRefundScreen(
+        onConfirmButtonClicked = { _, _ -> },
+        onCancelButtonClicked = {}
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidRefundScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidRefundScreen.kt
@@ -17,12 +17,14 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.joinforage.android.example.ui.pos.ui.ErrorText
 import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
 
 @Composable
 fun VoidRefundScreen(
     onConfirmButtonClicked: (paymentRef: String, refundRef: String) -> Unit,
-    onCancelButtonClicked: () -> Unit
+    onCancelButtonClicked: () -> Unit,
+    errorText: String? = null
 ) {
     var refundRefInput by rememberSaveable {
         mutableStateOf("")
@@ -51,6 +53,7 @@ fun VoidRefundScreen(
                     imeAction = ImeAction.Done
                 )
             )
+            ErrorText(errorText)
         },
         bottomRowContent = {
             Button(onClick = onCancelButtonClicked, colors = ButtonDefaults.elevatedButtonColors()) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidResultScreen.kt
@@ -1,0 +1,23 @@
+package com.joinforage.android.example.ui.pos.screens.voids
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun VoidResultScreen(
+    data: String
+) {
+    Column {
+        Text(data)
+    }
+}
+
+@Preview
+@Composable
+fun VoidResultScreenPreview() {
+    VoidResultScreen(
+        data = "some data"
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidTypeSelectionScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidTypeSelectionScreen.kt
@@ -1,0 +1,47 @@
+package com.joinforage.android.example.ui.pos.screens.voids
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
+
+@Composable
+fun VoidTypeSelectionScreen(
+    onPaymentButtonClicked: () -> Unit,
+    onRefundButtonClicked: () -> Unit,
+    onCancelButtonClicked: () -> Unit
+) {
+    ScreenWithBottomRow(
+        mainContent = {
+            Text("Select a transaction type to void", fontSize = 18.sp)
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(onClick = onPaymentButtonClicked) {
+                Text("Payment / Purchase")
+            }
+            Button(onClick = onRefundButtonClicked) {
+                Text("Refund / Return")
+            }
+        },
+        bottomRowContent = {
+            Button(onClick = onCancelButtonClicked) {
+                Text("Cancel")
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+fun VoidTypeSelectionScreenPreview() {
+    VoidTypeSelectionScreen(
+        onPaymentButtonClicked = {},
+        onRefundButtonClicked = {},
+        onCancelButtonClicked = {}
+    )
+}

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -44,4 +44,5 @@
     <string name="title_pos_payment_ebt_cash">Create a Payment / Purchase</string>
     <string name="title_pos_payment_cash_withdrawal">Create a Payment / Purchase</string>
     <string name="title_pos_payment_with_cashback">Create a Payment / Purchase</string>
+    <string name="title_pos_void_flow">Void a Transaction</string>
 </resources>


### PR DESCRIPTION
## What
Adds the flow for voiding payments and refunds. I was able to successfully test voiding a payment ([link](https://api.dev.joinforage.app/admin/api/payment/17107/change/)) but I don't have a refund on my merchant to attempt to void yet. I did try it with a refund from another merchant and got a valid response from the server, but it was a 404 since that refund ref doesn't exist on my merchant. I'll make sure to test voiding a refund before we actually merge this

## Why
https://linear.app/joinforage/issue/FX-820/scene-choose-to-void-a-payment-or-a-refund

## Test Plan
- ❌ Just building out basic functionality
- ❌ Demo video should suffice for voiding a payment, will need to void a refund first before we merge

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/fa119755-89b7-4296-aacf-f8bb7bdaac35

## How
Can be merged as-is once we confirm voiding a refund works