### PR TITLE
[FX-1015] Add more unit tests for AbstractVaultSubmitter

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/vault/AbstractVaultSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/vault/AbstractVaultSubmitter.kt
@@ -86,11 +86,14 @@ internal abstract class AbstractVaultSubmitter<VaultResponse>(
         // FNS requirement to clear the PIN after each submission
         foragePinEditText.clearText()
 
-        val httpStatusCode = when (forageResponse) {
-            is ForageApiResponse.Success -> 200
-            is ForageApiResponse.Failure -> forageResponse.errors[0].httpStatusCode
+        if (forageResponse is ForageApiResponse.Failure && forageResponse.errors.isNotEmpty()) {
+            val forageError = forageResponse.errors.first()
+            proxyResponseMonitor.setForageErrorCode(forageError.code)
+            proxyResponseMonitor.setHttpStatusCode(forageError.httpStatusCode)
+        } else {
+            proxyResponseMonitor.setHttpStatusCode(200)
         }
-        proxyResponseMonitor.setHttpStatusCode(httpStatusCode).logResult()
+        proxyResponseMonitor.logResult()
 
         return forageResponse
     }

--- a/forage-android/src/test/java/com/joinforage/forage/android/mock/MockLogger.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/mock/MockLogger.kt
@@ -27,6 +27,8 @@ internal class MockLogger : Log {
     val warnLogs: MutableList<LogEntry> = mutableListOf()
     val errorLogs: MutableList<LogEntry> = mutableListOf()
 
+    internal fun getMetricsLog() = infoLogs.last()
+
     private val cumulativeAttributes = mutableMapOf<String, Any?>()
 
     override fun initializeDD(context: Context, config: ForageConfig) {

--- a/forage-android/src/test/java/com/joinforage/forage/android/pos/ForageTerminalSDKTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/pos/ForageTerminalSDKTest.kt
@@ -187,7 +187,7 @@ class ForageTerminalSDKTest : MockServerSuite() {
         assertThat(successResponse.data).contains(expectedData.balance.snap)
 
         assertMetricsLog()
-        val attributes = getMetricsLog().getAttributes()
+        val attributes = mockLogger.getMetricsLog().getAttributes()
 
         assertThat(attributes.getValue("response_time_ms").toString().toDouble()).isGreaterThan(0.0)
         assertThat(attributes.getValue("vault_type").toString()).isEqualTo("vgs")
@@ -228,7 +228,7 @@ class ForageTerminalSDKTest : MockServerSuite() {
             failureResponse
         )
         assertMetricsLog()
-        val attributes = getMetricsLog().getAttributes()
+        val attributes = mockLogger.getMetricsLog().getAttributes()
         assertThat(attributes.getValue("response_time_ms").toString().toDouble()).isGreaterThan(0.0)
         assertThat(attributes.getValue("vault_type").toString()).isEqualTo("vgs")
         assertThat(attributes.getValue("action").toString()).isEqualTo("balance")
@@ -266,7 +266,7 @@ class ForageTerminalSDKTest : MockServerSuite() {
         )
 
         assertMetricsLog()
-        val attributes = getMetricsLog().getAttributes()
+        val attributes = mockLogger.getMetricsLog().getAttributes()
         assertThat(attributes.getValue("response_time_ms").toString().toDouble()).isGreaterThan(0.0)
         assertThat(attributes.getValue("vault_type").toString()).isEqualTo("vgs")
         assertThat(attributes.getValue("action").toString()).isEqualTo("refund")
@@ -293,7 +293,7 @@ class ForageTerminalSDKTest : MockServerSuite() {
             failureResponse
         )
         assertMetricsLog()
-        val attributes = getMetricsLog().getAttributes()
+        val attributes = mockLogger.getMetricsLog().getAttributes()
         assertThat(attributes.getValue("response_time_ms").toString().toDouble()).isGreaterThan(0.0)
         assertThat(attributes.getValue("vault_type").toString()).isEqualTo("vgs")
         assertThat(attributes.getValue("action").toString()).isEqualTo("refund")
@@ -408,9 +408,6 @@ class ForageTerminalSDKTest : MockServerSuite() {
             """.trimIndent()
         )
     }
-
-    private fun getMetricsLog() =
-        mockLogger.infoLogs.last()
 
     private fun assertFirstLoggedMessage(expectedMessage: String) =
         assertThat(mockLogger.infoLogs.first().getMessage()).contains(expectedMessage)

--- a/forage-android/src/test/java/com/joinforage/forage/android/vault/AbstractVaultSubmitterTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/vault/AbstractVaultSubmitterTest.kt
@@ -1,0 +1,313 @@
+package com.joinforage.forage.android.vault
+
+import android.content.Context
+import com.joinforage.forage.android.VaultType
+import com.joinforage.forage.android.core.element.state.INITIAL_PIN_ELEMENT_STATE
+import com.joinforage.forage.android.core.telemetry.Log
+import com.joinforage.forage.android.core.telemetry.UserAction
+import com.joinforage.forage.android.mock.MockLogger
+import com.joinforage.forage.android.model.Card
+import com.joinforage.forage.android.model.EncryptionKeys
+import com.joinforage.forage.android.model.PaymentMethod
+import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.network.model.UnknownErrorApiResponse
+import com.joinforage.forage.android.ui.ForagePINEditText
+import kotlinx.coroutines.test.runTest
+import me.jorgecastillo.hiroaki.internal.MockServerSuite
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class AbstractVaultSubmitterTest : MockServerSuite() {
+    private lateinit var mockLogger: MockLogger
+    private lateinit var mockForagePinEditText: ForagePINEditText
+    private lateinit var mockContext: Context
+    private lateinit var abstractVaultSubmitter: AbstractVaultSubmitter<Any>
+
+    companion object {
+        private val mockEncryptionKeys = EncryptionKeys("vgs-alias", "bt-alias")
+        private val mockPaymentMethod = PaymentMethod(
+            ref = "1f148fe399",
+            type = "ebt",
+            balance = null,
+            card = Card(
+                last4 = "7845",
+                token = "tok_sandbox_sYiPe9Q249qQ5wQyUPP5f7,basis-theory-token"
+            ),
+            customerId = "test-android-customer-id",
+            reusable = true
+        )
+        private val mockVaultParams = VaultSubmitterParams(
+            encryptionKeys = mockEncryptionKeys,
+            idempotencyKey = "mock-idempotency-key",
+            merchantId = "1234567",
+            path = "/api/payments/abcdefg123/capture/",
+            paymentMethod = mockPaymentMethod,
+            userAction = UserAction.CAPTURE
+        )
+    }
+
+    @Before
+    fun setUp() {
+        super.setup()
+
+        mockLogger = MockLogger()
+        mockForagePinEditText = mock(ForagePINEditText::class.java)
+        mockContext = mock(Context::class.java)
+
+        abstractVaultSubmitter = ConcreteVaultSubmitter(
+            context = mockContext,
+            foragePinEditText = mockForagePinEditText,
+            logger = mockLogger,
+            vaultType = VaultType.BT_VAULT_TYPE
+        )
+    }
+
+    @Test
+    fun `submit with invalid PIN returns IncompletePinError`() = runTest {
+        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = false)
+
+        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
+        val response = abstractVaultSubmitter.submit(mockVaultParams)
+
+        val forageError = (response as ForageApiResponse.Failure).errors.first()
+        assertEquals(forageError.code, "user_error")
+        assertEquals(forageError.httpStatusCode, 400)
+    }
+
+    @Test
+    fun `submit with successful vault proxy response returns Success`() = runTest {
+        val concreteSubmitter = object : ConcreteVaultSubmitter(
+            context = mockContext,
+            foragePinEditText = mockForagePinEditText,
+            logger = mockLogger,
+            vaultType = VaultType.VGS_VAULT_TYPE
+        ) {
+            override suspend fun submitProxyRequest(
+                vaultProxyRequest: VaultProxyRequest
+            ): ForageApiResponse<String> {
+                return ForageApiResponse.Success("success")
+            }
+        }
+
+        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
+        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
+
+        val response = concreteSubmitter.submit(mockVaultParams)
+
+        assertTrue(response is ForageApiResponse.Success)
+    }
+
+    @Test
+    fun `submit with failed proxy response returns Failure`() = runTest {
+        val concreteVaultSubmitter = object : ConcreteVaultSubmitter(
+            context = mockContext,
+            foragePinEditText = mockForagePinEditText,
+            logger = mockLogger,
+            vaultType = VaultType.VGS_VAULT_TYPE
+        ) {
+            override suspend fun submitProxyRequest(
+                vaultProxyRequest: VaultProxyRequest
+            ): ForageApiResponse<String> {
+                return UnknownErrorApiResponse
+            }
+        }
+        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
+        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
+
+        val response = concreteVaultSubmitter.submit(mockVaultParams)
+
+        assertTrue(response is ForageApiResponse.Failure)
+    }
+
+    @Test
+    fun `submit with missing vault token returns UnknownErrorApiResponse`() = runTest {
+        val concreteSubmitter = object : ConcreteVaultSubmitter(
+            context = mockContext,
+            foragePinEditText = mockForagePinEditText,
+            logger = mockLogger,
+            vaultType = VaultType.BT_VAULT_TYPE
+        ) {
+            // Mock missing token
+            override fun getVaultToken(paymentMethod: PaymentMethod): String? {
+                return null
+            }
+        }
+
+        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
+        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
+
+        val response = concreteSubmitter.submit(mockVaultParams)
+
+        val forageError = (response as ForageApiResponse.Failure).errors.first()
+        assertEquals("unknown_server_error", forageError.code)
+        assertEquals(500, forageError.httpStatusCode)
+        assertEquals("Unknown Server Error", forageError.message)
+    }
+
+    @Test
+    fun `calls clearText after submitting`() = runTest {
+        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
+        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
+
+        abstractVaultSubmitter.submit(mockVaultParams)
+
+        verify(mockForagePinEditText, times(1)).clearText()
+    }
+
+    @Test
+    fun `grabs the correct vault token`() = runTest {
+        val basisTheorySubmitter = object : ConcreteVaultSubmitter(
+            context = mockContext,
+            foragePinEditText = mockForagePinEditText,
+            logger = mockLogger,
+            vaultType = VaultType.BT_VAULT_TYPE
+        ) {
+            override fun getVaultToken(paymentMethod: PaymentMethod): String? {
+                return pickVaultTokenByIndex(paymentMethod, 1)
+            }
+        }
+
+        val vgsSubmitter = object : ConcreteVaultSubmitter(
+            context = mockContext,
+            foragePinEditText = mockForagePinEditText,
+            logger = mockLogger,
+            vaultType = VaultType.VGS_VAULT_TYPE
+        ) {
+            override fun getVaultToken(paymentMethod: PaymentMethod): String? {
+                return pickVaultTokenByIndex(paymentMethod, 0)
+            }
+        }
+
+        val basisTheoryVaultToken = basisTheorySubmitter.getVaultToken(mockVaultParams.paymentMethod)
+        val vgsVaultToken = vgsSubmitter.getVaultToken(mockVaultParams.paymentMethod)
+
+        assertEquals("tok_sandbox_sYiPe9Q249qQ5wQyUPP5f7", vgsVaultToken)
+        assertEquals("basis-theory-token", basisTheoryVaultToken)
+    }
+
+    @Test
+    fun `success metrics event is reported`() = runTest {
+        val concreteVaultSubmitter = object : ConcreteVaultSubmitter(
+            context = mockContext,
+            foragePinEditText = mockForagePinEditText,
+            logger = mockLogger,
+            vaultType = VaultType.VGS_VAULT_TYPE
+        ) {
+            override suspend fun submitProxyRequest(
+                vaultProxyRequest: VaultProxyRequest
+            ): ForageApiResponse<String> {
+                return ForageApiResponse.Success("success")
+            }
+        }
+        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
+        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
+
+        concreteVaultSubmitter.submit(mockVaultParams)
+
+        assertThat(mockLogger.infoLogs).anyMatch { logEntry ->
+            logEntry.getMessage().contains("[Metrics] Received response from vgs proxy")
+        }
+        val attributes = mockLogger.getMetricsLog().getAttributes()
+        assertThat(attributes.getValue("response_time_ms").toString().toDouble()).isGreaterThan(0.0)
+        assertThat(attributes.getValue("vault_type").toString()).isEqualTo("vgs")
+        assertThat(attributes.getValue("action").toString()).isEqualTo("capture")
+        assertThat(attributes.getValue("event_name").toString()).isEqualTo("vault_response")
+        assertThat(attributes.getValue("log_type").toString()).isEqualTo("metric")
+        assertThat(attributes.getValue("forage_error_code").toString()).isEqualTo("unknown")
+        assertThat(attributes.getValue("path").toString()).isEqualTo("/api/payments/abcdefg123/capture/")
+    }
+
+    @Test
+    fun `failure metrics event is reported`() = runTest {
+        val concreteVaultSubmitter = object : ConcreteVaultSubmitter(
+            context = mockContext,
+            foragePinEditText = mockForagePinEditText,
+            logger = mockLogger,
+            vaultType = VaultType.BT_VAULT_TYPE
+        ) {
+            override suspend fun submitProxyRequest(
+                vaultProxyRequest: VaultProxyRequest
+            ): ForageApiResponse<String> {
+                return UnknownErrorApiResponse
+            }
+        }
+
+        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
+        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
+
+        concreteVaultSubmitter.submit(
+            VaultSubmitterParams(
+                encryptionKeys = mockEncryptionKeys,
+                idempotencyKey = "mock-idempotency-key",
+                merchantId = "1234567",
+                path = "/api/payment_methods/abcdefg123/balance/",
+                paymentMethod = mockPaymentMethod,
+                // we cover BALANCE here instead of CAPTURE
+                userAction = UserAction.BALANCE
+            )
+        )
+
+        val metricsLog = mockLogger.getMetricsLog()
+
+        assertThat(mockLogger.infoLogs).anyMatch { logEntry ->
+            logEntry.getMessage().contains("[Metrics] Received response from basis_theory proxy")
+        }
+        val attributes = metricsLog.getAttributes()
+        assertThat(attributes.getValue("response_time_ms").toString().toDouble()).isGreaterThan(0.0)
+        assertThat(attributes.getValue("vault_type").toString()).isEqualTo("basis_theory")
+        assertThat(attributes.getValue("action").toString()).isEqualTo("balance")
+        assertThat(attributes.getValue("event_name").toString()).isEqualTo("vault_response")
+        assertThat(attributes.getValue("path").toString()).isEqualTo("/api/payment_methods/abcdefg123/balance/")
+        assertThat(attributes.getValue("log_type").toString()).isEqualTo("metric")
+        assertThat(attributes.getValue("forage_error_code").toString()).isEqualTo("unknown_server_error")
+    }
+}
+
+internal open class ConcreteVaultSubmitter(
+    context: Context,
+    foragePinEditText: ForagePINEditText,
+    logger: Log,
+    vaultType: VaultType = VaultType.VGS_VAULT_TYPE
+) : AbstractVaultSubmitter<Any>(
+    context = context,
+    foragePinEditText = foragePinEditText,
+    logger = logger,
+    vaultType = vaultType
+) {
+    override fun parseEncryptionKey(encryptionKeys: EncryptionKeys): String {
+        return "mock-encryption-key-alias"
+    }
+
+    override suspend fun submitProxyRequest(
+        vaultProxyRequest: VaultProxyRequest
+    ): ForageApiResponse<String> {
+        return ForageApiResponse.Success("success")
+    }
+
+    override fun getVaultToken(paymentMethod: PaymentMethod): String? {
+        return "mock-vault-token"
+    }
+
+    override fun parseVaultErrorMessage(vaultResponse: Any): String {
+        return "Mock Forage Vault Error"
+    }
+
+    override fun toForageSuccessOrNull(vaultResponse: Any): ForageApiResponse.Success<String>? {
+        return null
+    }
+
+    override fun toForageErrorOrNull(vaultResponse: Any): ForageApiResponse.Failure? {
+        return null
+    }
+
+    override fun toVaultErrorOrNull(vaultResponse: Any): ForageApiResponse.Failure? {
+        return null
+    }
+}

--- a/forage-android/src/test/java/com/joinforage/forage/android/vault/AbstractVaultSubmitterTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/vault/AbstractVaultSubmitterTest.kt
@@ -61,6 +61,9 @@ class AbstractVaultSubmitterTest : MockServerSuite() {
         mockForagePinEditText = mock(ForagePINEditText::class.java)
         mockContext = mock(Context::class.java)
 
+        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
+        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
+
         abstractVaultSubmitter = ConcreteVaultSubmitter(
             context = mockContext,
             foragePinEditText = mockForagePinEditText,
@@ -96,9 +99,6 @@ class AbstractVaultSubmitterTest : MockServerSuite() {
             }
         }
 
-        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
-        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
-
         val response = concreteSubmitter.submit(mockVaultParams)
 
         assertTrue(response is ForageApiResponse.Success)
@@ -118,8 +118,6 @@ class AbstractVaultSubmitterTest : MockServerSuite() {
                 return UnknownErrorApiResponse
             }
         }
-        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
-        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
 
         val response = concreteVaultSubmitter.submit(mockVaultParams)
 
@@ -140,9 +138,6 @@ class AbstractVaultSubmitterTest : MockServerSuite() {
             }
         }
 
-        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
-        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
-
         val response = concreteSubmitter.submit(mockVaultParams)
 
         val forageError = (response as ForageApiResponse.Failure).errors.first()
@@ -153,9 +148,6 @@ class AbstractVaultSubmitterTest : MockServerSuite() {
 
     @Test
     fun `calls clearText after submitting`() = runTest {
-        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
-        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
-
         abstractVaultSubmitter.submit(mockVaultParams)
 
         verify(mockForagePinEditText, times(1)).clearText()
@@ -206,8 +198,6 @@ class AbstractVaultSubmitterTest : MockServerSuite() {
                 return ForageApiResponse.Success("success")
             }
         }
-        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
-        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
 
         concreteVaultSubmitter.submit(mockVaultParams)
 
@@ -239,9 +229,6 @@ class AbstractVaultSubmitterTest : MockServerSuite() {
             }
         }
 
-        val state = INITIAL_PIN_ELEMENT_STATE.copy(isComplete = true)
-        `when`(mockForagePinEditText.getElementState()).thenReturn(state)
-
         concreteVaultSubmitter.submit(
             VaultSubmitterParams(
                 encryptionKeys = mockEncryptionKeys,
@@ -267,6 +254,23 @@ class AbstractVaultSubmitterTest : MockServerSuite() {
         assertThat(attributes.getValue("path").toString()).isEqualTo("/api/payment_methods/abcdefg123/balance/")
         assertThat(attributes.getValue("log_type").toString()).isEqualTo("metric")
         assertThat(attributes.getValue("forage_error_code").toString()).isEqualTo("unknown_server_error")
+    }
+
+    @Test
+    fun `creates the correct vault submitter`() = runTest {
+        val mockBasisTheoryPinEditText = mock(ForagePINEditText::class.java)
+        `when`(mockBasisTheoryPinEditText.getVaultType()).thenReturn(VaultType.BT_VAULT_TYPE)
+        `when`(mockBasisTheoryPinEditText.context).thenReturn(mockContext)
+
+        val mockVgsPinEditText = mock(ForagePINEditText::class.java)
+        `when`(mockVgsPinEditText.getVaultType()).thenReturn(VaultType.VGS_VAULT_TYPE)
+        `when`(mockVgsPinEditText.context).thenReturn(mockContext)
+
+        val btVaultSubmitter = AbstractVaultSubmitter.create(mockBasisTheoryPinEditText, mockLogger)
+        val vgsVaultSubmitter = AbstractVaultSubmitter.create(mockVgsPinEditText, mockLogger)
+
+        assertTrue(vgsVaultSubmitter is VgsPinSubmitter)
+        assertTrue(btVaultSubmitter is BasisTheoryPinSubmitter)
     }
 }
 


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

- Adds unit tests for `AbstractVaultSubmitter.kt`
  - verifies incomplete pin error condition
  - verifies encryption keys + vault tokens parsing
  - verifies metrics logging

## How 

Can be released as-is.