### PR TITLE
Introduce setPosForageConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@ SecretRingKey.gpg
 /buildSrc/build/
 *.jks
 
+# Intellij
+.idea
+
 # Dokka HTML documentation
 reference-docs/

--- a/forage-android/src/main/java/com/joinforage/forage/android/ForageSDKInterface.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ForageSDKInterface.kt
@@ -90,7 +90,7 @@ internal interface ForageSDKInterface {
  * [tokenizeEBTCard][com.joinforage.forage.android.ForageSDK.tokenizeEBTCard] function.
  *
  * @property foragePanEditText A reference to a [ForagePANEditText] instance.
- * [setForageConfig][com.joinforage.forage.android.ui.AbstractForageElement.setForageConfig] must
+ * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] must
  * be called on the instance before it can be passed.
  * @property customerId A unique ID for the end customer making the payment.
  * If using your internal customer ID, then we recommend that you hash the value
@@ -110,7 +110,7 @@ data class TokenizeEBTCardParams(
  * [checkBalance][com.joinforage.forage.android.ForageSDK.checkBalance] function.
  *
  * @property foragePinEditText A reference to a [ForagePINEditText] instance.
- * [setForageConfig][com.joinforage.forage.android.ui.AbstractForageElement.setForageConfig] must
+ * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] must
  * be called on the instance before it can be passed.
  * @property paymentMethodRef A unique string identifier for a previously created
  * [`PaymentMethod`](https://docs.joinforage.app/reference/payment-methods) in Forage's database,
@@ -131,7 +131,7 @@ data class CheckBalanceParams(
  * [capturePayment][com.joinforage.forage.android.ForageSDK.capturePayment] function.
  *
  * @property foragePinEditText A reference to a [ForagePINEditText] instance.
- * [setForageConfig][com.joinforage.forage.android.ui.AbstractForageElement.setForageConfig] must
+ * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] must
  * be called on the instance before it can be passed.
  * @property paymentRef A unique string identifier for a previously created
  * [`Payment`](https://docs.joinforage.app/reference/payments) in Forage's
@@ -156,7 +156,7 @@ data class CapturePaymentParams(
  * [deferPaymentCapture][com.joinforage.forage.android.ForageSDK.deferPaymentCapture].
  *
  * @property foragePinEditText A reference to a [ForagePINEditText] instance.
- * [setForageConfig][com.joinforage.forage.android.ui.AbstractForageElement.setForageConfig] must
+ * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] must
  * be called on the instance before it can be passed.
  * @property paymentRef A unique string identifier for a previously created
  * [`Payment`](https://docs.joinforage.app/reference/payments) in Forage's

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
@@ -13,7 +13,6 @@ import com.joinforage.forage.android.core.telemetry.Log
 import com.joinforage.forage.android.core.telemetry.UserAction
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.network.model.ForageError
-import com.joinforage.forage.android.network.model.UnknownErrorApiResponse
 import com.joinforage.forage.android.ui.ForagePANEditText
 import com.joinforage.forage.android.ui.ForagePINEditText
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
@@ -12,6 +12,7 @@ import com.joinforage.forage.android.core.telemetry.CustomerPerceivedResponseMon
 import com.joinforage.forage.android.core.telemetry.Log
 import com.joinforage.forage.android.core.telemetry.UserAction
 import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.network.model.ForageError
 import com.joinforage.forage.android.network.model.UnknownErrorApiResponse
 import com.joinforage.forage.android.ui.ForagePANEditText
 import com.joinforage.forage.android.ui.ForagePINEditText
@@ -320,7 +321,13 @@ class ForageTerminalSDK(
     ): ForageApiResponse<String>? {
         if (foragePinEditText.getVaultType() != VaultType.VGS_VAULT_TYPE) {
             logger.e("[POS] checkBalance failed on Terminal $posTerminalId because the vault type is not VGS")
-            return UnknownErrorApiResponse
+            return ForageApiResponse.Failure.fromError(
+                ForageError(
+                    code = "invalid_input_data",
+                    message = "IllegalStateException: Use ForageElement.setPosForageConfig, instead of ForageElement.setForageConfig.",
+                    httpStatusCode = 400
+                )
+            )
         }
         return null
     }

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/PosMethodParams.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/PosMethodParams.kt
@@ -1,7 +1,32 @@
 package com.joinforage.forage.android.pos
 
 import com.joinforage.forage.android.ui.ForageConfig
+import com.joinforage.forage.android.ui.ForageElement
 import com.joinforage.forage.android.ui.ForagePINEditText
+
+/**
+ * **[PosForageConfig] is only valid for in-store POS Terminal transactions.**
+ *
+ * The configuration details that Forage needs to create a functional [ForageElement].
+ *
+ * Pass a [PosForageConfig] instance in a call to
+ * [setPosForageConfig][com.joinforage.forage.android.ui.ForageElement.setPosForageConfig] to
+ * configure an Element.
+ *
+ * @property merchantId A unique Merchant ID that Forage provides during onboarding onboarding preceded by "mid/".
+ * For example, `mid/123ab45c67`. The Merchant ID can be found in the Forage [Sandbox](https://dashboard.sandbox.joinforage.app/login/)
+ * or [Production](https://dashboard.joinforage.app/login/) Dashboard.
+ *
+ * @property sessionToken A short-lived token that authenticates front-end requests to Forage.
+ * To create one, send a server-side `POST` request from your backend to the
+ * [`/session_token/`](https://docs.joinforage.app/reference/create-session-token) endpoint.
+ *
+ * @constructor Creates an instance of the [PosForageConfig] data class.
+ */
+data class PosForageConfig(
+    val merchantId: String,
+    val sessionToken: String
+)
 
 /**
  * The [PosTokenizeCardParams] are only valid for in-store POS Terminal transactions.

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/AbstractForageElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/AbstractForageElement.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.widget.LinearLayout
 import com.joinforage.forage.android.core.StopgapGlobalState
 import com.joinforage.forage.android.core.element.state.ElementState
+import com.joinforage.forage.android.pos.PosForageConfig
 
 /**
  * ⚠️ Forage developers use this class to manage common attributes across [ForageElement] types.
@@ -23,9 +24,14 @@ abstract class AbstractForageElement<T : ElementState>(
     // setForageConfig is called. Side effect include
     // initializing logger module, feature flag module,
     // and view UI manipulation logic
-    protected abstract fun initWithForageConfig(forageConfig: ForageConfig)
+    protected abstract fun initWithForageConfig(forageConfig: ForageConfig, isPos: Boolean)
 
     override fun setForageConfig(forageConfig: ForageConfig) {
+        commonInitializer(forageConfig, false)
+    }
+
+    // common initializer for both setForageConfig and setPosForageConfig
+    private fun commonInitializer(forageConfig: ForageConfig, isPos: Boolean) {
         // keep a record of whether this was the first time
         // setForageConfig is getting called. we'll use
         // this info later
@@ -45,11 +51,21 @@ abstract class AbstractForageElement<T : ElementState>(
         // operations on any subsequent calls to setForageConfig
         // or else that could crash the app.
         if (isFirstCallToSet) {
-            initWithForageConfig(forageConfig)
+            initWithForageConfig(forageConfig, isPos)
         } else {
             // TODO: possible opportunity to log that
             //  they tried to do sessionToken refreshing
         }
+    }
+
+    override fun setPosForageConfig(posForageConfig: PosForageConfig) {
+        commonInitializer(
+            ForageConfig(
+                merchantId = posForageConfig.merchantId,
+                sessionToken = posForageConfig.sessionToken
+            ),
+            true
+        )
     }
 
     // internal because submit methods need read-access

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageElement.kt
@@ -4,19 +4,19 @@ import android.graphics.Typeface
 import com.joinforage.forage.android.core.element.SimpleElementListener
 import com.joinforage.forage.android.core.element.StatefulElementListener
 import com.joinforage.forage.android.core.element.state.ElementState
+import com.joinforage.forage.android.pos.PosForageConfig
 
 /**
  * The configuration details that Forage needs to create a functional [ForageElement].
  *
  * Pass a [ForageConfig] instance in a call to
- * [setForageConfig][com.joinforage.forage.android.ui.AbstractForageElement.setForageConfig] to
+ * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] to
  * configure an Element.
  *
- * @property merchantId Either a unique seven digit numeric string that
- * [FNS](https://docs.joinforage.app/docs/ebt-online-101#food-and-nutrition-service-fns) issues
- * to authorized EBT merchants, or a unique merchant ID that Forage provides during onboarding
- * and can be retrieved from the dashboard.
- * Accepted formats include: `mid/<merchant-id>`, `<fns-number>`.
+ * @property merchantId A unique Merchant ID that Forage provides during onboarding
+ * onboarding preceded by "mid/". For example, `mid/123ab45c67`.
+ * The Merchant ID can be found in the Forage [Sandbox](https://dashboard.sandbox.joinforage.app/login/)
+ * or [Production](https://dashboard.joinforage.app/login/) Dashboard.
  *
  * @property sessionToken A short-lived token that authenticates front-end requests to Forage.
  * To create one, send a server-side `POST` request from your backend to the
@@ -42,13 +42,29 @@ interface ForageElement<T : ElementState> {
     var typeface: Typeface?
 
     /**
-     * Sets the necessary [ForageConfig] configuration properties for a ForageElement.
+     * ⚠️ **The [setForageConfig] method is only valid for online-only transactions.** Use [setPosForageConfig]
+     * for in-store POS Terminal transactions.
      *
-     * [setForageConfig] must be called before any other methods can be executed on the Element.
+     * Sets the necessary [ForageConfig] configuration properties for a ForageElement.
+     * **[setForageConfig] must be called before any other methods can be executed on the Element.**
+     *
+     * @see setPosForageConfig Use [setPosForageConfig] for the equivalent Terminal SDK.
      *
      * @param forageConfig A [ForageConfig] instance that specifies a `merchantId` and `sessionToken`.
      */
     fun setForageConfig(forageConfig: ForageConfig)
+
+    /**
+     * ⚠️ **The [setPosForageConfig] method is only valid for in-store POS Terminal transactions.**
+     *
+     * Sets the necessary [PosForageConfig] configuration properties for a ForageElement.
+     * **[setPosForageConfig] must be called before any other methods can be executed on the Element.**
+     *
+     * @see setForageConfig Use [setForageConfig] for the equivalent online-only method.
+     *
+     * @param posForageConfig A [PosForageConfig] instance that specifies a `merchantId` and `sessionToken`.
+     */
+    fun setPosForageConfig(posForageConfig: PosForageConfig)
 
     /**
      * Clears the text input field of the ForageElement.

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -146,7 +146,7 @@ class ForagePANEditText @JvmOverloads constructor(
             }
     }
 
-    override fun initWithForageConfig(forageConfig: ForageConfig) {
+    override fun initWithForageConfig(forageConfig: ForageConfig, isPos: Boolean) {
         // Must initialize DD at the beginning of each render function. DD requires the context,
         // so we need to wait until a context is present to run initialization code. However,
         // we have logging all over the SDK that relies on the render happening first.

--- a/forage-android/src/test/java/com/joinforage/forage/android/pos/ForageTerminalSDKTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/pos/ForageTerminalSDKTest.kt
@@ -5,6 +5,7 @@ import com.joinforage.forage.android.CheckBalanceParams
 import com.joinforage.forage.android.DeferPaymentCaptureParams
 import com.joinforage.forage.android.ForageSDK
 import com.joinforage.forage.android.TokenizeEBTCardParams
+import com.joinforage.forage.android.VaultType
 import com.joinforage.forage.android.core.telemetry.Log
 import com.joinforage.forage.android.fixtures.givenContentId
 import com.joinforage.forage.android.fixtures.givenEncryptionKey
@@ -84,7 +85,7 @@ class ForageTerminalSDKTest : MockServerSuite() {
     }
 
     @Test
-    fun `should send the correct headers + body to tokenize the card`() = runTest {
+    fun `POS should send the correct headers + body to tokenize the card`() = runTest {
         server.givenPaymentMethod(
             PosPaymentMethodRequestBody(
                 track2Data = expectedData.track2Data,
@@ -115,7 +116,7 @@ class ForageTerminalSDKTest : MockServerSuite() {
     }
 
     @Test
-    fun `tokenize EBT card with Track 2 data successfully`() = runTest {
+    fun `POS tokenize EBT card with Track 2 data successfully`() = runTest {
         server.givenPaymentMethod(
             PosPaymentMethodRequestBody(
                 track2Data = expectedData.track2Data,
@@ -147,7 +148,7 @@ class ForageTerminalSDKTest : MockServerSuite() {
     }
 
     @Test
-    fun `tokenize EBT card via UI-based PAN entry`() = runTest {
+    fun `POS tokenize EBT card via UI-based PAN entry`() = runTest {
         `when`(
             mockForageSdk.tokenizeEBTCard(
                 TokenizeEBTCardParams(
@@ -304,7 +305,7 @@ class ForageTerminalSDKTest : MockServerSuite() {
     }
 
     @Test
-    fun testCapturePayment() = runTest {
+    fun `POS capturePayment`() = runTest {
         `when`(
             mockForageSdk.capturePayment(
                 CapturePaymentParams(
@@ -326,7 +327,20 @@ class ForageTerminalSDKTest : MockServerSuite() {
     }
 
     @Test
-    fun testDeferPaymentCapture() = runTest {
+    fun `POS illegal vault exception`() = runTest {
+        `when`(mockForagePinEditText.getVaultType()).thenReturn(VaultType.BT_VAULT_TYPE)
+        val response = terminalSdk.checkBalance(
+            CheckBalanceParams(
+                foragePinEditText = mockForagePinEditText,
+                paymentMethodRef = "1f148fe399"
+            )
+        )
+        assertTrue(response is ForageApiResponse.Failure)
+        assertThat(mockLogger.errorLogs.last().getMessage()).contains("because the vault type is not VGS")
+    }
+
+    @Test
+    fun `POS deferPaymentCapture`() = runTest {
         `when`(
             mockForageSdk.deferPaymentCapture(
                 DeferPaymentCaptureParams(


### PR DESCRIPTION
## What

- Introduce `ForageElement#setPosForageConfig` and `PosForageConfig` ; helps us use custom logic for loading vault provider-related elements.
- Added comments and validation in case the merchant uses the wrong method.
- gitignore `.idea` directory
- fix comments (for merchant ID, reference `ForageElement` instead of `AbstractForageElement`)

## Why

- [See design proposal doc](https://www.notion.so/joinforage/Handling-SDK-vault-routing-for-Toast-integration-f4b8aa60776640e9a7de013f48c13ea3#ca06e1abcf9b47f0a1c1ec5d7f3d8b9e)

## Test plan

- flipped flags in launchdarkly and tested against sample app
- wrote unit tests
- checked logs

## How

- PATCH-level change
- Will eventually be followed by PR for ensuring POS transactions go through rosetta
- ⚠️  @devinmorgan the certification app should be updated to use `setPosForageConfig` instead of `setForageConfig`