### PR TITLE
Add session token constructor arg for key management and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,15 +300,16 @@ You can then use the instance to call methods that perform payment operations. R
 
 `ForageTerminalSDK()` is the entry point to the Forage Terminal SDK. A `ForageTerminalSDK` instance interacts with the Forage API.
 
-To create a `ForageTerminalSDK` instance, call the constructor, passing the `posTerminalId` as the only parameter, as in the following snippet:
+To create a `ForageTerminalSDK` instance, call the constructor, passing the `posTerminalId` and a `sessionToken` as the only parameters, as in the following snippet:
 
 ```kotlin
-val forage = ForageTerminalSDK(posTerminalId)
+val forage = ForageTerminalSDK(posTerminalId, sessionToken)
 ```
 
 #### `ForageTerminalSDK()` parameters
 
 - `posTerminalId` (_required_): A string that uniquely identifies the POS Terminal used for a transaction.
+- `sessionToken` (_required_): A session token which will authenticate the POS Terminal against Forage's key management service.
 
 You can then use the instance to call methods that perform payment operations, as demonstrated in the following section.
 
@@ -727,7 +728,7 @@ class PosRefundViewModel : ViewModel() {
 
 
   fun refundPayment(foragePinEditText: ForagePINEditText) = viewModelScope.launch {
-    val forageParams = ForageTerminalSDKParams(posTerminalId)
+    val forageParams = ForageTerminalSDKParams(posTerminalId, sessionToken)
     val forage = ForageTerminalSDK(forageParams)
     val refundParams = PosRefundPaymentParams(
       foragePinEditText,

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
@@ -31,7 +31,8 @@ import com.joinforage.forage.android.ui.ForagePINEditText
  * @param posTerminalId The unique string that identifies the POS Terminal.
  */
 class ForageTerminalSDK(
-    private val posTerminalId: String
+    private val posTerminalId: String,
+    private val sessionToken: String
 ) : ForageSDKInterface {
     private var createServiceFactory = {
             sessionToken: String, merchantId: String, logger: Log ->


### PR DESCRIPTION
## What

Title

## Why

This param is needed for key management which is still under development. I don't want the extra constructor arg to be a surprise when we turn that work over, in case it is a significant flow change.

## Test Plan

- ❌ I've not added unit tests for this change. We will do that with the key management work itself

## How

Should be included in the next release
