### PR TITLE
[FX-1033] Add deferred refund endpoint to terminal SDK

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ForageSDK.kt
@@ -16,6 +16,7 @@ import com.joinforage.forage.android.network.TokenizeCardService
 import com.joinforage.forage.android.network.data.CapturePaymentRepository
 import com.joinforage.forage.android.network.data.CheckBalanceRepository
 import com.joinforage.forage.android.network.data.DeferPaymentCaptureRepository
+import com.joinforage.forage.android.network.data.DeferPaymentRefundRepository
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.pos.PosRefundPaymentRepository
 import com.joinforage.forage.android.pos.PosRefundService
@@ -350,6 +351,15 @@ class ForageSDK : ForageSDKInterface {
 
         open fun createDeferPaymentCaptureRepository(foragePinEditText: ForagePINEditText): DeferPaymentCaptureRepository {
             return DeferPaymentCaptureRepository(
+                vaultSubmitter = createVaultSubmitter(foragePinEditText),
+                encryptionKeyService = encryptionKeyService,
+                paymentService = paymentService,
+                paymentMethodService = paymentMethodService
+            )
+        }
+
+        open fun createDeferPaymentRefundRepository(foragePinEditText: ForagePINEditText): DeferPaymentRefundRepository {
+            return DeferPaymentRefundRepository(
                 vaultSubmitter = createVaultSubmitter(foragePinEditText),
                 encryptionKeyService = encryptionKeyService,
                 paymentService = paymentService,

--- a/forage-android/src/main/java/com/joinforage/forage/android/ForageSDKInterface.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ForageSDKInterface.kt
@@ -167,3 +167,22 @@ data class DeferPaymentCaptureParams(
     val foragePinEditText: ForagePINEditText,
     val paymentRef: String
 )
+
+/**
+ * A model that represents the parameters that Forage requires to collect a card PIN and defer
+ * the refund of the payment to the server.
+ * [PosDeferPaymentRefundParams] are passed to the
+ * [deferPaymentRefund][com.joinforage.forage.android.pos.ForageTerminalSDK.deferPaymentRefund] function.
+ *
+ * @property foragePinEditText A reference to a [ForagePINEditText] instance.
+ * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] must
+ * be called on the instance before it can be passed.
+ * @property paymentRef A unique string identifier for a previously created
+ * [`Payment`](https://docs.joinforage.app/reference/payments) in Forage's
+ * database, returned by the
+ * [Create a `Payment`](https://docs.joinforage.app/reference/create-a-payment) endpoint.
+ */
+data class PosDeferPaymentRefundParams(
+    val foragePinEditText: ForagePINEditText,
+    val paymentRef: String
+)

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/telemetry/Metrics.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/telemetry/Metrics.kt
@@ -34,7 +34,8 @@ internal enum class UserAction(val value: String) {
     BALANCE("balance"),
     CAPTURE("capture"),
     DEFER_CAPTURE("defer_capture"),
-    REFUND("refund");
+    REFUND("refund"),
+    DEFER_REFUND("defer_refund");
 
     override fun toString(): String {
         return value

--- a/forage-android/src/main/java/com/joinforage/forage/android/network/data/DeferPaymentRefundRepository.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/network/data/DeferPaymentRefundRepository.kt
@@ -1,0 +1,53 @@
+package com.joinforage.forage.android.network.data
+
+import com.joinforage.forage.android.core.telemetry.UserAction
+import com.joinforage.forage.android.model.EncryptionKeys
+import com.joinforage.forage.android.model.Payment
+import com.joinforage.forage.android.model.PaymentMethod
+import com.joinforage.forage.android.network.EncryptionKeyService
+import com.joinforage.forage.android.network.PaymentMethodService
+import com.joinforage.forage.android.network.PaymentService
+import com.joinforage.forage.android.network.model.ForageApiResponse
+import com.joinforage.forage.android.vault.AbstractVaultSubmitter
+import com.joinforage.forage.android.vault.VaultSubmitter
+import com.joinforage.forage.android.vault.VaultSubmitterParams
+import java.util.UUID
+
+internal class DeferPaymentRefundRepository(
+    private val vaultSubmitter: VaultSubmitter,
+    private val encryptionKeyService: EncryptionKeyService,
+    private val paymentMethodService: PaymentMethodService,
+    private val paymentService: PaymentService
+) {
+    /**
+     * @return if successful, the response.data field is an empty string
+     */
+    suspend fun deferPaymentRefund(
+        merchantId: String,
+        paymentRef: String
+    ): ForageApiResponse<String> {
+        val encryptionKeys = when (val response = encryptionKeyService.getEncryptionKey()) {
+            is ForageApiResponse.Success -> EncryptionKeys.ModelMapper.from(response.data)
+            else -> return response
+        }
+        val payment = when (val response = paymentService.getPayment(paymentRef)) {
+            is ForageApiResponse.Success -> Payment.ModelMapper.from(response.data)
+            else -> return response
+        }
+        val paymentMethod = when (val response = paymentMethodService.getPaymentMethod(payment.paymentMethod)) {
+            is ForageApiResponse.Success -> PaymentMethod.ModelMapper.from(response.data)
+            else -> return response
+        }
+
+        return vaultSubmitter.submit(
+            VaultSubmitterParams(
+                encryptionKeys = encryptionKeys,
+                idempotencyKey = UUID.randomUUID().toString(),
+                merchantId = merchantId,
+                path = AbstractVaultSubmitter.deferPaymentRefundPath(paymentRef),
+                paymentMethod = paymentMethod,
+                userAction = UserAction.DEFER_REFUND
+            )
+        )
+    }
+}

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
@@ -6,6 +6,7 @@ import com.joinforage.forage.android.DeferPaymentCaptureParams
 import com.joinforage.forage.android.ForageConfigNotSetException
 import com.joinforage.forage.android.ForageSDK
 import com.joinforage.forage.android.ForageSDKInterface
+import com.joinforage.forage.android.PosDeferPaymentRefundParams
 import com.joinforage.forage.android.TokenizeEBTCardParams
 import com.joinforage.forage.android.VaultType
 import com.joinforage.forage.android.core.telemetry.CustomerPerceivedResponseMonitor
@@ -374,6 +375,65 @@ class ForageTerminalSDK(
 
         if (refund is ForageApiResponse.Failure) {
             logger.e("[POS] refundPayment failed for Payment $paymentRef on Terminal $posTerminalId: ${refund.errors[0]}")
+        }
+
+        return refund
+    }
+
+    /**
+     * Collect's a customer's PIN for an EBT payment and defers
+     * the refund of the payment to the server.
+     *
+     * @param params The [PosRefundPaymentParams] parameters required for refunding a Payment.
+     * @return A [ForageAPIResponse][com.joinforage.forage.android.network.model.ForageApiResponse]
+     * indicating the success or failure of the
+     * PIN capture. On success, returns `Nothing`.
+     * On failure, the response includes a list of
+     * [ForageError][com.joinforage.forage.android.network.model.ForageError] objects that you can
+     * unpack to troubleshoot the issue.
+     * @throws ForageConfigNotSetException If the passed ForagePINEditText instance
+     * hasn't had its ForageConfig set via .setForageConfig().
+     */
+    suspend fun deferPaymentRefund(params: PosDeferPaymentRefundParams): ForageApiResponse<String> {
+        val logger = createLogger()
+        val (foragePinEditText, paymentRef) = params
+        val (merchantId, sessionToken) = forageSdk._getForageConfigOrThrow(foragePinEditText)
+
+        val illegalVaultException = isIllegalVaultExceptionOrNull(foragePinEditText, logger)
+        if (illegalVaultException != null) {
+            return illegalVaultException
+        }
+
+        logger
+            .addAttribute("payment_ref", paymentRef)
+            .addAttribute("merchant_ref", merchantId)
+        logger.i(
+            """
+            [POS] Called deferPaymentRefund for Payment $paymentRef
+            on Terminal: $posTerminalId
+            """.trimIndent()
+        )
+
+        // This block is used for tracking Metrics!
+        // ------------------------------------------------------
+        val measurement = CustomerPerceivedResponseMonitor.newMeasurement(
+            vault = foragePinEditText.getVaultType(),
+            vaultAction = UserAction.DEFER_REFUND,
+            logger
+        )
+        measurement.start()
+        // ------------------------------------------------------
+
+        val serviceFactory = createServiceFactory(sessionToken, merchantId, logger)
+        val refundService = serviceFactory.createDeferPaymentRefundRepository(foragePinEditText)
+        val refund = refundService.deferPaymentRefund(
+            merchantId = merchantId,
+            paymentRef = paymentRef
+        )
+        forageSdk.processApiResponseForMetrics(refund, measurement)
+
+        if (refund is ForageApiResponse.Failure) {
+            logger.e("[POS] deferPaymentRefund failed for Payment $paymentRef on Terminal $posTerminalId: ${refund.errors[0]}")
         }
 
         return refund

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -27,6 +27,8 @@ import com.verygoodsecurity.vgscollect.widget.VGSEditText
  * * [Collect a card PIN to defer payment capture to the server][com.joinforage.forage.android.ForageSDK.deferPaymentCapture]
  * * [Capture a payment immediately][com.joinforage.forage.android.ForageSDK.capturePayment]
  * * [Refund a Payment][com.joinforage.forage.android.pos.ForageTerminalSDK.refundPayment] (POS only)
+ * * [Collect a card PIN to defer payment refund to the server][com.joinforage.forage.android.pos.ForageTerminalSDK.deferPaymentRefund] (POS only)
+ *
  */
 class ForagePINEditText @JvmOverloads constructor(
     context: Context,

--- a/forage-android/src/main/java/com/joinforage/forage/android/vault/AbstractVaultSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/vault/AbstractVaultSubmitter.kt
@@ -239,5 +239,7 @@ internal abstract class AbstractVaultSubmitter<VaultResponse>(
             "/api/payments/$paymentRef/collect_pin/"
 
         internal fun refundPaymentPath(paymentRef: String) = "/api/payments/$paymentRef/refunds/"
+
+        internal fun deferPaymentRefundPath(paymentRef: String) = "/api/payments/$paymentRef/refunds/collect_pin/"
     }
 }

--- a/forage-android/src/test/java/com/joinforage/forage/android/mock/MockServerUtils.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/mock/MockServerUtils.kt
@@ -46,6 +46,20 @@ internal fun mockSuccessfulPosRefund(
     )
 }
 
+internal fun mockSuccessfulPosDeferredRefund(
+    mockVaultSubmitter: MockVaultSubmitter,
+    server: MockWebServer
+) {
+    server.givenEncryptionKey().returnsEncryptionKeySuccessfully()
+    server.givenPaymentRef().returnsPayment()
+    server.givenPaymentMethodRef().returnsPaymentMethod()
+
+    mockVaultSubmitter.setSubmitResponse(
+        path = "/api/payments/${MockServiceFactory.ExpectedData.paymentRef}/refunds/collect_pin/",
+        response = ForageApiResponse.Success("")
+    )
+}
+
 internal fun getVaultMessageResponse(contentId: String): String {
     return JSONObject().apply {
         put("content_id", contentId)

--- a/forage-android/src/test/java/com/joinforage/forage/android/mock/MockServiceFactory.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/mock/MockServiceFactory.kt
@@ -14,6 +14,7 @@ import com.joinforage.forage.android.network.data.BaseVaultRequestParams
 import com.joinforage.forage.android.network.data.CapturePaymentRepository
 import com.joinforage.forage.android.network.data.CheckBalanceRepository
 import com.joinforage.forage.android.network.data.DeferPaymentCaptureRepository
+import com.joinforage.forage.android.network.data.DeferPaymentRefundRepository
 import com.joinforage.forage.android.pos.PosRefundPaymentRepository
 import com.joinforage.forage.android.pos.PosRefundService
 import com.joinforage.forage.android.pos.PosVaultRequestParams
@@ -112,6 +113,15 @@ internal class MockServiceFactory(
             encryptionKeyService = encryptionKeyService,
             paymentService = paymentService,
             paymentMethodService = paymentMethodService
+        )
+    }
+
+    override fun createDeferPaymentRefundRepository(foragePinEditText: ForagePINEditText): DeferPaymentRefundRepository {
+        return DeferPaymentRefundRepository(
+            vaultSubmitter = mockVaultSubmitter,
+            encryptionKeyService = encryptionKeyService,
+            paymentMethodService = paymentMethodService,
+            paymentService = paymentService
         )
     }
 

--- a/forage-android/src/test/java/com/joinforage/forage/android/pos/ForageTerminalSDKTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/pos/ForageTerminalSDKTest.kt
@@ -3,8 +3,8 @@ package com.joinforage.forage.android.pos
 import com.joinforage.forage.android.CapturePaymentParams
 import com.joinforage.forage.android.CheckBalanceParams
 import com.joinforage.forage.android.DeferPaymentCaptureParams
-import com.joinforage.forage.android.DeferPosPaymentRefundParams
 import com.joinforage.forage.android.ForageSDK
+import com.joinforage.forage.android.PosDeferPaymentRefundParams
 import com.joinforage.forage.android.TokenizeEBTCardParams
 import com.joinforage.forage.android.VaultType
 import com.joinforage.forage.android.core.telemetry.Log
@@ -481,7 +481,7 @@ class ForageTerminalSDKTest : MockServerSuite() {
     private suspend fun executeDeferPaymentRefund(): ForageApiResponse<String> {
         val terminalSdk = createMockTerminalSdk()
         return terminalSdk.deferPaymentRefund(
-            DeferPosPaymentRefundParams(
+            PosDeferPaymentRefundParams(
                 foragePinEditText = mockForagePinEditText,
                 paymentRef = expectedData.paymentRef
             )


### PR DESCRIPTION
## What
Add the deferred refund endpoint to the Android SDK for Toast to use.

## Test Plan

- ✅ I've added unit tests for this change.

## How
Can be released as is.
