### PR TITLE
[FX-1028] Pull latest forage pos config inside data-fetching methods

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -44,10 +44,8 @@ sealed interface MerchantDetailsState {
 class POSViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(POSUIState())
     val uiState: StateFlow<POSUIState> = _uiState.asStateFlow()
-
-    private fun getForageRetrofitApi(): PosApiService {
-        return PosApiService.from(uiState.value.posForageConfig)
-    }
+    private val api
+        get() = PosApiService.from(uiState.value.posForageConfig)
 
     fun setMerchantId(merchantId: String, onSuccess: () -> Unit) {
         _uiState.update { it.copy(merchantId = merchantId) }
@@ -66,7 +64,7 @@ class POSViewModel : ViewModel() {
         viewModelScope.launch {
             _uiState.update { it.copy(merchantDetailsState = MerchantDetailsState.Loading) }
             val merchantDetailsState = try {
-                val result = getForageRetrofitApi().getMerchantInfo()
+                val result = api.getMerchantInfo()
                 onSuccess()
                 MerchantDetailsState.Success(result)
             } catch (e: HttpException) {
@@ -81,7 +79,7 @@ class POSViewModel : ViewModel() {
 
         viewModelScope.launch {
             try {
-                val response = getForageRetrofitApi().createPayment(
+                val response = api.createPayment(
                     idempotencyKey = idempotencyKey,
                     payment = payment
                 )
@@ -225,7 +223,7 @@ class POSViewModel : ViewModel() {
 
         viewModelScope.launch {
             try {
-                val response = getForageRetrofitApi().voidPayment(
+                val response = api.voidPayment(
                     idempotencyKey = idempotencyKey,
                     paymentRef = paymentRef
                 )
@@ -244,7 +242,7 @@ class POSViewModel : ViewModel() {
 
         viewModelScope.launch {
             try {
-                val response = getForageRetrofitApi().voidRefund(
+                val response = api.voidRefund(
                     idempotencyKey = idempotencyKey,
                     paymentRef = paymentRef,
                     refundRef = refundRef


### PR DESCRIPTION
## What
Pulls the latest POS config for retrofit api methods.

## Why
Since were initializing `api` using `by lazy`, the first time one of these methods gets called (which would almost certainly `getMerchantInfo` based on the app flow), we would initialize the `PosApiService` with whatever the value of `uiState.value.posForageConfig` was at that moment. Since `by lazy` caches its value once it runs, we'd never update the retrofit client creation. That wouldn't theoretically be a problem, but since [we inject the merchant ID in the headers](https://github.com/teamforage/forage-android-sdk/blob/main/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt#L53) when initializing the retrofit client, it would always keep the same merchant ID from first call.

## Test Plan
- ✅  I manually tested this based on the description in the [linear ticket](https://linear.app/joinforage/issue/FX-1028/bug-app-uses-old-fns-number-merchantid-for-requests-despite-user) and verified the behavior seems to be working correctly. 

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/593659c1-b1e7-4b10-9ccc-4d225e911b3b

## How
Can be merged as-is