### PR TITLE
[FX-1052] Fix purchase with cashback throwing a 400 error

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentRequest.kt
@@ -41,7 +41,7 @@ data class PosPaymentRequest(
             transactionType = TransactionType.Withdrawal.value
         )
         fun forEbtCashPaymentWithCashBack(ebtCashAmount: String, cashBackAmount: String, terminalId: String) = PosPaymentRequest(
-            amount = ebtCashAmount + cashBackAmount,
+            amount = (ebtCashAmount.toDouble() + cashBackAmount.toDouble()).toString(),
             cashBackAmount = cashBackAmount,
             transactionType = TransactionType.PurchaseWithCashBack.value,
             description = "Testing POS certification app payments (EBT Cash Purchase with Cash Back)",


### PR DESCRIPTION
## What
Fixes an issue with the purchase + cashback flow throwing a 400 error. It looks like the `ebtCashAmount` and `cashBackAmounts` are coming into the helper method that generates the payment as strings, then we're trying to add them with `+`, which produces a result that the backend can't coerce to a number. This changes the logic to cast each item to a double, do the math to get the total, then cast that total _back_ to a string to send to the backend.

## Why
https://linear.app/joinforage/issue/FX-1052/bug-cash-purchase-with-cashback-gives-400-error

## Test Plan
Manually tested the flow in the android emulator

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/834ab196-5609-45ab-8190-81369592fdbd

## How
Can be merged as-is