### PR TITLE
[FX-1031] feature result pages should have a return to flows button

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -129,6 +130,22 @@ fun POSComposeApp(
                             Icon(
                                 imageVector = Icons.Filled.ArrowBack,
                                 contentDescription = stringResource(R.string.pos_back_button)
+                            )
+                        }
+                    }
+                },
+                actions = {
+                    val isMerchantScreen = navController.currentBackStackEntry?.destination?.route == POSScreen.MerchantSetupScreen.name
+                    val isActionScreen = navController.currentBackStackEntry?.destination?.route == POSScreen.ActionSelectionScreen.name
+                    if (!isMerchantScreen && !isActionScreen) {
+                        IconButton(onClick = {
+                            navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false)
+                            pageTitle = null
+                            viewModel.resetUiState()
+                        }) {
+                            Icon(
+                                imageVector = Icons.Filled.Refresh,
+                                contentDescription = stringResource(R.string.pos_restart)
                             )
                         }
                     }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -26,6 +26,7 @@ import com.joinforage.forage.android.ui.ForagePANEditText
 import com.joinforage.forage.android.ui.ForagePINEditText
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -58,6 +59,22 @@ class POSViewModel : ViewModel() {
 
     fun setLocalRefundState(refundState: RefundUIState) {
         _uiState.update { it.copy(localRefundState = refundState) }
+    }
+
+    fun resetUiState() {
+        // this needs to be in a coroutine and delayed to allow for the back-stack
+        // to be fully popped before some of the data it depends on disappears.
+        // There's probably a better way to do this but this works for now.
+        viewModelScope.launch {
+            delay(1000)
+            _uiState.update {
+                POSUIState(
+                    merchantId = it.merchantId,
+                    sessionToken = it.sessionToken,
+                    merchantDetailsState = it.merchantDetailsState
+                )
+            }
+        }
     }
 
     private fun getMerchantInfo(onSuccess: () -> Unit) {

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -52,4 +52,5 @@
     <string name="title_pos_void_refund">Void a Refund</string>
     <string name="title_pos_void_payment_result">Void Payment Result</string>
     <string name="title_pos_void_refund_result">Void Refund Result</string>
+    <string name="pos_restart">Restart</string>
 </resources>


### PR DESCRIPTION
## What
Adds a reset/restart button to the top right of the app bar on all screens that aren't the merchant details or action selection. This will allow testers to jump back to the action selection screen from any subsequent scene regardless of where they are in the flow. It also resets the state to be ready for a new action selection. It persists the merchant details (the assumption being you want to keep the same merchant), but those could easily be changed with another tap of the back arrow after you tap the Reset icon button.

## Why
https://linear.app/joinforage/issue/FX-1031/feature-result-pages-should-have-a-return-to-flows-button

## Test Plan
Manually tested in the android emulator

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/e838679d-d26e-45f1-9b35-b6edd1766b15

## How
Can be merged as-is