### PR TITLE
[FX-1029] Hide keyboard after submitting PAN or PIN

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -202,6 +202,7 @@ fun POSComposeApp(
                     posForageConfig = uiState.posForageConfig,
                     onSubmitButtonClicked = {
                         if (panElement != null) {
+                            panElement!!.clearFocus()
                             viewModel.tokenizeEBTCard(
                                 panElement as ForagePANEditText,
                                 k9SDK.terminalId,
@@ -241,6 +242,7 @@ fun POSComposeApp(
                     paymentMethodRef = uiState.tokenizedPaymentMethod?.ref,
                     onSubmitButtonClicked = {
                         if (pinElement != null && uiState.tokenizedPaymentMethod?.ref != null) {
+                            pinElement!!.clearFocus()
                             viewModel.checkEBTCardBalance(
                                 pinElement as ForagePINEditText,
                                 paymentMethodRef = uiState.tokenizedPaymentMethod!!.ref,
@@ -373,8 +375,8 @@ fun POSComposeApp(
                     posForageConfig = uiState.posForageConfig,
                     onSubmitButtonClicked = {
                         Log.i("POSComposeApp", "Calling onSubmitButtonClicked in ManualPANEntryScreen in PAYChoosePANMethodScreen")
-
                         if (panElement != null) {
+                            panElement!!.clearFocus()
                             viewModel.tokenizeEBTCard(
                                 panElement as ForagePANEditText,
                                 k9SDK.terminalId,
@@ -425,6 +427,7 @@ fun POSComposeApp(
                     paymentMethodRef = uiState.createPaymentResponse?.paymentMethod,
                     onSubmitButtonClicked = {
                         if (pinElement != null && uiState.createPaymentResponse?.ref != null) {
+                            pinElement!!.clearFocus()
                             viewModel.capturePayment(
                                 foragePinEditText = pinElement as ForagePINEditText,
                                 terminalId = k9SDK.terminalId,
@@ -473,6 +476,7 @@ fun POSComposeApp(
                     paymentMethodRef = uiState.localRefundState?.paymentRef,
                     onSubmitButtonClicked = {
                         if (pinElement != null && uiState.localRefundState != null) {
+                            pinElement!!.clearFocus()
                             viewModel.refundPayment(
                                 foragePinEditText = pinElement as ForagePINEditText,
                                 terminalId = k9SDK.terminalId,


### PR DESCRIPTION
## What
Calls `.clearFocus()` on the PAN or PIN (depending on which flow you're on) to hide the keyboard after submitting either of those fields.

## Why
https://linear.app/joinforage/issue/FX-1029/bug-keyboard-does-not-hide-after-pressing-buttons-to-navigate-forward

## Test Plan
Manually tested to verify

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/6fe6fed6-f858-4640-9aab-07384872633a

## How
Can be merged as-is