### PR TITLE
[FX-1051] Fix issue with void receipts having inaccurate data

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -469,8 +469,9 @@ fun POSComposeApp(
                             amount = amount,
                             reason = reason
                         )
-                        viewModel.setLocalRefundState(refundState)
-                        navController.navigate(POSScreen.REFUNDPINEntryScreen.name)
+                        viewModel.setLocalRefundState(refundState) {
+                            navController.navigate(POSScreen.REFUNDPINEntryScreen.name)
+                        }
                     },
                     onCancelButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
                 )
@@ -478,7 +479,7 @@ fun POSComposeApp(
             composable(route = POSScreen.REFUNDPINEntryScreen.name) {
                 PINEntryScreen(
                     posForageConfig = uiState.posForageConfig,
-                    paymentMethodRef = uiState.localRefundState?.paymentRef,
+                    paymentMethodRef = uiState.tokenizedPaymentMethod?.ref,
                     onSubmitButtonClicked = {
                         if (pinElement != null && uiState.localRefundState != null) {
                             pinElement!!.clearFocus()

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -559,7 +559,7 @@ fun POSComposeApp(
                             it2
                         )
                     } },
-                    paymentResponse = uiState.voidPaymentResponse!!,
+                    paymentResponse = uiState.voidPaymentResponse,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.VOIDPaymentScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
                 )
@@ -570,7 +570,7 @@ fun POSComposeApp(
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
                     txType = uiState.voidRefundResponse?.let { it1 -> TxType.forReceipt(it1.receipt) },
-                    refundResponse = uiState.refundPaymentResponse!!,
+                    refundResponse = uiState.voidRefundResponse,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.VOIDRefundScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
                 )

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -33,6 +33,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.joinforage.android.example.R
 import com.joinforage.android.example.pos.k9sdk.K9SDK
+import com.joinforage.android.example.pos.receipts.templates.txs.TxType
 import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
 import com.joinforage.android.example.ui.pos.data.RefundUIState
 import com.joinforage.android.example.ui.pos.screens.ActionSelectionScreen
@@ -450,7 +451,11 @@ fun POSComposeApp(
                     merchant = uiState.merchant,
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
-                    paymentRequest = uiState.localPayment,
+                    txType = uiState.capturePaymentResponse?.receipt?.let { it1 ->
+                        TxType.forReceipt(
+                            it1
+                        )
+                    },
                     paymentResponse = uiState.capturePaymentResponse!!,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.PAYPINEntryScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
@@ -501,7 +506,7 @@ fun POSComposeApp(
                     merchant = uiState.merchant,
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
-                    paymentRequest = uiState.localPayment,
+                    txType = uiState.refundPaymentResponse?.let { it1 -> TxType.forReceipt(it1.receipt) },
                     refundResponse = uiState.refundPaymentResponse!!,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.REFUNDPINEntryScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
@@ -549,8 +554,12 @@ fun POSComposeApp(
                     merchant = uiState.merchant,
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
-                    paymentRequest = uiState.localPayment,
-                    paymentResponse = uiState.capturePaymentResponse!!,
+                    txType = uiState.voidPaymentResponse?.let { it1 -> it1.receipt?.let { it2 ->
+                        TxType.forReceipt(
+                            it2
+                        )
+                    } },
+                    paymentResponse = uiState.voidPaymentResponse!!,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.VOIDPaymentScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
                 )
@@ -560,7 +569,7 @@ fun POSComposeApp(
                     merchant = uiState.merchant,
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
-                    paymentRequest = uiState.localPayment,
+                    txType = uiState.voidRefundResponse?.let { it1 -> TxType.forReceipt(it1.receipt) },
                     refundResponse = uiState.refundPaymentResponse!!,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.VOIDRefundScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -554,11 +554,13 @@ fun POSComposeApp(
                     merchant = uiState.merchant,
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
-                    txType = uiState.voidPaymentResponse?.let { it1 -> it1.receipt?.let { it2 ->
-                        TxType.forReceipt(
-                            it2
-                        )
-                    } },
+                    txType = uiState.voidPaymentResponse?.let { it1 ->
+                        it1.receipt?.let { it2 ->
+                            TxType.forReceipt(
+                                it2
+                            )
+                        }
+                    },
                     paymentResponse = uiState.voidPaymentResponse,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.VOIDPaymentScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -268,7 +268,7 @@ class POSViewModel : ViewModel() {
 
         viewModelScope.launch {
             try {
-                var response = api.voidPayment(
+                val response = api.voidPayment(
                     idempotencyKey = idempotencyKey,
                     paymentRef = paymentRef
                 )
@@ -302,10 +302,10 @@ class POSViewModel : ViewModel() {
                     refundRef = refundRef
                 )
                 val paymentMethod = api.getPaymentMethod(payment.paymentMethod)
-                if (response.receipt != null && payment.receipt != null) {
-                    response.receipt!!.isVoided = true
-                    response.receipt!!.balance.snap = (response.receipt!!.balance.snap.toDouble() - refund.receipt!!.snapAmount.toDouble()).toString()
-                    response.receipt!!.balance.nonSnap = (response.receipt!!.balance.nonSnap.toDouble() - refund.receipt!!.ebtCashAmount.toDouble()).toString()
+                if (payment.receipt != null) {
+                    response.receipt.isVoided = true
+                    response.receipt.balance.snap = (response.receipt.balance.snap.toDouble() - refund.receipt.snapAmount.toDouble()).toString()
+                    response.receipt.balance.nonSnap = (response.receipt.balance.nonSnap.toDouble() - refund.receipt.ebtCashAmount.toDouble()).toString()
                 }
                 _uiState.update { it.copy(voidRefundResponse = response, voidRefundError = null, tokenizedPaymentMethod = paymentMethod) }
                 onSuccess(response)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -263,7 +263,7 @@ class POSViewModel : ViewModel() {
                     idempotencyKey = idempotencyKey,
                     paymentRef = paymentRef
                 )
-                _uiState.update { it.copy(voidPaymentResponse = response) }
+                _uiState.update { it.copy(voidPaymentResponse = response, voidPaymentError = null) }
                 onSuccess(response)
                 Log.i("POSViewModel", "Void payment call succeeded: $response")
             } catch (e: HttpException) {
@@ -283,7 +283,7 @@ class POSViewModel : ViewModel() {
                     paymentRef = paymentRef,
                     refundRef = refundRef
                 )
-                _uiState.update { it.copy(voidRefundResponse = response) }
+                _uiState.update { it.copy(voidRefundResponse = response, voidRefundError = null) }
                 onSuccess(response)
                 Log.i("POSViewModel", "Void refund call succeeded: $response")
             } catch (e: HttpException) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosReceipt.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosReceipt.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class Receipt(
     @Json(name = "ref_number") val refNumber: String,
-    @Json(name = "is_voided") val isVoided: Boolean,
+    @Json(name = "is_voided") var isVoided: Boolean,
     @Json(name = "snap_amount") val snapAmount: String,
     @Json(name = "ebt_cash_amount") val ebtCashAmount: String,
     @Json(name = "cash_back_amount") val cashBackAmount: String,
@@ -23,7 +23,7 @@ data class Receipt(
 @JsonClass(generateAdapter = true)
 data class ReceiptBalance(
     val id: Double,
-    val snap: String,
-    @Json(name = "non_snap") val nonSnap: String,
+    var snap: String,
+    @Json(name = "non_snap") var nonSnap: String,
     val updated: String
 )

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
@@ -33,6 +33,11 @@ interface PosApiService {
         @Body payment: PosPaymentRequest
     ): PosPaymentResponse
 
+    @GET("api/payments/{paymentRef}/")
+    suspend fun getPayment(
+        @Path("paymentRef") paymentRef: String
+    ): PosPaymentResponse
+
     @POST("api/payments/{paymentRef}/void/")
     suspend fun voidPayment(
         @Header("Idempotency-Key") idempotencyKey: String,
@@ -47,7 +52,7 @@ interface PosApiService {
     ): Refund
 
     @POST("api/payment_methods/{paymentMethodRef}/")
-    suspend fun reFetchCard(
+    suspend fun getPaymentMethod(
         @Path("paymentMethodRef") paymentMethodRef: String
     ): PosPaymentMethod
 

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
@@ -44,6 +44,12 @@ interface PosApiService {
         @Path("paymentRef") paymentRef: String
     ): PosPaymentResponse
 
+    @GET("api/payments/{paymentRef}/refunds/{refundRef}/")
+    suspend fun getRefund(
+        @Path("paymentRef") paymentRef: String,
+        @Path("refundRef") refundRef: String
+    ): Refund
+
     @POST("api/payments/{paymentRef}/refunds/{refundRef}/void/")
     suspend fun voidRefund(
         @Header("Idempotency-Key") idempotencyKey: String,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentResultScreen.kt
@@ -16,7 +16,6 @@ import com.joinforage.android.example.pos.receipts.templates.txs.CashWithdrawalT
 import com.joinforage.android.example.pos.receipts.templates.txs.SnapPurchaseTxReceipt
 import com.joinforage.android.example.pos.receipts.templates.txs.TxType
 import com.joinforage.android.example.ui.pos.data.Merchant
-import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
 import com.joinforage.android.example.ui.pos.data.PosPaymentResponse
 import com.joinforage.android.example.ui.pos.data.tokenize.PosPaymentMethod
 import com.joinforage.android.example.ui.pos.screens.ReceiptPreviewScreen

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentResultScreen.kt
@@ -26,7 +26,7 @@ fun PaymentResultScreen(
     merchant: Merchant?,
     terminalId: String,
     paymentMethod: PosPaymentMethod?,
-    paymentRequest: PosPaymentRequest?,
+    txType: TxType?,
     paymentResponse: PosPaymentResponse?,
     onBackButtonClicked: () -> Unit,
     onDoneButtonClicked: () -> Unit
@@ -39,12 +39,11 @@ fun PaymentResultScreen(
         Column(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            if (paymentRequest == null) {
-                Text("null paymentRequest")
+            if (txType == null) {
+                Text("null txType")
             } else if (paymentResponse == null) {
                 Text("null paymentResponse")
             } else {
-                val txType = TxType.forPayment(paymentRequest)
                 var receipt: BaseReceiptTemplate? = null
                 if (txType == TxType.SNAP_PAYMENT) {
                     receipt = SnapPurchaseTxReceipt(
@@ -100,7 +99,7 @@ fun PaymentResultScreenPreview() {
         merchant = null,
         terminalId = "",
         paymentMethod = null,
-        paymentRequest = null,
+        txType = null,
         paymentResponse = null,
         onBackButtonClicked = {},
         onDoneButtonClicked = {}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentResultScreen.kt
@@ -2,12 +2,16 @@ package com.joinforage.android.example.ui.pos.screens.payment
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import com.joinforage.android.example.pos.receipts.templates.BaseReceiptTemplate
 import com.joinforage.android.example.pos.receipts.templates.txs.CashPurchaseTxReceipt
@@ -30,6 +34,8 @@ fun PaymentResultScreen(
     onBackButtonClicked: () -> Unit,
     onDoneButtonClicked: () -> Unit
 ) {
+    val clipboardManager = LocalClipboardManager.current
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceBetween,
@@ -76,7 +82,22 @@ fun PaymentResultScreen(
                         paymentResponse
                     )
                 }
-                ReceiptPreviewScreen(receipt!!.getReceiptLayout())
+                Column {
+                    if (paymentResponse.ref != null) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
+                        ) {
+                            Text("Payment Ref: ${paymentResponse.ref}")
+                            Button(onClick = {
+                                clipboardManager.setText(AnnotatedString(paymentResponse.ref!!))
+                            }, colors = ButtonDefaults.elevatedButtonColors()) {
+                                Text("Copy")
+                            }
+                        }
+                    }
+                    ReceiptPreviewScreen(receipt!!.getReceiptLayout())
+                }
             }
         }
         if (paymentMethod?.balance == null) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
@@ -26,7 +26,7 @@ fun RefundResultScreen(
     merchant: Merchant?,
     terminalId: String,
     paymentMethod: PosPaymentMethod?,
-    paymentRequest: PosPaymentRequest?,
+    txType: TxType?,
     refundResponse: Refund?,
     onBackButtonClicked: () -> Unit,
     onDoneButtonClicked: () -> Unit
@@ -39,12 +39,11 @@ fun RefundResultScreen(
         Column(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            if (paymentRequest == null) {
+            if (txType == null) {
                 Text("null paymentRequest")
             } else if (refundResponse == null) {
                 Text("null refundResponse")
             } else {
-                val txType = TxType.forPayment(paymentRequest)
                 var receipt: BaseReceiptTemplate? = null
                 if (txType == TxType.SNAP_PAYMENT) {
                     receipt = SnapPurchaseTxReceipt(
@@ -100,7 +99,7 @@ fun RefundResultScreenPreview() {
         merchant = null,
         terminalId = "",
         paymentMethod = null,
-        paymentRequest = null,
+        txType = null,
         refundResponse = null,
         onBackButtonClicked = {},
         onDoneButtonClicked = {}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
@@ -16,7 +16,6 @@ import com.joinforage.android.example.pos.receipts.templates.txs.CashWithdrawalT
 import com.joinforage.android.example.pos.receipts.templates.txs.SnapPurchaseTxReceipt
 import com.joinforage.android.example.pos.receipts.templates.txs.TxType
 import com.joinforage.android.example.ui.pos.data.Merchant
-import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
 import com.joinforage.android.example.ui.pos.data.Refund
 import com.joinforage.android.example.ui.pos.data.tokenize.PosPaymentMethod
 import com.joinforage.android.example.ui.pos.screens.ReceiptPreviewScreen

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
@@ -2,12 +2,16 @@ package com.joinforage.android.example.ui.pos.screens.refund
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import com.joinforage.android.example.pos.receipts.templates.BaseReceiptTemplate
 import com.joinforage.android.example.pos.receipts.templates.txs.CashPurchaseTxReceipt
@@ -30,6 +34,8 @@ fun RefundResultScreen(
     onBackButtonClicked: () -> Unit,
     onDoneButtonClicked: () -> Unit
 ) {
+    val clipboardManager = LocalClipboardManager.current
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceBetween,
@@ -76,11 +82,25 @@ fun RefundResultScreen(
                         refundResponse
                     )
                 }
-                if (receipt != null) {
-                    ReceiptPreviewScreen(receipt.getReceiptLayout())
-                } else {
-                    Text("Couldn't find receipt template matching transaction type: ${txType.title}")
+                Column {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        Text("Refund Ref: ${refundResponse.ref}")
+                        Button(onClick = {
+                            clipboardManager.setText(AnnotatedString(refundResponse.ref))
+                        }, colors = ButtonDefaults.elevatedButtonColors()) {
+                            Text("Copy")
+                        }
+                    }
+                    if (receipt != null) {
+                        ReceiptPreviewScreen(receipt.getReceiptLayout())
+                    } else {
+                        Text("Couldn't find receipt template matching transaction type: ${txType.title}")
+                    }
                 }
+
             }
         }
         if (paymentMethod?.balance == null) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
@@ -100,7 +100,6 @@ fun RefundResultScreen(
                         Text("Couldn't find receipt template matching transaction type: ${txType.title}")
                     }
                 }
-
             }
         }
         if (paymentMethod?.balance == null) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
@@ -40,12 +40,12 @@ fun RefundResultScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             if (txType == null) {
-                Text("null paymentRequest")
+                Text("null txType")
             } else if (refundResponse == null) {
                 Text("null refundResponse")
             } else {
                 var receipt: BaseReceiptTemplate? = null
-                if (txType == TxType.SNAP_PAYMENT) {
+                if (txType == TxType.REFUND_SNAP_PAYMENT) {
                     receipt = SnapPurchaseTxReceipt(
                         merchant,
                         terminalId,
@@ -53,7 +53,7 @@ fun RefundResultScreen(
                         refundResponse
                     )
                 }
-                if (txType == TxType.CASH_PAYMENT) {
+                if (txType == TxType.REFUND_CASH_PAYMENT) {
                     receipt = CashPurchaseTxReceipt(
                         merchant,
                         terminalId,
@@ -61,7 +61,7 @@ fun RefundResultScreen(
                         refundResponse
                     )
                 }
-                if (txType == TxType.CASH_PURCHASE_WITH_CASHBACK) {
+                if (txType == TxType.REFUND_CASH_PURCHASE_WITH_CASHBACK) {
                     receipt = CashPurchaseWithCashbackTxReceipt(
                         merchant,
                         terminalId,
@@ -69,7 +69,7 @@ fun RefundResultScreen(
                         refundResponse
                     )
                 }
-                if (txType == TxType.CASH_WITHDRAWAL) {
+                if (txType == TxType.REFUND_CASH_WITHDRAWAL) {
                     receipt = CashWithdrawalTxReceipt(
                         merchant,
                         terminalId,
@@ -77,7 +77,11 @@ fun RefundResultScreen(
                         refundResponse
                     )
                 }
-                ReceiptPreviewScreen(receipt!!.getReceiptLayout())
+                if (receipt != null) {
+                    ReceiptPreviewScreen(receipt.getReceiptLayout())
+                } else {
+                    Text("Couldn't find receipt template matching transaction type: ${txType.title}")
+                }
             }
         }
         if (paymentMethod?.balance == null) {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidPaymentResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidPaymentResultScreen.kt
@@ -2,8 +2,8 @@ package com.joinforage.android.example.ui.pos.screens.voids
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.joinforage.android.example.pos.receipts.templates.txs.TxType
 import com.joinforage.android.example.ui.pos.data.Merchant
-import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
 import com.joinforage.android.example.ui.pos.data.PosPaymentResponse
 import com.joinforage.android.example.ui.pos.data.tokenize.PosPaymentMethod
 import com.joinforage.android.example.ui.pos.screens.payment.PaymentResultScreen
@@ -13,7 +13,7 @@ fun VoidPaymentResultScreen(
     merchant: Merchant?,
     terminalId: String,
     paymentMethod: PosPaymentMethod?,
-    paymentRequest: PosPaymentRequest?,
+    txType: TxType?,
     paymentResponse: PosPaymentResponse?,
     onBackButtonClicked: () -> Unit,
     onDoneButtonClicked: () -> Unit
@@ -22,7 +22,7 @@ fun VoidPaymentResultScreen(
         merchant,
         terminalId,
         paymentMethod,
-        paymentRequest,
+        txType,
         paymentResponse,
         onBackButtonClicked,
         onDoneButtonClicked
@@ -36,7 +36,7 @@ fun VoidPaymentResultScreenPreview() {
         merchant = null,
         terminalId = "",
         paymentMethod = null,
-        paymentRequest = null,
+        txType = null,
         paymentResponse = null,
         onBackButtonClicked = {},
         onDoneButtonClicked = {}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidRefundResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidRefundResultScreen.kt
@@ -2,8 +2,8 @@ package com.joinforage.android.example.ui.pos.screens.voids
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.joinforage.android.example.pos.receipts.templates.txs.TxType
 import com.joinforage.android.example.ui.pos.data.Merchant
-import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
 import com.joinforage.android.example.ui.pos.data.Refund
 import com.joinforage.android.example.ui.pos.data.tokenize.PosPaymentMethod
 import com.joinforage.android.example.ui.pos.screens.refund.RefundResultScreen
@@ -13,7 +13,7 @@ fun VoidRefundResultScreen(
     merchant: Merchant?,
     terminalId: String,
     paymentMethod: PosPaymentMethod?,
-    paymentRequest: PosPaymentRequest?,
+    txType: TxType?,
     refundResponse: Refund?,
     onBackButtonClicked: () -> Unit,
     onDoneButtonClicked: () -> Unit
@@ -22,7 +22,7 @@ fun VoidRefundResultScreen(
         merchant,
         terminalId,
         paymentMethod,
-        paymentRequest,
+        txType,
         refundResponse,
         onBackButtonClicked,
         onDoneButtonClicked
@@ -36,7 +36,7 @@ fun VoidRefundResultScreenPreview() {
         merchant = null,
         terminalId = "",
         paymentMethod = null,
-        paymentRequest = null,
+        txType = null,
         refundResponse = null,
         onBackButtonClicked = {},
         onDoneButtonClicked = {}


### PR DESCRIPTION
## What
Updates void receipts to have accurate status and balances.

In order to facilitate that^ I had to do a fair amount of refactoring. We were relying on the local tokenizedPaymentMethod and paymentRequest in a few places where they sometimes may not be set. Now that we're clearing the app state with the restart button, these values get cleared when starting a new flow. So, for instance, trying to void something would never have a tokenizedPaymentMethod since you never hit a PAN field in that flow. Before this change, we could've had a subtle bug where the receipt could've shown payment method info that wasn't associated with the actual transaction being voided or refunded.

I went through the receipt flows and figured out what data we needed where and what the right source of truth for it was, then added calls in the view model methods to populate those state fields each time. 

This also adds click-to-copy refs to payment and refund result pages

## Why
https://linear.app/joinforage/issue/FX-1050/feature-add-ref-to-payment-and-refund-receipts
https://linear.app/joinforage/issue/FX-1051/bug-void-receipt-has-inaccurate-data

## Test Plan
Manually tested to verify correct receipt status and balances for both payment and refund voids

## How
Can be merged as-is