### PR TITLE
[FX-828] Handle cord-pulled scenarios where we need to refetch payments/refunds on demand to generate receipts

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/CashPurchaseTxReceipt.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/CashPurchaseTxReceipt.kt
@@ -18,7 +18,7 @@ internal class CashPurchaseTxReceipt : TxReceiptTemplate {
         terminalId: String,
         paymentMethod: PosPaymentMethod?,
         refund: Refund
-    ) : super(merchant, terminalId, paymentMethod, refund.receipt) {
+    ) : super(merchant, terminalId, paymentMethod, refund.receipt!!) {
         cashAmt = negateAmt(cashAmt)
     }
 

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/CashPurchaseWithCashbackTxReceipt.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/CashPurchaseWithCashbackTxReceipt.kt
@@ -20,7 +20,7 @@ internal class CashPurchaseWithCashbackTxReceipt : TxReceiptTemplate {
         terminalId: String,
         paymentMethod: PosPaymentMethod?,
         refund: Refund
-    ) : super(merchant, terminalId, paymentMethod, refund.receipt) {
+    ) : super(merchant, terminalId, paymentMethod, refund.receipt!!) {
         cashAmt = negateAmt(cashAmt)
     }
 

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/CashWithdrawalTxReceipt.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/CashWithdrawalTxReceipt.kt
@@ -19,7 +19,7 @@ internal class CashWithdrawalTxReceipt : TxReceiptTemplate {
         terminalId: String,
         paymentMethod: PosPaymentMethod?,
         refund: Refund
-    ) : super(merchant, terminalId, paymentMethod, refund.receipt)
+    ) : super(merchant, terminalId, paymentMethod, refund.receipt!!)
 
     override val txContent = CashWithdrawalLayout(
         snapBal,

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/SnapPurchaseTxReceipt.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/SnapPurchaseTxReceipt.kt
@@ -19,7 +19,7 @@ internal class SnapPurchaseTxReceipt : TxReceiptTemplate {
         terminalId: String,
         paymentMethod: PosPaymentMethod?,
         refund: Refund
-    ) : super(merchant, terminalId, paymentMethod, refund.receipt) {
+    ) : super(merchant, terminalId, paymentMethod, refund.receipt!!) {
         snapAmt = negateAmt(snapAmt)
     }
 

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -512,11 +512,13 @@ fun POSComposeApp(
                     merchant = uiState.merchant,
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
-                    txType = uiState.refundPaymentResponse?.let { it1 -> it1.receipt?.let { it2 ->
-                        TxType.forReceipt(
-                            it2
-                        )
-                    } },
+                    txType = uiState.refundPaymentResponse?.let { it1 ->
+                        it1.receipt?.let { it2 ->
+                            TxType.forReceipt(
+                                it2
+                            )
+                        }
+                    },
                     refundResponse = uiState.refundPaymentResponse!!,
                     fetchedPayment = uiState.capturePaymentResponse,
                     onRefundRefClicked = { paymentRef, refundRef -> viewModel.fetchRefund(paymentRef, refundRef) },
@@ -590,11 +592,13 @@ fun POSComposeApp(
                     merchant = uiState.merchant,
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
-                    txType = uiState.voidRefundResponse?.let { it1 -> it1.receipt?.let { it2 ->
-                        TxType.forReceipt(
-                            it2
-                        )
-                    } },
+                    txType = uiState.voidRefundResponse?.let { it1 ->
+                        it1.receipt?.let { it2 ->
+                            TxType.forReceipt(
+                                it2
+                            )
+                        }
+                    },
                     refundResponse = uiState.voidRefundResponse,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.VOIDRefundScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -458,7 +458,12 @@ fun POSComposeApp(
                     },
                     paymentResponse = uiState.capturePaymentResponse!!,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.PAYPINEntryScreen.name, inclusive = false) },
-                    onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
+                    onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) },
+                    onReloadButtonClicked = {
+                        if (uiState.createPaymentResponse?.ref != null) {
+                            viewModel.fetchPayment(uiState.createPaymentResponse!!.ref!!)
+                        }
+                    }
                 )
             }
             composable(route = POSScreen.REFUNDDetailsScreen.name) {
@@ -507,10 +512,23 @@ fun POSComposeApp(
                     merchant = uiState.merchant,
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
-                    txType = uiState.refundPaymentResponse?.let { it1 -> TxType.forReceipt(it1.receipt) },
+                    txType = uiState.refundPaymentResponse?.let { it1 -> it1.receipt?.let { it2 ->
+                        TxType.forReceipt(
+                            it2
+                        )
+                    } },
                     refundResponse = uiState.refundPaymentResponse!!,
+                    fetchedPayment = uiState.capturePaymentResponse,
+                    onRefundRefClicked = { paymentRef, refundRef -> viewModel.fetchRefund(paymentRef, refundRef) },
                     onBackButtonClicked = { navController.popBackStack(POSScreen.REFUNDPINEntryScreen.name, inclusive = false) },
-                    onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
+                    onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) },
+                    onReloadButtonClicked = {
+                        if (uiState.localRefundState?.paymentRef != null) {
+                            if (uiState.capturePaymentResponse?.ref == null) {
+                                viewModel.fetchPayment(uiState.localRefundState!!.paymentRef)
+                            }
+                        }
+                    }
                 )
             }
             composable(route = POSScreen.VOIDTransactionTypeSelectionScreen.name) {
@@ -572,7 +590,11 @@ fun POSComposeApp(
                     merchant = uiState.merchant,
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
-                    txType = uiState.voidRefundResponse?.let { it1 -> TxType.forReceipt(it1.receipt) },
+                    txType = uiState.voidRefundResponse?.let { it1 -> it1.receipt?.let { it2 ->
+                        TxType.forReceipt(
+                            it2
+                        )
+                    } },
                     refundResponse = uiState.voidRefundResponse,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.VOIDRefundScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -71,6 +71,28 @@ class POSViewModel : ViewModel() {
         }
     }
 
+    fun fetchPayment(paymentRef: String) {
+        viewModelScope.launch {
+            try {
+                val payment = api.getPayment(paymentRef)
+                _uiState.update { it.copy(capturePaymentResponse = payment, capturePaymentError = null) }
+            } catch (e: HttpException) {
+                _uiState.update { it.copy(capturePaymentError = e.toString()) }
+            }
+        }
+    }
+
+    fun fetchRefund(paymentRef: String, refundRef: String) {
+        viewModelScope.launch {
+            try {
+                val refund = api.getRefund(paymentRef, refundRef)
+                _uiState.update { it.copy(refundPaymentResponse = refund, refundPaymentError = null) }
+            } catch (e: HttpException) {
+                _uiState.update { it.copy(refundPaymentError = e.toString()) }
+            }
+        }
+    }
+
     fun resetUiState() {
         // this needs to be in a coroutine and delayed to allow for the back-stack
         // to be fully popped before some of the data it depends on disappears.
@@ -313,9 +335,9 @@ class POSViewModel : ViewModel() {
                 )
                 val paymentMethod = api.getPaymentMethod(payment.paymentMethod)
                 if (payment.receipt != null) {
-                    response.receipt.isVoided = true
-                    response.receipt.balance.snap = (response.receipt.balance.snap.toDouble() - refund.receipt.snapAmount.toDouble()).toString()
-                    response.receipt.balance.nonSnap = (response.receipt.balance.nonSnap.toDouble() - refund.receipt.ebtCashAmount.toDouble()).toString()
+                    response.receipt!!.isVoided = true
+                    response.receipt.balance.snap = (response.receipt.balance.snap.toDouble() - refund.receipt!!.snapAmount!!.toDouble()).toString()
+                    response.receipt.balance.nonSnap = (response.receipt.balance.nonSnap.toDouble() - refund.receipt!!.ebtCashAmount!!.toDouble()).toString()
                 }
                 _uiState.update { it.copy(voidRefundResponse = response, voidRefundError = null, tokenizedPaymentMethod = paymentMethod) }
                 onSuccess(response)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/Refund.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/Refund.kt
@@ -15,7 +15,7 @@ data class Refund(
     val updated: String,
     val status: String,
     @Json(name = "last_processing_error") val lastProcessingError: String?,
-    val receipt: Receipt,
+    val receipt: Receipt?,
     @Json(name = "pos_terminal") val posTerminal: RefundPosTerminal,
     @Json(name = "external_order_id") val externalOrderId: String?,
     val messages: RefundVoidMessages?

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentResultScreen.kt
@@ -32,7 +32,8 @@ fun PaymentResultScreen(
     txType: TxType?,
     paymentResponse: PosPaymentResponse?,
     onBackButtonClicked: () -> Unit,
-    onDoneButtonClicked: () -> Unit
+    onDoneButtonClicked: () -> Unit,
+    onReloadButtonClicked: () -> Unit
 ) {
     val clipboardManager = LocalClipboardManager.current
 
@@ -45,7 +46,10 @@ fun PaymentResultScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             if (txType == null) {
-                Text("null txType")
+                Text("Unable to determine transaction type. Terminal might be offline.")
+                Button(onClick = onReloadButtonClicked) {
+                    Text("Re-fetch Payment")
+                }
             } else if (paymentResponse == null) {
                 Text("null paymentResponse")
             } else {
@@ -122,6 +126,7 @@ fun PaymentResultScreenPreview() {
         txType = null,
         paymentResponse = null,
         onBackButtonClicked = {},
-        onDoneButtonClicked = {}
+        onDoneButtonClicked = {},
+        onReloadButtonClicked = {}
     )
 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
@@ -20,6 +20,7 @@ import com.joinforage.android.example.pos.receipts.templates.txs.CashWithdrawalT
 import com.joinforage.android.example.pos.receipts.templates.txs.SnapPurchaseTxReceipt
 import com.joinforage.android.example.pos.receipts.templates.txs.TxType
 import com.joinforage.android.example.ui.pos.data.Merchant
+import com.joinforage.android.example.ui.pos.data.PosPaymentResponse
 import com.joinforage.android.example.ui.pos.data.Refund
 import com.joinforage.android.example.ui.pos.data.tokenize.PosPaymentMethod
 import com.joinforage.android.example.ui.pos.screens.ReceiptPreviewScreen
@@ -31,8 +32,11 @@ fun RefundResultScreen(
     paymentMethod: PosPaymentMethod?,
     txType: TxType?,
     refundResponse: Refund?,
+    fetchedPayment: PosPaymentResponse?,
+    onRefundRefClicked: (paymentRef: String, refundRef: String) -> Unit,
     onBackButtonClicked: () -> Unit,
-    onDoneButtonClicked: () -> Unit
+    onDoneButtonClicked: () -> Unit,
+    onReloadButtonClicked: () -> Unit
 ) {
     val clipboardManager = LocalClipboardManager.current
 
@@ -45,7 +49,20 @@ fun RefundResultScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             if (txType == null) {
-                Text("null txType")
+                Text("Unable to determine transaction type. Terminal might be offline.")
+                if (fetchedPayment?.ref == null) {
+                    Text("Re-fetch payment to see a list of refunds on the payment.")
+                    Button(onClick = onReloadButtonClicked) {
+                        Text("Re-fetch Payment")
+                    }
+                } else {
+                    Text("Select a Refund ref from payment (${fetchedPayment.ref}) to view the receipt for:")
+                    fetchedPayment.refunds.forEach { refundRef ->
+                        Button(onClick = { onRefundRefClicked(fetchedPayment.ref!!, refundRef) }) {
+                            Text(refundRef)
+                        }
+                    }
+                }
             } else if (refundResponse == null) {
                 Text("null refundResponse")
             } else {
@@ -123,7 +140,10 @@ fun RefundResultScreenPreview() {
         paymentMethod = null,
         txType = null,
         refundResponse = null,
+        fetchedPayment = null,
+        onRefundRefClicked = { _, _ ->},
         onBackButtonClicked = {},
-        onDoneButtonClicked = {}
+        onDoneButtonClicked = {},
+        onReloadButtonClicked = {}
     )
 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/refund/RefundResultScreen.kt
@@ -141,7 +141,7 @@ fun RefundResultScreenPreview() {
         txType = null,
         refundResponse = null,
         fetchedPayment = null,
-        onRefundRefClicked = { _, _ ->},
+        onRefundRefClicked = { _, _ -> },
         onBackButtonClicked = {},
         onDoneButtonClicked = {},
         onReloadButtonClicked = {}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidPaymentResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidPaymentResultScreen.kt
@@ -25,7 +25,8 @@ fun VoidPaymentResultScreen(
         txType,
         paymentResponse,
         onBackButtonClicked,
-        onDoneButtonClicked
+        onDoneButtonClicked,
+        onReloadButtonClicked = {}
     )
 }
 

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidRefundResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidRefundResultScreen.kt
@@ -25,7 +25,7 @@ fun VoidRefundResultScreen(
         txType,
         refundResponse,
         fetchedPayment = null,
-        onRefundRefClicked = { _, _ ->},
+        onRefundRefClicked = { _, _ -> },
         onBackButtonClicked,
         onDoneButtonClicked,
         onReloadButtonClicked = {}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidRefundResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidRefundResultScreen.kt
@@ -24,8 +24,11 @@ fun VoidRefundResultScreen(
         paymentMethod,
         txType,
         refundResponse,
+        fetchedPayment = null,
+        onRefundRefClicked = { _, _ ->},
         onBackButtonClicked,
-        onDoneButtonClicked
+        onDoneButtonClicked,
+        onReloadButtonClicked = {}
     )
 }
 


### PR DESCRIPTION
## What
Updates the receipt logic to handle the situation where the android SDK doesn't poll for sqs messages (simulating what would happen if the terminal was offline), so the backend auto-voids the payment/refund after it goes unacknowledged by the client for 90 seconds.

This is accomplished by showing a button to refetch the relevant entity instead of displaying a receipt. After the auto-void has occurred in the backend, we can tap the button to refetch the data and display the receipt that accurately reflects the now-voided status

## Why
https://linear.app/joinforage/issue/FX-828/pos-application-needs-to-offer-a-way-to-get-the-last-payment-refund

## Test Plan
- Manually verified the correct behavior in the emulator with the polling disabled in the local android SDK. See demo videos.

## Demo

This is the behavior when we don't poll for a payment...

https://github.com/teamforage/forage-android-sdk/assets/11556475/2b59fdb0-a48f-4a2f-8b48-a0205fd73348


This is the behavior when we don't poll for a refund... 

https://github.com/teamforage/forage-android-sdk/assets/11556475/095fbbdf-f949-460c-ac13-4d89cd5ee154


## How
Can be merged as-is