### PR TITLE
[FX-1019] Add support for printing receipts for payment declines

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/CashPurchaseTxReceipt.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/CashPurchaseTxReceipt.kt
@@ -1,7 +1,7 @@
 package com.joinforage.android.example.pos.receipts.templates.txs
 
 import com.joinforage.android.example.ui.pos.data.Merchant
-import com.joinforage.android.example.ui.pos.data.PosPaymentResponse
+import com.joinforage.android.example.ui.pos.data.Receipt
 import com.joinforage.android.example.ui.pos.data.Refund
 import com.joinforage.android.example.ui.pos.data.tokenize.PosPaymentMethod
 
@@ -11,8 +11,8 @@ internal class CashPurchaseTxReceipt : TxReceiptTemplate {
         merchant: Merchant?,
         terminalId: String,
         paymentMethod: PosPaymentMethod?,
-        payment: PosPaymentResponse
-    ) : super(merchant, terminalId, paymentMethod, payment.receipt!!)
+        receipt: Receipt
+    ) : super(merchant, terminalId, paymentMethod, receipt)
     constructor(
         merchant: Merchant?,
         terminalId: String,

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/CashPurchaseWithCashbackTxReceipt.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/CashPurchaseWithCashbackTxReceipt.kt
@@ -1,7 +1,7 @@
 package com.joinforage.android.example.pos.receipts.templates.txs
 
 import com.joinforage.android.example.ui.pos.data.Merchant
-import com.joinforage.android.example.ui.pos.data.PosPaymentResponse
+import com.joinforage.android.example.ui.pos.data.Receipt
 import com.joinforage.android.example.ui.pos.data.Refund
 import com.joinforage.android.example.ui.pos.data.tokenize.PosPaymentMethod
 
@@ -12,8 +12,8 @@ internal class CashPurchaseWithCashbackTxReceipt : TxReceiptTemplate {
         merchant: Merchant?,
         terminalId: String,
         paymentMethod: PosPaymentMethod?,
-        payment: PosPaymentResponse
-    ) : super(merchant, terminalId, paymentMethod, payment.receipt!!)
+        receipt: Receipt
+    ) : super(merchant, terminalId, paymentMethod, receipt)
 
     constructor(
         merchant: Merchant?,

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/CashWithdrawalTxReceipt.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/CashWithdrawalTxReceipt.kt
@@ -1,7 +1,7 @@
 package com.joinforage.android.example.pos.receipts.templates.txs
 
 import com.joinforage.android.example.ui.pos.data.Merchant
-import com.joinforage.android.example.ui.pos.data.PosPaymentResponse
+import com.joinforage.android.example.ui.pos.data.Receipt
 import com.joinforage.android.example.ui.pos.data.Refund
 import com.joinforage.android.example.ui.pos.data.tokenize.PosPaymentMethod
 
@@ -10,8 +10,8 @@ internal class CashWithdrawalTxReceipt : TxReceiptTemplate {
         merchant: Merchant?,
         terminalId: String,
         paymentMethod: PosPaymentMethod?,
-        payment: PosPaymentResponse
-    ) : super(merchant, terminalId, paymentMethod, payment.receipt!!)
+        receipt: Receipt
+    ) : super(merchant, terminalId, paymentMethod, receipt)
 
     // TODO: find out whether it's even possible to negate a cashback tx
     constructor(

--- a/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/SnapPurchaseTxReceipt.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/pos/receipts/templates/txs/SnapPurchaseTxReceipt.kt
@@ -1,7 +1,7 @@
 package com.joinforage.android.example.pos.receipts.templates.txs
 
 import com.joinforage.android.example.ui.pos.data.Merchant
-import com.joinforage.android.example.ui.pos.data.PosPaymentResponse
+import com.joinforage.android.example.ui.pos.data.Receipt
 import com.joinforage.android.example.ui.pos.data.Refund
 import com.joinforage.android.example.ui.pos.data.tokenize.PosPaymentMethod
 
@@ -11,8 +11,8 @@ internal class SnapPurchaseTxReceipt : TxReceiptTemplate {
         merchant: Merchant?,
         terminalId: String,
         paymentMethod: PosPaymentMethod?,
-        payment: PosPaymentResponse
-    ) : super(merchant, terminalId, paymentMethod, payment.receipt!!)
+        receipt: Receipt
+    ) : super(merchant, terminalId, paymentMethod, receipt)
 
     constructor(
         merchant: Merchant?,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -35,11 +35,9 @@ import com.joinforage.android.example.R
 import com.joinforage.android.example.pos.k9sdk.K9SDK
 import com.joinforage.android.example.pos.receipts.templates.txs.TxType
 import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
-import com.joinforage.android.example.ui.pos.data.Receipt
 import com.joinforage.android.example.ui.pos.data.RefundUIState
 import com.joinforage.android.example.ui.pos.screens.ActionSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.MerchantSetupScreen
-import com.joinforage.android.example.ui.pos.screens.ReceiptPreviewScreen
 import com.joinforage.android.example.ui.pos.screens.balance.BalanceResultScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTCashPurchaseScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTCashPurchaseWithCashBackScreen
@@ -58,7 +56,6 @@ import com.joinforage.android.example.ui.pos.screens.voids.VoidPaymentScreen
 import com.joinforage.android.example.ui.pos.screens.voids.VoidRefundResultScreen
 import com.joinforage.android.example.ui.pos.screens.voids.VoidRefundScreen
 import com.joinforage.android.example.ui.pos.screens.voids.VoidTypeSelectionScreen
-import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
 import com.joinforage.forage.android.ui.ForagePANEditText
 import com.joinforage.forage.android.ui.ForagePINEditText
 
@@ -457,12 +454,13 @@ fun POSComposeApp(
                     merchant = uiState.merchant,
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
+                    paymentRef = uiState.capturePaymentResponse!!.ref!!,
                     txType = uiState.capturePaymentResponse?.receipt?.let { it1 ->
                         TxType.forReceipt(
                             it1
                         )
                     },
-                    paymentResponse = uiState.capturePaymentResponse!!,
+                    receipt = uiState.capturePaymentResponse!!.receipt,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.PAYPINEntryScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) },
                     onReloadButtonClicked = {
@@ -584,6 +582,7 @@ fun POSComposeApp(
                     merchant = uiState.merchant,
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
+                    paymentRef = uiState.voidPaymentResponse!!.ref!!,
                     txType = uiState.voidPaymentResponse?.let { it1 ->
                         it1.receipt?.let { it2 ->
                             TxType.forReceipt(
@@ -591,7 +590,7 @@ fun POSComposeApp(
                             )
                         }
                     },
-                    paymentResponse = uiState.voidPaymentResponse,
+                    receipt = uiState.voidPaymentResponse!!.receipt,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.VOIDPaymentScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
                 )

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -35,9 +35,11 @@ import com.joinforage.android.example.R
 import com.joinforage.android.example.pos.k9sdk.K9SDK
 import com.joinforage.android.example.pos.receipts.templates.txs.TxType
 import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
+import com.joinforage.android.example.ui.pos.data.Receipt
 import com.joinforage.android.example.ui.pos.data.RefundUIState
 import com.joinforage.android.example.ui.pos.screens.ActionSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.MerchantSetupScreen
+import com.joinforage.android.example.ui.pos.screens.ReceiptPreviewScreen
 import com.joinforage.android.example.ui.pos.screens.balance.BalanceResultScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTCashPurchaseScreen
 import com.joinforage.android.example.ui.pos.screens.payment.EBTCashPurchaseWithCashBackScreen
@@ -56,6 +58,7 @@ import com.joinforage.android.example.ui.pos.screens.voids.VoidPaymentScreen
 import com.joinforage.android.example.ui.pos.screens.voids.VoidRefundResultScreen
 import com.joinforage.android.example.ui.pos.screens.voids.VoidRefundScreen
 import com.joinforage.android.example.ui.pos.screens.voids.VoidTypeSelectionScreen
+import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
 import com.joinforage.forage.android.ui.ForagePANEditText
 import com.joinforage.forage.android.ui.ForagePINEditText
 
@@ -437,6 +440,9 @@ fun POSComposeApp(
                                     if (it?.ref != null) {
                                         navController.navigate(POSScreen.PAYResultScreen.name)
                                     }
+                                },
+                                onFailure = {
+                                    navController.navigate(POSScreen.PAYResultScreen.name)
                                 }
                             )
                         }
@@ -498,6 +504,9 @@ fun POSComposeApp(
                                     if (it != null) {
                                         navController.navigate(POSScreen.REFUNDResultScreen.name)
                                     }
+                                },
+                                onFailure = {
+                                    navController.navigate(POSScreen.REFUNDResultScreen.name)
                                 }
                             )
                         }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -35,6 +35,8 @@ import com.joinforage.android.example.R
 import com.joinforage.android.example.pos.k9sdk.K9SDK
 import com.joinforage.android.example.pos.receipts.templates.txs.TxType
 import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
+import com.joinforage.android.example.ui.pos.data.Receipt
+import com.joinforage.android.example.ui.pos.data.ReceiptBalance
 import com.joinforage.android.example.ui.pos.data.RefundUIState
 import com.joinforage.android.example.ui.pos.screens.ActionSelectionScreen
 import com.joinforage.android.example.ui.pos.screens.MerchantSetupScreen
@@ -433,12 +435,7 @@ fun POSComposeApp(
                                 foragePinEditText = pinElement as ForagePINEditText,
                                 terminalId = k9SDK.terminalId,
                                 paymentRef = uiState.createPaymentResponse!!.ref!!,
-                                onSuccess = {
-                                    if (it?.ref != null) {
-                                        navController.navigate(POSScreen.PAYResultScreen.name)
-                                    }
-                                },
-                                onFailure = {
+                                onComplete = {
                                     navController.navigate(POSScreen.PAYResultScreen.name)
                                 }
                             )
@@ -450,17 +447,39 @@ fun POSComposeApp(
                 )
             }
             composable(route = POSScreen.PAYResultScreen.name) {
+                val paymentRef = uiState.capturePaymentResponse?.ref ?: uiState.createPaymentResponse!!.ref!!
+                val manualErrorReceipt = Receipt(
+                    refNumber = paymentRef,
+                    isVoided = false,
+                    snapAmount = (if (uiState.createPaymentResponse!!.fundingType == "ebt_snap") uiState.createPaymentResponse!!.amount else "0.00").toString(),
+                    ebtCashAmount = (if (uiState.createPaymentResponse!!.fundingType == "ebt_cash") uiState.createPaymentResponse!!.amount else "0.00").toString(),
+                    cashBackAmount = uiState.createPaymentResponse!!.cashBackAmount.toString(),
+                    otherAmount = "0.00",
+                    salesTaxApplied = "0.00",
+                    last4 = uiState.tokenizedPaymentMethod!!.card!!.last4,
+                    transactionType = "Payment",
+                    sequenceNumber = "TODO", // TODO (evanfreeze): Need to get this sequence number from somewhere?
+                    balance = ReceiptBalance(
+                        id = 0.toDouble(),
+                        snap = uiState.tokenizedPaymentMethod!!.balance!!.snap,
+                        nonSnap = uiState.tokenizedPaymentMethod!!.balance!!.non_snap,
+                        updated = uiState.tokenizedPaymentMethod!!.balance!!.updated
+                    ),
+                    created = uiState.createPaymentResponse!!.created,
+                    message = uiState.capturePaymentError ?: "Unknown Error"
+                )
+
                 PaymentResultScreen(
                     merchant = uiState.merchant,
                     terminalId = k9SDK.terminalId,
                     paymentMethod = uiState.tokenizedPaymentMethod,
-                    paymentRef = uiState.capturePaymentResponse!!.ref!!,
+                    paymentRef = paymentRef,
                     txType = uiState.capturePaymentResponse?.receipt?.let { it1 ->
                         TxType.forReceipt(
                             it1
                         )
-                    },
-                    receipt = uiState.capturePaymentResponse!!.receipt,
+                    } ?: uiState.localPayment?.let { TxType.forPayment(it) },
+                    receipt = uiState.capturePaymentResponse?.receipt ?: manualErrorReceipt,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.PAYPINEntryScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) },
                     onReloadButtonClicked = {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -521,9 +521,6 @@ fun POSComposeApp(
                                     if (it != null) {
                                         navController.navigate(POSScreen.REFUNDResultScreen.name)
                                     }
-                                },
-                                onFailure = {
-                                    navController.navigate(POSScreen.REFUNDResultScreen.name)
                                 }
                             )
                         }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -260,7 +260,7 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun refundPayment(foragePinEditText: ForagePINEditText, terminalId: String, amount: Float, paymentRef: String, reason: String, onSuccess: (response: Refund?) -> Unit, onFailure: () -> Unit) {
+    fun refundPayment(foragePinEditText: ForagePINEditText, terminalId: String, amount: Float, paymentRef: String, reason: String, onSuccess: (response: Refund?) -> Unit) {
         viewModelScope.launch {
             val response = ForageTerminalSDK(terminalId).refundPayment(
                 PosRefundPaymentParams(
@@ -290,8 +290,7 @@ class POSViewModel : ViewModel() {
                 }
                 is ForageApiResponse.Failure -> {
                     Log.e("POSViewModel", response.toString())
-                    _uiState.update { it.copy(refundPaymentError = response.errors.joinToString("\n"), refundPaymentResponse = null) }
-                    onFailure()
+                    _uiState.update { it.copy(refundPaymentError = response.toString(), refundPaymentResponse = null) }
                 }
             }
         }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -225,7 +225,7 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun capturePayment(foragePinEditText: ForagePINEditText, terminalId: String, paymentRef: String, onSuccess: (response: PosPaymentResponse?) -> Unit) {
+    fun capturePayment(foragePinEditText: ForagePINEditText, terminalId: String, paymentRef: String, onSuccess: (response: PosPaymentResponse?) -> Unit, onFailure: (String) -> Unit) {
         viewModelScope.launch {
             val response = ForageTerminalSDK(terminalId).capturePayment(
                 CapturePaymentParams(
@@ -254,12 +254,13 @@ class POSViewModel : ViewModel() {
                 is ForageApiResponse.Failure -> {
                     Log.e("POSViewModel", response.toString())
                     _uiState.update { it.copy(capturePaymentError = response.toString(), capturePaymentResponse = null) }
+                    onFailure(response.toString())
                 }
             }
         }
     }
 
-    fun refundPayment(foragePinEditText: ForagePINEditText, terminalId: String, amount: Float, paymentRef: String, reason: String, onSuccess: (response: Refund?) -> Unit) {
+    fun refundPayment(foragePinEditText: ForagePINEditText, terminalId: String, amount: Float, paymentRef: String, reason: String, onSuccess: (response: Refund?) -> Unit, onFailure: (String) -> Unit) {
         viewModelScope.launch {
             val response = ForageTerminalSDK(terminalId).refundPayment(
                 PosRefundPaymentParams(
@@ -290,6 +291,7 @@ class POSViewModel : ViewModel() {
                 is ForageApiResponse.Failure -> {
                     Log.e("POSViewModel", response.toString())
                     _uiState.update { it.copy(refundPaymentError = response.toString(), refundPaymentResponse = null) }
+                    onFailure(response.toString())
                 }
             }
         }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/payment/PaymentResultScreen.kt
@@ -20,7 +20,7 @@ import com.joinforage.android.example.pos.receipts.templates.txs.CashWithdrawalT
 import com.joinforage.android.example.pos.receipts.templates.txs.SnapPurchaseTxReceipt
 import com.joinforage.android.example.pos.receipts.templates.txs.TxType
 import com.joinforage.android.example.ui.pos.data.Merchant
-import com.joinforage.android.example.ui.pos.data.PosPaymentResponse
+import com.joinforage.android.example.ui.pos.data.Receipt
 import com.joinforage.android.example.ui.pos.data.tokenize.PosPaymentMethod
 import com.joinforage.android.example.ui.pos.screens.ReceiptPreviewScreen
 
@@ -29,8 +29,9 @@ fun PaymentResultScreen(
     merchant: Merchant?,
     terminalId: String,
     paymentMethod: PosPaymentMethod?,
+    paymentRef: String,
     txType: TxType?,
-    paymentResponse: PosPaymentResponse?,
+    receipt: Receipt?,
     onBackButtonClicked: () -> Unit,
     onDoneButtonClicked: () -> Unit,
     onReloadButtonClicked: () -> Unit
@@ -50,57 +51,55 @@ fun PaymentResultScreen(
                 Button(onClick = onReloadButtonClicked) {
                     Text("Re-fetch Payment")
                 }
-            } else if (paymentResponse == null) {
+            } else if (receipt == null) {
                 Text("null paymentResponse")
             } else {
-                var receipt: BaseReceiptTemplate? = null
+                var receiptTemplate: BaseReceiptTemplate? = null
                 if (txType == TxType.SNAP_PAYMENT) {
-                    receipt = SnapPurchaseTxReceipt(
+                    receiptTemplate = SnapPurchaseTxReceipt(
                         merchant,
                         terminalId,
                         paymentMethod,
-                        paymentResponse
+                        receipt
                     )
                 }
                 if (txType == TxType.CASH_PAYMENT) {
-                    receipt = CashPurchaseTxReceipt(
+                    receiptTemplate = CashPurchaseTxReceipt(
                         merchant,
                         terminalId,
                         paymentMethod,
-                        paymentResponse
+                        receipt
                     )
                 }
                 if (txType == TxType.CASH_PURCHASE_WITH_CASHBACK) {
-                    receipt = CashPurchaseWithCashbackTxReceipt(
+                    receiptTemplate = CashPurchaseWithCashbackTxReceipt(
                         merchant,
                         terminalId,
                         paymentMethod,
-                        paymentResponse
+                        receipt
                     )
                 }
                 if (txType == TxType.CASH_WITHDRAWAL) {
-                    receipt = CashWithdrawalTxReceipt(
+                    receiptTemplate = CashWithdrawalTxReceipt(
                         merchant,
                         terminalId,
                         paymentMethod,
-                        paymentResponse
+                        receipt
                     )
                 }
                 Column {
-                    if (paymentResponse.ref != null) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Center
-                        ) {
-                            Text("Payment Ref: ${paymentResponse.ref}")
-                            Button(onClick = {
-                                clipboardManager.setText(AnnotatedString(paymentResponse.ref!!))
-                            }, colors = ButtonDefaults.elevatedButtonColors()) {
-                                Text("Copy")
-                            }
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        Text("Payment Ref: $paymentRef")
+                        Button(onClick = {
+                            clipboardManager.setText(AnnotatedString(paymentRef))
+                        }, colors = ButtonDefaults.elevatedButtonColors()) {
+                            Text("Copy")
                         }
                     }
-                    ReceiptPreviewScreen(receipt!!.getReceiptLayout())
+                    ReceiptPreviewScreen(receiptTemplate!!.getReceiptLayout())
                 }
             }
         }
@@ -123,8 +122,9 @@ fun PaymentResultScreenPreview() {
         merchant = null,
         terminalId = "",
         paymentMethod = null,
+        paymentRef = "",
         txType = null,
-        paymentResponse = null,
+        receipt = null,
         onBackButtonClicked = {},
         onDoneButtonClicked = {},
         onReloadButtonClicked = {}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidPaymentResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/voids/VoidPaymentResultScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.joinforage.android.example.pos.receipts.templates.txs.TxType
 import com.joinforage.android.example.ui.pos.data.Merchant
-import com.joinforage.android.example.ui.pos.data.PosPaymentResponse
+import com.joinforage.android.example.ui.pos.data.Receipt
 import com.joinforage.android.example.ui.pos.data.tokenize.PosPaymentMethod
 import com.joinforage.android.example.ui.pos.screens.payment.PaymentResultScreen
 
@@ -13,8 +13,9 @@ fun VoidPaymentResultScreen(
     merchant: Merchant?,
     terminalId: String,
     paymentMethod: PosPaymentMethod?,
+    paymentRef: String,
     txType: TxType?,
-    paymentResponse: PosPaymentResponse?,
+    receipt: Receipt?,
     onBackButtonClicked: () -> Unit,
     onDoneButtonClicked: () -> Unit
 ) {
@@ -22,8 +23,9 @@ fun VoidPaymentResultScreen(
         merchant,
         terminalId,
         paymentMethod,
+        paymentRef,
         txType,
-        paymentResponse,
+        receipt,
         onBackButtonClicked,
         onDoneButtonClicked,
         onReloadButtonClicked = {}
@@ -37,8 +39,9 @@ fun VoidPaymentResultScreenPreview() {
         merchant = null,
         terminalId = "",
         paymentMethod = null,
+        paymentRef = "",
         txType = null,
-        paymentResponse = null,
+        receipt = null,
         onBackButtonClicked = {},
         onDoneButtonClicked = {}
     )


### PR DESCRIPTION
## What
Adds support for printing receipts for declined payments. We're essentially cobbling together a manual receipt since we don't really get any receipt data back from the backend when a payment is declined. There is probably be a better way to do this, but this works?

## Why
https://linear.app/joinforage/issue/FX-1019/error-handling-need-a-receipt-scene-for-failed-payment-captures

## Test Plan
- Manually tested both insufficient funds and incorrect/invalid PIN and saw declined receipts

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/596c8011-df98-4882-b41c-8b181f7eb257

## How
Can be merged as-is