### PR TITLE
[FX-1047] Fix issue where error messages from previous entries would persist

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -198,7 +198,7 @@ fun POSComposeApp(
                         navController.navigate(POSScreen.BIManualPANEntryScreen.name)
                     },
                     onSwipeButtonClicked = {
-                        viewModel.resetPinActionErrors()
+                        viewModel.resetTokenizationError()
                         navController.navigate(POSScreen.BIMagSwipePANEntryScreen.name)
                     },
                     onBackButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
@@ -375,11 +375,11 @@ fun POSComposeApp(
             composable(route = POSScreen.PAYChoosePANMethodScreen.name) {
                 PANMethodSelectionScreen(
                     onManualEntryButtonClicked = {
-                        viewModel.resetPinActionErrors()
+                        viewModel.resetTokenizationError()
                         navController.navigate(POSScreen.PAYManualPANEntryScreen.name)
                     },
                     onSwipeButtonClicked = {
-                        viewModel.resetPinActionErrors()
+                        viewModel.resetTokenizationError()
                         navController.navigate(POSScreen.PAYMagSwipePANEntryScreen.name)
                     },
                     onBackButtonClicked = { navController.popBackStack(POSScreen.PAYTransactionTypeSelectionScreen.name, inclusive = false) }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -193,8 +193,14 @@ fun POSComposeApp(
             }
             composable(route = POSScreen.BIChoosePANMethodScreen.name) {
                 PANMethodSelectionScreen(
-                    onManualEntryButtonClicked = { navController.navigate(POSScreen.BIManualPANEntryScreen.name) },
-                    onSwipeButtonClicked = { navController.navigate(POSScreen.BIMagSwipePANEntryScreen.name) },
+                    onManualEntryButtonClicked = {
+                        viewModel.resetTokenizationError()
+                        navController.navigate(POSScreen.BIManualPANEntryScreen.name)
+                    },
+                    onSwipeButtonClicked = {
+                        viewModel.resetPinActionErrors()
+                        navController.navigate(POSScreen.BIMagSwipePANEntryScreen.name)
+                    },
                     onBackButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) }
                 )
             }
@@ -210,6 +216,7 @@ fun POSComposeApp(
                                 onSuccess = {
                                     if (it?.ref != null) {
                                         Log.i("POSComposeApp", "Successfully tokenized EBT card with ref: $it.ref")
+                                        viewModel.resetPinActionErrors()
                                         navController.navigate(POSScreen.BIPINEntryScreen.name)
                                     }
                                 }
@@ -228,6 +235,7 @@ fun POSComposeApp(
                             viewModel.tokenizeEBTCard(track2Data, k9SDK.terminalId) {
                                 if (it?.ref != null) {
                                     Log.i("POSComposeApp", "Successfully tokenized EBT card with ref: $it.ref")
+                                    viewModel.resetPinActionErrors()
                                     navController.navigate(POSScreen.BIPINEntryScreen.name)
                                 }
                             }
@@ -366,8 +374,14 @@ fun POSComposeApp(
             }
             composable(route = POSScreen.PAYChoosePANMethodScreen.name) {
                 PANMethodSelectionScreen(
-                    onManualEntryButtonClicked = { navController.navigate(POSScreen.PAYManualPANEntryScreen.name) },
-                    onSwipeButtonClicked = { navController.navigate(POSScreen.PAYMagSwipePANEntryScreen.name) },
+                    onManualEntryButtonClicked = {
+                        viewModel.resetPinActionErrors()
+                        navController.navigate(POSScreen.PAYManualPANEntryScreen.name)
+                    },
+                    onSwipeButtonClicked = {
+                        viewModel.resetPinActionErrors()
+                        navController.navigate(POSScreen.PAYMagSwipePANEntryScreen.name)
+                    },
                     onBackButtonClicked = { navController.popBackStack(POSScreen.PAYTransactionTypeSelectionScreen.name, inclusive = false) }
                 )
             }
@@ -388,6 +402,7 @@ fun POSComposeApp(
                                         val payment = uiState.localPayment!!.copy(paymentMethodRef = tokenizedCard.ref)
                                         viewModel.createPayment(payment = payment, onSuccess = { serverPayment ->
                                             if (serverPayment.ref !== null) {
+                                                viewModel.resetPinActionErrors()
                                                 navController.navigate(POSScreen.PAYPINEntryScreen.name)
                                             }
                                         })
@@ -411,6 +426,7 @@ fun POSComposeApp(
                                     val payment = uiState.localPayment!!.copy(paymentMethodRef = tokenizedCard.ref)
                                     viewModel.createPayment(payment = payment, onSuccess = { serverPayment ->
                                         if (serverPayment.ref !== null) {
+                                            viewModel.resetPinActionErrors()
                                             navController.navigate(POSScreen.PAYPINEntryScreen.name)
                                         }
                                     })
@@ -475,6 +491,7 @@ fun POSComposeApp(
                             reason = reason
                         )
                         viewModel.setLocalRefundState(refundState) {
+                            viewModel.resetPinActionErrors()
                             navController.navigate(POSScreen.REFUNDPINEntryScreen.name)
                         }
                     },

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -109,6 +109,18 @@ class POSViewModel : ViewModel() {
         }
     }
 
+    fun resetTokenizationError() {
+        _uiState.update { it.copy(tokenizationError = null) }
+    }
+
+    fun resetPinActionErrors() {
+        _uiState.update { it.copy(
+            balanceCheckError = null,
+            capturePaymentError = null,
+            refundPaymentError = null,
+        ) }
+    }
+
     private fun getMerchantInfo(onSuccess: () -> Unit) {
         viewModelScope.launch {
             _uiState.update { it.copy(merchantDetailsState = MerchantDetailsState.Loading) }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -114,11 +114,13 @@ class POSViewModel : ViewModel() {
     }
 
     fun resetPinActionErrors() {
-        _uiState.update { it.copy(
-            balanceCheckError = null,
-            capturePaymentError = null,
-            refundPaymentError = null,
-        ) }
+        _uiState.update {
+            it.copy(
+                balanceCheckError = null,
+                capturePaymentError = null,
+                refundPaymentError = null
+            )
+        }
     }
 
     private fun getMerchantInfo(onSuccess: () -> Unit) {


### PR DESCRIPTION
## What
Clears PAN & PIN errors when navigating forward to those screens to avoid showing potentially stale error messages

## Why
https://linear.app/joinforage/issue/FX-1047/bug-error-messages-from-previous-entries-persist-across-navigation

## Test Plan
- Manually verified in emulator (see demo)

## Demo
https://github.com/teamforage/forage-android-sdk/assets/11556475/45c7a44b-6cb2-4d17-bf2e-b42c4c2e1c9c

## How
Can be merged as-is