### PR TITLE
[FX-1074] Fix cord pull scenarios, update models to reflect server response changes

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -239,7 +239,7 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun capturePayment(foragePinEditText: ForagePINEditText, terminalId: String, paymentRef: String, onComplete: () -> Unit) {
+    fun capturePayment(foragePinEditText: ForagePINEditText, terminalId: String, paymentRef: String, onSuccess: () -> Unit, onFailure: () -> Unit) {
         viewModelScope.launch {
             val response = ForageTerminalSDK(terminalId).capturePayment(
                 CapturePaymentParams(
@@ -263,18 +263,18 @@ class POSViewModel : ViewModel() {
                     _uiState.update {
                         it.copy(tokenizedPaymentMethod = updatedCard)
                     }
-                    onComplete()
+                    onSuccess()
                 }
                 is ForageApiResponse.Failure -> {
                     Log.e("POSViewModel", response.toString())
                     _uiState.update { it.copy(capturePaymentError = response.errors.joinToString("\n"), capturePaymentResponse = null) }
-                    onComplete()
+                    onFailure()
                 }
             }
         }
     }
 
-    fun refundPayment(foragePinEditText: ForagePINEditText, terminalId: String, amount: Float, paymentRef: String, reason: String, onComplete: () -> Unit) {
+    fun refundPayment(foragePinEditText: ForagePINEditText, terminalId: String, amount: Float, paymentRef: String, reason: String, onSuccess: () -> Unit, onFailure: () -> Unit) {
         viewModelScope.launch {
             val response = ForageTerminalSDK(terminalId).refundPayment(
                 PosRefundPaymentParams(
@@ -299,12 +299,12 @@ class POSViewModel : ViewModel() {
                     val jsonAdapter: JsonAdapter<Refund> = RefundJsonAdapter(moshi)
                     val refundResponse = jsonAdapter.fromJson(response.data)
                     _uiState.update { it.copy(refundPaymentResponse = refundResponse, refundPaymentError = null) }
-                    onComplete()
+                    onSuccess()
                 }
                 is ForageApiResponse.Failure -> {
                     Log.e("POSViewModel", response.toString())
                     _uiState.update { it.copy(refundPaymentError = response.errors.joinToString("\n"), refundPaymentResponse = null) }
-                    onComplete()
+                    onFailure()
                 }
             }
         }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentResponse.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentResponse.kt
@@ -35,5 +35,7 @@ data class PosPaymentResponse(
     @Json(name = "customer_id")
     var customerId: String?,
     @Json(name = "cash_back_amount")
-    var cashBackAmount: Float?
+    var cashBackAmount: Float?,
+    @Json(name = "sequence_number")
+    var sequenceNumber: String?
 )

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/Refund.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/Refund.kt
@@ -18,7 +18,8 @@ data class Refund(
     val receipt: Receipt?,
     @Json(name = "pos_terminal") val posTerminal: RefundPosTerminal,
     @Json(name = "external_order_id") val externalOrderId: String?,
-    val messages: RefundVoidMessages?
+    val message: RefundVoidMessage?,
+    @Json(name = "sequence_number") val sequenceNumber: String?
 )
 
 @JsonClass(generateAdapter = true)
@@ -28,7 +29,7 @@ data class RefundPosTerminal(
 )
 
 @JsonClass(generateAdapter = true)
-data class RefundVoidMessages(
+data class RefundVoidMessage(
     @Json(name = "content_id") val contentId: String,
     @Json(name = "message_type") val messageType: String,
     val status: String,


### PR DESCRIPTION
## What
- Adds `sequence_number` to payment response and refund response ([slack discussion](https://joinforage.slack.com/archives/C06HYPPV2EB/p1707759719149339))
- Updates `messages` refund field to be `message` ([slack discussion](https://joinforage.slack.com/archives/C057H6RGPU0/p1706624389761629))
- Routes `ForageApiResponse.Success` and `ForageApiResponse.Error` responses for payments and refunds to different result screens. This allows us to disambiguate success state with an empty receipt (cord pull or late notification scenario) from a failure state with an empty receipt (declined transaction, invalid pin, etc.)

## Why
https://linear.app/joinforage/issue/FX-1074/verify-cord-pulled-scenarios-still-work-with-declined-receipts-code

## Test Plan
- Manually verified in the emulator

## How
Can be merged as-is