### PR TITLE
[FX-1086, FX-1085, FX-1046] Improve declined receipts, fix terminal ID, avoid unknown sequence numbers

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -459,8 +459,10 @@ fun POSComposeApp(
                                 onSuccess = {
                                     navController.navigate(POSScreen.PAYResultScreen.name)
                                 },
-                                onFailure = {
-                                    navController.navigate(POSScreen.PAYErrorResultScreen.name)
+                                onFailure = {sequenceNumber ->
+                                    if (sequenceNumber != null) {
+                                        navController.navigate(POSScreen.PAYErrorResultScreen.name)
+                                    }
                                 }
                             )
                         }
@@ -471,7 +473,7 @@ fun POSComposeApp(
                 )
             }
             composable(route = POSScreen.PAYErrorResultScreen.name) {
-                val manualErrorReceipt = Receipt(
+                val errorReceipt = uiState.capturePaymentResponse?.receipt ?: Receipt(
                     refNumber = uiState.createPaymentResponse!!.ref!!,
                     isVoided = false,
                     snapAmount = (if (uiState.createPaymentResponse!!.fundingType == "ebt_snap") uiState.createPaymentResponse!!.amount else "0.00").toString(),
@@ -494,11 +496,11 @@ fun POSComposeApp(
 
                 PaymentResultScreen(
                     merchant = uiState.merchant,
-                    terminalId = k9SDK.terminalId,
+                    terminalId = uiState.capturePaymentResponse?.posTerminal?.terminalId ?: "Unknown",
                     paymentMethod = uiState.tokenizedPaymentMethod,
-                    paymentRef = manualErrorReceipt.refNumber,
-                    txType = uiState.localPayment?.let { TxType.forPayment(it) },
-                    receipt = manualErrorReceipt,
+                    paymentRef = errorReceipt.refNumber,
+                    txType = uiState.localPayment?.let { TxType.forPayment(it) } ?: TxType.forReceipt(errorReceipt),
+                    receipt = errorReceipt,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.PAYPINEntryScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) },
                     onReloadButtonClicked = {
@@ -511,14 +513,10 @@ fun POSComposeApp(
             composable(route = POSScreen.PAYResultScreen.name) {
                 PaymentResultScreen(
                     merchant = uiState.merchant,
-                    terminalId = k9SDK.terminalId,
+                    terminalId = uiState.capturePaymentResponse?.posTerminal?.terminalId ?: "Unknown",
                     paymentMethod = uiState.tokenizedPaymentMethod,
                     paymentRef = uiState.capturePaymentResponse!!.ref!!,
-                    txType = uiState.capturePaymentResponse?.receipt?.let { it1 ->
-                        TxType.forReceipt(
-                            it1
-                        )
-                    },
+                    txType = uiState.capturePaymentResponse?.receipt?.let { TxType.forReceipt(it) } ?: uiState.localPayment?.let { TxType.forPayment(it) },
                     receipt = uiState.capturePaymentResponse?.receipt,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.PAYPINEntryScreen.name, inclusive = false) },
                     onDoneButtonClicked = { navController.popBackStack(POSScreen.ActionSelectionScreen.name, inclusive = false) },
@@ -573,7 +571,7 @@ fun POSComposeApp(
                 )
             }
             composable(route = POSScreen.REFUNDErrorResultScreen.name) {
-                val manualErrorReceipt = uiState.capturePaymentResponse!!.receipt!!.copy(
+                val errorReceipt = uiState.refundPaymentResponse?.receipt ?: uiState.capturePaymentResponse!!.receipt!!.copy(
                     transactionType = "Refund",
                     created = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).format(Timestamp(System.currentTimeMillis())),
                     message = uiState.refundPaymentError ?: uiState.capturePaymentResponse?.receipt?.message ?: ""
@@ -581,12 +579,12 @@ fun POSComposeApp(
 
                 RefundResultScreen(
                     merchant = uiState.merchant,
-                    terminalId = k9SDK.terminalId,
+                    terminalId = uiState.refundPaymentResponse?.posTerminal?.terminalId ?: uiState.capturePaymentResponse?.posTerminal?.terminalId ?: "Unknown",
                     paymentMethod = uiState.tokenizedPaymentMethod,
                     paymentRef = uiState.localRefundState!!.paymentRef,
                     refundRef = uiState.refundPaymentResponse?.ref,
-                    txType = TxType.forReceipt(manualErrorReceipt),
-                    receipt = manualErrorReceipt,
+                    txType = TxType.forReceipt(errorReceipt),
+                    receipt = errorReceipt,
                     fetchedPayment = uiState.capturePaymentResponse,
                     onRefundRefClicked = { paymentRef, refundRef -> viewModel.fetchRefund(paymentRef, refundRef) },
                     onBackButtonClicked = { navController.popBackStack(POSScreen.REFUNDPINEntryScreen.name, inclusive = false) },
@@ -603,7 +601,7 @@ fun POSComposeApp(
             composable(route = POSScreen.REFUNDResultScreen.name) {
                 RefundResultScreen(
                     merchant = uiState.merchant,
-                    terminalId = k9SDK.terminalId,
+                    terminalId = uiState.refundPaymentResponse?.posTerminal?.terminalId ?: uiState.capturePaymentResponse?.posTerminal?.terminalId ?: "Unknown",
                     paymentMethod = uiState.tokenizedPaymentMethod,
                     paymentRef = uiState.localRefundState!!.paymentRef,
                     refundRef = uiState.refundPaymentResponse?.ref,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -459,7 +459,7 @@ fun POSComposeApp(
                                 onSuccess = {
                                     navController.navigate(POSScreen.PAYResultScreen.name)
                                 },
-                                onFailure = {sequenceNumber ->
+                                onFailure = { sequenceNumber ->
                                     if (sequenceNumber != null) {
                                         navController.navigate(POSScreen.PAYErrorResultScreen.name)
                                     }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -305,7 +305,6 @@ class POSViewModel : ViewModel() {
                     val jsonAdapter: JsonAdapter<Refund> = RefundJsonAdapter(moshi)
                     val refundResponse = jsonAdapter.fromJson(response.data)
                     _uiState.update { it.copy(refundPaymentResponse = refundResponse, refundPaymentError = null) }
-                    Log.i("POSViewModel-REFUND", refundResponse.toString())
                     onSuccess()
                 }
                 is ForageApiResponse.Failure -> {
@@ -321,8 +320,6 @@ class POSViewModel : ViewModel() {
                     } catch (e: HttpException) {
                         Log.e("POSViewModel", "Failed to re-fetch payment or refund after failed refund attempt. PaymentRef: $paymentRef")
                     }
-                    Log.i("POSViewModel-REFUND", payment.toString())
-                    Log.i("POSViewModel-REFUND", refund.toString())
                     _uiState.update { it.copy(refundPaymentError = response.errors[0].message, refundPaymentResponse = refund, capturePaymentResponse = payment) }
                     onFailure()
                 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -239,7 +239,7 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun capturePayment(foragePinEditText: ForagePINEditText, terminalId: String, paymentRef: String, onSuccess: () -> Unit, onFailure: () -> Unit) {
+    fun capturePayment(foragePinEditText: ForagePINEditText, terminalId: String, paymentRef: String, onSuccess: () -> Unit, onFailure: (sequenceNumber: String?) -> Unit) {
         viewModelScope.launch {
             val response = ForageTerminalSDK(terminalId).capturePayment(
                 CapturePaymentParams(
@@ -266,9 +266,15 @@ class POSViewModel : ViewModel() {
                     onSuccess()
                 }
                 is ForageApiResponse.Failure -> {
-                    Log.e("POSViewModel", response.toString())
-                    _uiState.update { it.copy(capturePaymentError = response.errors.joinToString("\n"), capturePaymentResponse = null) }
-                    onFailure()
+                    Log.e("POSViewModel", response.errors[0].message)
+                    var payment: PosPaymentResponse? = null
+                    try {
+                        payment = api.getPayment(paymentRef)
+                    } catch (e: HttpException) {
+                        Log.e("POSViewModel", "Failed to re-fetch payment $paymentRef after failed capture")
+                    }
+                    _uiState.update { it.copy(capturePaymentError = response.errors[0].message, capturePaymentResponse = payment) }
+                    onFailure(payment?.sequenceNumber)
                 }
             }
         }
@@ -299,11 +305,25 @@ class POSViewModel : ViewModel() {
                     val jsonAdapter: JsonAdapter<Refund> = RefundJsonAdapter(moshi)
                     val refundResponse = jsonAdapter.fromJson(response.data)
                     _uiState.update { it.copy(refundPaymentResponse = refundResponse, refundPaymentError = null) }
+                    Log.i("POSViewModel-REFUND", refundResponse.toString())
                     onSuccess()
                 }
                 is ForageApiResponse.Failure -> {
                     Log.e("POSViewModel", response.toString())
-                    _uiState.update { it.copy(refundPaymentError = response.errors.joinToString("\n"), refundPaymentResponse = null) }
+                    var payment: PosPaymentResponse? = null
+                    var refund: Refund? = null
+                    try {
+                        payment = api.getPayment(paymentRef)
+                        val mostRecentRefundRef = payment.refunds.lastOrNull()
+                        if (mostRecentRefundRef != null) {
+                            refund = api.getRefund(paymentRef, mostRecentRefundRef)
+                        }
+                    } catch (e: HttpException) {
+                        Log.e("POSViewModel", "Failed to re-fetch payment or refund after failed refund attempt. PaymentRef: $paymentRef")
+                    }
+                    Log.i("POSViewModel-REFUND", payment.toString())
+                    Log.i("POSViewModel-REFUND", refund.toString())
+                    _uiState.update { it.copy(refundPaymentError = response.errors[0].message, refundPaymentResponse = refund, capturePaymentResponse = payment) }
                     onFailure()
                 }
             }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentResponse.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/PosPaymentResponse.kt
@@ -37,5 +37,7 @@ data class PosPaymentResponse(
     @Json(name = "cash_back_amount")
     var cashBackAmount: Float?,
     @Json(name = "sequence_number")
-    var sequenceNumber: String?
+    var sequenceNumber: String?,
+    @Json(name = "transaction_type")
+    var transactionType: String?
 )


### PR DESCRIPTION
## What
- Improves declined receipts by refetching the payment when a decline fails, which allows us to read the `receipt` field and use that data to populate the declined receipt instead of my cobbled together version.
  - Also tidies up the error message to only show the message response instead of the full stringified error
- Updates the terminal ID to read from the receipt's `posTerminal.terminalId` so we're showing the forage ref value
- Updates the logic for PIN errors to only route to a receipt if we have a sequence number, which means we actually tried to capture the payment. 
  - For invalid PIN errors like only typing in 3 digits, we never make it to FIS so there's no sequence number, so we won't show a receipt. Instead we'll just show an inline error message. If we _do_ have a sequence number, like in the case of entering an incorrect 4-digit PIN, we'll still show a receipt since we would've actually tried to capture the payment at that point. See [this Slack discussion](https://joinforage.slack.com/archives/C061FR1EW2Y/p1707943851160979) for context.

## Why
https://linear.app/joinforage/issue/FX-1086/declined-error-messages-are-noisy
https://linear.app/joinforage/issue/FX-1085/unknown-sequence-number-on-declined-receipts
https://linear.app/joinforage/issue/FX-1046/terminal-id-on-receipt-is-the-from-the-cpay-sdk

## Test Plan
Manually verified in the emulator

## How
Can be merged as-is