### PR TITLE
[FX-1066] Handle late-notification scenarios by showing voided receipts

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -475,7 +475,7 @@ fun POSComposeApp(
             composable(route = POSScreen.PAYErrorResultScreen.name) {
                 val errorReceipt = uiState.capturePaymentResponse?.receipt ?: Receipt(
                     refNumber = uiState.createPaymentResponse!!.ref!!,
-                    isVoided = false,
+                    isVoided = true, // We should only use this manual receipt when in the late-notification scenario
                     snapAmount = (if (uiState.createPaymentResponse!!.fundingType == "ebt_snap") uiState.createPaymentResponse!!.amount else "0.00").toString(),
                     ebtCashAmount = (if (uiState.createPaymentResponse!!.fundingType == "ebt_cash") uiState.createPaymentResponse!!.amount else "0.00").toString(),
                     cashBackAmount = uiState.createPaymentResponse!!.cashBackAmount.toString(),
@@ -483,12 +483,12 @@ fun POSComposeApp(
                     salesTaxApplied = "0.00",
                     last4 = uiState.tokenizedPaymentMethod!!.card!!.last4,
                     transactionType = "Payment",
-                    sequenceNumber = uiState.createPaymentResponse!!.sequenceNumber ?: "Unknown",
+                    sequenceNumber = uiState.capturePaymentResponse?.sequenceNumber ?: uiState.createPaymentResponse?.sequenceNumber ?: "ERROR",
                     balance = ReceiptBalance(
                         id = 0.toDouble(),
-                        snap = uiState.tokenizedPaymentMethod!!.balance!!.snap,
-                        nonSnap = uiState.tokenizedPaymentMethod!!.balance!!.non_snap,
-                        updated = uiState.tokenizedPaymentMethod!!.balance!!.updated
+                        snap = uiState.tokenizedPaymentMethod!!.balance?.snap ?: "ERROR",
+                        nonSnap = uiState.tokenizedPaymentMethod!!.balance?.non_snap ?: "ERROR",
+                        updated = uiState.tokenizedPaymentMethod!!.balance?.updated ?: "ERROR"
                     ),
                     created = uiState.createPaymentResponse!!.created,
                     message = uiState.capturePaymentError ?: "Unknown Error"


### PR DESCRIPTION
## What
Handles the late-notification payment scenarios by showing voided receipts (I think this is what we want? it's easy to make it a decline if that's what we want instead)

## Why
https://linear.app/joinforage/issue/FX-1066/handle-late-notification-responses-from-payments-api

## Test Plan
Manually verified in emulator

## How
Can be merged as-is