### PR TITLE
[FX-1094] Fix terminal ID on void & balance inquiry receipts 

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -660,7 +660,7 @@ fun POSComposeApp(
             composable(route = POSScreen.VOIDPaymentResultScreen.name) {
                 VoidPaymentResultScreen(
                     merchant = uiState.merchant,
-                    terminalId = k9SDK.terminalId,
+                    terminalId = uiState.voidPaymentResponse?.posTerminal?.terminalId ?: "Unknown",
                     paymentMethod = uiState.tokenizedPaymentMethod,
                     paymentRef = uiState.voidPaymentResponse!!.ref!!,
                     txType = uiState.voidPaymentResponse?.let { it1 ->
@@ -678,7 +678,7 @@ fun POSComposeApp(
             composable(route = POSScreen.VOIDRefundResultScreen.name) {
                 VoidRefundResultScreen(
                     merchant = uiState.merchant,
-                    terminalId = k9SDK.terminalId,
+                    terminalId = uiState.voidRefundResponse?.posTerminal?.terminalId ?: "Unknown",
                     paymentMethod = uiState.tokenizedPaymentMethod,
                     paymentRef = uiState.voidRefundResponse!!.paymentRef,
                     refundRef = uiState.voidRefundResponse?.ref,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -280,7 +280,7 @@ fun POSComposeApp(
             composable(route = POSScreen.BIResultScreen.name) {
                 BalanceResultScreen(
                     merchant = uiState.merchant,
-                    terminalId = k9SDK.terminalId,
+                    terminalId = uiState.tokenizedPaymentMethod?.balance?.posTerminal?.terminalId ?: "Unknown",
                     paymentMethod = uiState.tokenizedPaymentMethod,
                     balanceCheckError = uiState.balanceCheckError,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.BIPINEntryScreen.name, inclusive = false) },

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -219,7 +219,6 @@ class POSViewModel : ViewModel() {
                     val jsonAdapter: JsonAdapter<BalanceCheck> = BalanceCheckJsonAdapter(moshi)
                     val balance = jsonAdapter.fromJson(response.data)
                     _uiState.update { it.copy(balance = balance, balanceCheckError = null) }
-                    onSuccess(balance)
 
                     // we need to refetch the EBT Card here because
                     // `ForageTerminalSDK(terminalId).checkBalance`
@@ -230,6 +229,7 @@ class POSViewModel : ViewModel() {
                     _uiState.update {
                         it.copy(tokenizedPaymentMethod = updatedCard)
                     }
+                    onSuccess(balance)
                 }
                 is ForageApiResponse.Failure -> {
                     Log.e("POSViewModel", response.toString())


### PR DESCRIPTION
## What
Fixes an issue where we were reading the terminal ID from the wrong place for void receipts.
Also fixes an issue where we were navigating to the receipt view for balance inquiries too early, which meant we weren't displaying the latest data from re-fetching the payment method.

## Why
https://linear.app/joinforage/issue/FX-1094/void-receipts-have-the-wrong-terminal-id

## Test Plan
Manually verified in the android emulator

## How
Can be merged as-is