### PR TITLE
[FX-1128] Remove get merchants call from pos cert app

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -176,7 +176,6 @@ fun POSComposeApp(
                     terminalId = k9SDK.terminalId,
                     merchantId = uiState.merchantId,
                     sessionToken = uiState.sessionToken,
-                    merchantDetailsState = uiState.merchantDetailsState,
                     onSaveButtonClicked = { merchantId, sessionToken ->
                         viewModel.setSessionToken(sessionToken)
                         viewModel.setMerchantId(merchantId, onSuccess = {
@@ -187,12 +186,7 @@ fun POSComposeApp(
             }
             composable(route = POSScreen.ActionSelectionScreen.name) {
                 ActionSelectionScreen(
-                    merchantDetails = when (uiState.merchantDetailsState) {
-                        is MerchantDetailsState.Success -> (uiState.merchantDetailsState as MerchantDetailsState.Success).merchant
-                        is MerchantDetailsState.Loading -> null
-                        is MerchantDetailsState.Idle -> null
-                        is MerchantDetailsState.Error -> null
-                    },
+                    merchantDetails = uiState.merchant,
                     onBackButtonClicked = { navController.popBackStack(POSScreen.MerchantSetupScreen.name, inclusive = false) },
                     onBalanceButtonClicked = { navController.navigate(POSScreen.BIChoosePANMethodScreen.name) },
                     onPaymentButtonClicked = { navController.navigate(POSScreen.PAYTransactionTypeSelectionScreen.name) },

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.joinforage.android.example.ui.pos.data.BalanceCheck
 import com.joinforage.android.example.ui.pos.data.BalanceCheckJsonAdapter
-import com.joinforage.android.example.ui.pos.data.Merchant
 import com.joinforage.android.example.ui.pos.data.POSUIState
 import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
 import com.joinforage.android.example.ui.pos.data.PosPaymentResponse
@@ -34,13 +33,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import java.util.UUID
-
-sealed interface MerchantDetailsState {
-    object Idle : MerchantDetailsState
-    data class Success(val merchant: Merchant) : MerchantDetailsState
-    data class Error(val error: String) : MerchantDetailsState
-    object Loading : MerchantDetailsState
-}
 
 class POSViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(POSUIState())

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -54,7 +54,7 @@ class POSViewModel : ViewModel() {
 
     fun setMerchantId(merchantId: String, onSuccess: () -> Unit) {
         _uiState.update { it.copy(merchantId = merchantId) }
-        getMerchantInfo(onSuccess)
+        onSuccess()
     }
 
     fun setLocalPayment(payment: PosPaymentRequest) {
@@ -106,8 +106,7 @@ class POSViewModel : ViewModel() {
             _uiState.update {
                 POSUIState(
                     merchantId = it.merchantId,
-                    sessionToken = it.sessionToken,
-                    merchantDetailsState = it.merchantDetailsState
+                    sessionToken = it.sessionToken
                 )
             }
         }
@@ -124,20 +123,6 @@ class POSViewModel : ViewModel() {
                 capturePaymentError = null,
                 refundPaymentError = null
             )
-        }
-    }
-
-    private fun getMerchantInfo(onSuccess: () -> Unit) {
-        viewModelScope.launch {
-            _uiState.update { it.copy(merchantDetailsState = MerchantDetailsState.Loading) }
-            val merchantDetailsState = try {
-                val result = api.getMerchantInfo()
-                onSuccess()
-                MerchantDetailsState.Success(result)
-            } catch (e: HttpException) {
-                MerchantDetailsState.Error(e.toString())
-            }
-            _uiState.update { it.copy(merchantDetailsState = merchantDetailsState) }
         }
     }
 

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/Merchant.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/Merchant.kt
@@ -1,20 +1,13 @@
 package com.joinforage.android.example.ui.pos.data
 
-import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class Merchant(
     val ref: String,
     val name: String,
-    @Json(name = "internal_name") val internalName: String,
     val fns: String,
-    val address: Address?,
-    val logo: String,
-    val homepage: String,
-    @Json(ignore = true, name = "third_party_api_keys") internal val thirdPartyApiKeys: Any? = null,
-    @Json(name = "possible_supported_benefits") val possibleSupportedBenefits: List<String>,
-    @Json(name = "uses_shopify") val usesShopify: Boolean
+    val address: Address?
 )
 
 @JsonClass(generateAdapter = true)

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/data/POSUIState.kt
@@ -1,13 +1,11 @@
 package com.joinforage.android.example.ui.pos.data
 
-import com.joinforage.android.example.ui.pos.MerchantDetailsState
 import com.joinforage.android.example.ui.pos.data.tokenize.PosPaymentMethod
 import com.joinforage.forage.android.pos.PosForageConfig
 
 data class POSUIState(
     val merchantId: String = "1234567", // <your_merchant_id>
     val sessionToken: String = "sandbox_eyabcdef....", // <your_oauth_or_session_token>
-    val merchantDetailsState: MerchantDetailsState = MerchantDetailsState.Idle,
 
     // Tokenizing EBT Cards
     val tokenizedPaymentMethod: PosPaymentMethod? = null,
@@ -43,11 +41,19 @@ data class POSUIState(
         get() = PosForageConfig(merchantId, sessionToken)
 
     val merchant
-        get() = if (merchantDetailsState is MerchantDetailsState.Success) {
-            merchantDetailsState.merchant
-        } else {
-            null
-        }
+        get() = Merchant(
+            name = "POS Test Merchant",
+            ref = "testMerchantRef",
+            fns = merchantId,
+            address = Address(
+                line1 = "171 E 2nd St",
+                line2 = null,
+                city = "New York",
+                state = "NY",
+                zipcode = "10009",
+                country = "USA"
+            )
+        )
 }
 
 data class RefundUIState(

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/network/PosApiService.kt
@@ -1,7 +1,6 @@
 package com.joinforage.android.example.ui.pos.network
 
 import com.joinforage.android.example.network.model.EnvConfig
-import com.joinforage.android.example.ui.pos.data.Merchant
 import com.joinforage.android.example.ui.pos.data.PosPaymentRequest
 import com.joinforage.android.example.ui.pos.data.PosPaymentResponse
 import com.joinforage.android.example.ui.pos.data.Refund
@@ -24,9 +23,6 @@ private val moshi = Moshi.Builder()
     .build()
 
 interface PosApiService {
-    @GET("api/merchants/")
-    suspend fun getMerchantInfo(): Merchant
-
     @POST("api/payments/")
     suspend fun createPayment(
         @Header("Idempotency-Key") idempotencyKey: String,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ActionSelectionScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/ActionSelectionScreen.kt
@@ -28,8 +28,6 @@ fun ActionSelectionScreen(
         mainContent = {
             Box {
                 Column {
-                    Text("Merchant Name: ${merchantDetails?.name ?: "Unknown"}")
-                    Text("Merchant Address: ${merchantDetails?.address?.line1 ?: "Unknown"}")
                     Text("Merchant FNS: ${merchantDetails?.fns ?: "Unknown"}")
                 }
             }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/MerchantSetupScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/MerchantSetupScreen.kt
@@ -7,11 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -27,7 +23,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.joinforage.android.example.ui.extensions.withTestId
-import com.joinforage.android.example.ui.pos.MerchantDetailsState
 import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
 
 @Composable
@@ -35,7 +30,6 @@ fun MerchantSetupScreen(
     terminalId: String,
     merchantId: String,
     sessionToken: String,
-    merchantDetailsState: MerchantDetailsState,
     onSaveButtonClicked: (String, String) -> Unit
 ) {
     var merchantIdInput by rememberSaveable {
@@ -44,13 +38,6 @@ fun MerchantSetupScreen(
 
     var sessionTokenInput by rememberSaveable {
         mutableStateOf(sessionToken)
-    }
-
-    val error = when (merchantDetailsState) {
-        is MerchantDetailsState.Idle -> null
-        is MerchantDetailsState.Success -> null
-        is MerchantDetailsState.Loading -> null
-        is MerchantDetailsState.Error -> merchantDetailsState.error
     }
 
     ScreenWithBottomRow(
@@ -78,18 +65,6 @@ fun MerchantSetupScreen(
                         keyboardType = KeyboardType.Number,
                         imeAction = ImeAction.Done
                     ),
-                    supportingText = {
-                        if (error != null) {
-                            Text(text = error, color = MaterialTheme.colorScheme.error)
-                        }
-                    },
-                    isError = error.toBoolean(),
-                    enabled = merchantDetailsState != MerchantDetailsState.Loading,
-                    trailingIcon = {
-                        if (error != null) {
-                            Icon(imageVector = Icons.Filled.Warning, contentDescription = "", tint = MaterialTheme.colorScheme.error)
-                        }
-                    },
                     modifier = Modifier.withTestId("pos_merchant_id_text_field")
                 )
             }
@@ -110,8 +85,7 @@ fun MerchantSetupScreen(
         },
         bottomRowContent = {
             Button(
-                onClick = { onSaveButtonClicked(merchantIdInput, sessionTokenInput) },
-                enabled = merchantDetailsState != MerchantDetailsState.Loading
+                onClick = { onSaveButtonClicked(merchantIdInput, sessionTokenInput) }
             ) {
                 Text(
                     "Bind POS to Merchant",
@@ -129,7 +103,6 @@ fun MerchantSetupScreenPreview() {
         terminalId = "preview terminal id",
         merchantId = "preview merchant id",
         sessionToken = "preview session token",
-        merchantDetailsState = MerchantDetailsState.Idle,
         onSaveButtonClicked = { _, _ -> }
     )
 }


### PR DESCRIPTION
## What
Removes the call to get merchant details from the POS cert app and updates the UI to use a hard-coded test merchant for the merchant name and address. Merchant ID will still read from whatever is provided in the text field in Merchant Setup.

## Why
https://linear.app/joinforage/issue/FX-1128/remove-get-merchants-call-from-pos-app

## Test Plan
- Manually verified in Android Emulator that expected flows still succeed with mock merchant data using a non-internal token

## How
Can be merged as-is