### PR TITLE
Move PosDeferPaymentRefundParams to the right module

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ForageSDKInterface.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ForageSDKInterface.kt
@@ -166,22 +166,3 @@ data class DeferPaymentCaptureParams(
     val foragePinEditText: ForagePINEditText,
     val paymentRef: String
 )
-
-/**
- * A model that represents the parameters that Forage requires to collect a card PIN and defer
- * the refund of the payment to the server.
- * [PosDeferPaymentRefundParams] are passed to the
- * [deferPaymentRefund][com.joinforage.forage.android.pos.ForageTerminalSDK.deferPaymentRefund] method.
- *
- * @property foragePinEditText A reference to a [ForagePINEditText] instance.
- * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] must
- * be called on the instance before it can be passed.
- * @property paymentRef A unique string identifier for a previously created
- * [`Payment`](https://docs.joinforage.app/reference/payments) in Forage's
- * database, returned by the
- * [Create a `Payment`](https://docs.joinforage.app/reference/create-a-payment) endpoint.
- */
-data class PosDeferPaymentRefundParams(
-    val foragePinEditText: ForagePINEditText,
-    val paymentRef: String
-)

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
@@ -6,7 +6,6 @@ import com.joinforage.forage.android.DeferPaymentCaptureParams
 import com.joinforage.forage.android.ForageConfigNotSetException
 import com.joinforage.forage.android.ForageSDK
 import com.joinforage.forage.android.ForageSDKInterface
-import com.joinforage.forage.android.PosDeferPaymentRefundParams
 import com.joinforage.forage.android.TokenizeEBTCardParams
 import com.joinforage.forage.android.VaultType
 import com.joinforage.forage.android.core.telemetry.CustomerPerceivedResponseMonitor

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/PosMethodParams.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/PosMethodParams.kt
@@ -52,6 +52,25 @@ data class PosTokenizeCardParams(
 )
 
 /**
+ * A model that represents the parameters that Forage requires to collect a card PIN and defer
+ * the refund of the payment to the server.
+ * [PosDeferPaymentRefundParams] are passed to the
+ * [deferPaymentRefund][com.joinforage.forage.android.pos.ForageTerminalSDK.deferPaymentRefund] method.
+ *
+ * @property foragePinEditText A reference to a [ForagePINEditText] instance.
+ * [setPosForageConfig][com.joinforage.forage.android.ui.ForageElement.setPosForageConfig] must
+ * be called on the instance before it can be passed.
+ * @property paymentRef A unique string identifier for a previously created
+ * [`Payment`](https://docs.joinforage.app/reference/payments) in Forage's
+ * database, returned by the
+ * [Create a `Payment`](https://docs.joinforage.app/reference/create-a-payment) endpoint.
+ */
+data class PosDeferPaymentRefundParams(
+    val foragePinEditText: ForagePINEditText,
+    val paymentRef: String
+)
+
+/**
  * A model that represents the parameters that [ForageTerminalSDK] requires to refund a Payment.
  * [PosRefundPaymentParams] are passed to the
  * [refundPayment][com.joinforage.forage.android.pos.ForageTerminalSDK.refundPayment] method.

--- a/forage-android/src/test/java/com/joinforage/forage/android/pos/ForageTerminalSDKTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/pos/ForageTerminalSDKTest.kt
@@ -4,7 +4,6 @@ import com.joinforage.forage.android.CapturePaymentParams
 import com.joinforage.forage.android.CheckBalanceParams
 import com.joinforage.forage.android.DeferPaymentCaptureParams
 import com.joinforage.forage.android.ForageSDK
-import com.joinforage.forage.android.PosDeferPaymentRefundParams
 import com.joinforage.forage.android.TokenizeEBTCardParams
 import com.joinforage.forage.android.VaultType
 import com.joinforage.forage.android.core.telemetry.Log


### PR DESCRIPTION
- Move `PosDeferPaymentRefundParams` to the right directory. 

- This ensures POS docs don't pollute the online docs
- Co-locate POS-related imports

⚠️ Technically a breaking change. [Learn more](https://linear.app/joinforage/issue/FX-1161/move-posdeferpaymentrefundparams-to-the-pos-directorymodule)
