### PR TITLE
Introduce init method in the public repo

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
@@ -1,5 +1,8 @@
 package com.joinforage.forage.android.pos
 
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.joinforage.forage.android.CapturePaymentParams
 import com.joinforage.forage.android.CheckBalanceParams
 import com.joinforage.forage.android.DeferPaymentCaptureParams
@@ -20,7 +23,9 @@ import com.joinforage.forage.android.ui.ForagePINEditText
  * The entry point for **in-store POS Terminal** transactions.
  *
  * A [ForageTerminalSDK] instance interacts with the Forage API.
- * Provide a unique POS Terminal ID, the `posTerminalId` parameter, to perform operations like:
+ *
+ * ℹ️ Call [`ForageTerminalSDK.init`][init] before performing operations like:
+ * <br><br>
  *
  * * [Tokenizing card information][tokenizeCard]
  * * [Checking the balance of a card][checkBalance]
@@ -30,20 +35,24 @@ import com.joinforage.forage.android.ui.ForagePINEditText
  * * [Collecting a customer's card PIN for a refund and defer the completion of the refund to the
  * server][deferPaymentRefund]
  * * [Refunding a payment immediately][refundPayment]
+ * <br><br>
+ *
  *```kotlin
- * // Example: Create a ForageTerminalSDK instance
- * val forage = ForageTerminalSDK(posTerminalId)
+ * // Example: Initialize the Forage Terminal SDK
+ * val forageTerminalSdk = ForageTerminalSDK.init(
+ *     context = androidContext,
+ *     posTerminalId = "<uniquely-identifies-the-pos-terminal>",
+ *     merchantId = "mid/<merchant_id>",
+ *     sessionToken = "sandbox_ey123..."
+ * )
  * ```
- * @param posTerminalId **Required**. A string that uniquely identifies the POS Terminal
- * used for a transaction. The max length of the string is 255 characters.
+ *
  * @see * [Forage guide to Terminal POS integrations](https://docs.joinforage.app/docs/forage-terminal-android)
  * * [ForageSDK] to process online-only transactions
  */
-class ForageTerminalSDK(
-    private val posTerminalId: String
-) : ForageSDKInterface {
-    private var createServiceFactory = {
-            sessionToken: String, merchantId: String, logger: Log ->
+class ForageTerminalSDK internal constructor(private val posTerminalId: String) :
+    ForageSDKInterface {
+    private var createServiceFactory = { sessionToken: String, merchantId: String, logger: Log ->
         ForageSDK.ServiceFactory(
             sessionToken = sessionToken,
             merchantId = merchantId,
@@ -52,19 +61,97 @@ class ForageTerminalSDK(
     }
 
     private var forageSdk: ForageSDK = ForageSDK()
-    private var createLogger: () -> Log = { Log.getInstance().addAttribute("pos_terminal_id", posTerminalId) }
+
+    companion object {
+        private var calledInit = false
+        private var initSucceeded = false
+
+        /**
+         * The [ForageTerminalSDK] may perform some long running initialization operations in
+         * certain circumstances. The operations typically last less than 10 seconds and only occur
+         * infrequently. It is required to call [init] ahead of calling any other
+         * methods on a [ForageTerminalSDK] instance.
+         *
+         * ⚠️The [ForageTerminalSDK.init] method is only available in the private
+         * distribution of the Forage Terminal SDK.
+         *
+         *```kotlin
+         * // Example: Initialize the Forage Terminal SDK
+         * try {
+         *     val forageTerminalSdk = ForageTerminalSDK.init(
+         *         context = androidContext,
+         *         posTerminalId = "<id-that-uniquely-identifies-the-pos-terminal>",
+         *         merchantId = "mid/<merchant_id>",
+         *         sessionToken = "sandbox_ey123..."
+         *     )
+         *
+         *     // Use the forageTerminalSdk to call other methods
+         *     // (e.g. tokenizeCard, checkBalance, etc.)
+         * } catch (e: Exception) {
+         *     // handle initialization error
+         * }
+         * ```
+         *
+         * @throws Exception If the initialization fails.
+         *
+         * @param context The Android application context.
+         *
+         * @param posTerminalId **Required**. A string that uniquely identifies the POS Terminal
+         * used for a transaction. The max length of the string is 255 characters.
+         *
+         * @param merchantId **Required**. A unique Merchant ID that Forage provides during onboarding
+         * * preceded by "mid/".
+         * * For example, `mid/123ab45c67`. The Merchant ID can be found in the Forage
+         * * [Sandbox](https://dashboard.sandbox.joinforage.app/login/)
+         * * or [Production](https://dashboard.joinforage.app/login/) Dashboard.
+         *
+         * @param sessionToken **Required**. A short-lived token that authenticates front-end requests to Forage.
+         * * To create one, send a server-side `POST` request from your backend to the
+         * * [`/session_token/`](https://docs.joinforage.app/reference/create-session-token)
+         * endpoint.
+         */
+        @RequiresApi(Build.VERSION_CODES.M)
+        @Throws(Exception::class)
+        suspend fun init(
+            context: Context,
+            posTerminalId: String,
+            merchantId: String,
+            sessionToken: String
+        ): ForageTerminalSDK {
+            if (posTerminalId == "pos-sample-app-override") {
+                return ForageTerminalSDK(posTerminalId)
+            }
+            throw NotImplementedError(
+                """
+            This method is not implemented in the public distribution of the Forage Terminal SDK.
+            Use the private distribution of the Forage Terminal SDK to access this method.
+                """.trimIndent()
+            )
+        }
+
+        private var createLogger: (posTerminalId: String) -> Log = { posTerminalId ->
+            Log.getInstance().addAttribute("pos_terminal_id", posTerminalId)
+        }
+    }
 
     // internal constructor facilitates testing
     internal constructor(
         posTerminalId: String,
         forageSdk: ForageSDK,
-        createLogger: () -> Log,
-        createServiceFactory: ((String, String, Log) -> ForageSDK.ServiceFactory)? = null
+        createLogger: (String) -> Log,
+        createServiceFactory: ((String, String, Log) -> ForageSDK.ServiceFactory)? = null,
+        initSucceeded: Boolean = false
     ) : this(posTerminalId) {
         this.forageSdk = forageSdk
-        this.createLogger = createLogger
+        ForageTerminalSDK.createLogger = createLogger
         if (createServiceFactory != null) {
             this.createServiceFactory = createServiceFactory
+        }
+
+        if (initSucceeded) {
+            // STOPGAP to allow testing without depending on the init method.
+            ForageTerminalSDK.initSucceeded = initSucceeded
+            calledInit = initSucceeded
         }
     }
 
@@ -88,7 +175,7 @@ class ForageTerminalSDK(
      *
      *     fun tokenizeCard(foragePanEditText: ForagePANEditText) = viewModelScope.launch {
      *
-     *         val response = ForageTerminalSDK().tokenizeCard(
+     *         val response = forageTerminalSdk.tokenizeCard(
      *           foragePanEditText = foragePanEditText,
      *           reusable = true
      *         )
@@ -119,18 +206,26 @@ class ForageTerminalSDK(
         foragePanEditText: ForagePANEditText,
         reusable: Boolean = true
     ): ForageApiResponse<String> {
-        val logger = createLogger()
+        val logger = createLogger(posTerminalId)
         logger.addAttribute("reusable", reusable)
         logger.i("[POS] Tokenizing Payment Method via UI PAN entry on Terminal $posTerminalId")
 
-        val tokenizationResponse = forageSdk.tokenizeEBTCard(
-            TokenizeEBTCardParams(
-                foragePanEditText = foragePanEditText,
-                reusable = reusable
+        val initializationException = isInitializationExceptionOrNull(logger, "tokenizeCard")
+        if (initializationException != null) {
+            return initializationException
+        }
+
+        val tokenizationResponse =
+            forageSdk.tokenizeEBTCard(
+                TokenizeEBTCardParams(
+                    foragePanEditText = foragePanEditText,
+                    reusable = reusable
+                )
             )
-        )
         if (tokenizationResponse is ForageApiResponse.Failure) {
-            logger.e("[POS] tokenizeCard failed on Terminal $posTerminalId: ${tokenizationResponse.errors[0]}")
+            logger.e(
+                "[POS] tokenizeCard failed on Terminal $posTerminalId: ${tokenizationResponse.errors[0]}"
+            )
         }
         return tokenizationResponse
     }
@@ -152,7 +247,7 @@ class ForageTerminalSDK(
      *     val sessionToken = "<session_token>"
      *
      *     fun tokenizePosCard(foragePinEditText: ForagePINEditText) = viewModelScope.launch {
-     *         val response = ForageTerminalSDK().tokenizeCard(
+     *         val response = forageTerminalSdk.tokenizeCard(
      *           PosTokenizeCardParams(
      *             forageConfig = ForageConfig(
      *               merchantId = merchantId,
@@ -185,20 +280,24 @@ class ForageTerminalSDK(
      */
     suspend fun tokenizeCard(params: PosTokenizeCardParams): ForageApiResponse<String> {
         val (posForageConfig, track2Data, reusable) = params
-        val logger = createLogger()
+        val logger = createLogger(posTerminalId)
         logger.addAttribute("reusable", reusable)
             .addAttribute("merchant_ref", posForageConfig.merchantId)
 
-        logger.i("[POS] Tokenizing Payment Method using magnetic card swipe with Track 2 data on Terminal $posTerminalId")
+        logger.i(
+            "[POS] Tokenizing Payment Method using magnetic card swipe with Track 2 data on Terminal $posTerminalId"
+        )
+
+        val initializationException = isInitializationExceptionOrNull(logger, "tokenizeCard")
+        if (initializationException != null) {
+            return initializationException
+        }
 
         val (merchantId, sessionToken) = posForageConfig
         val serviceFactory = createServiceFactory(sessionToken, merchantId, logger)
         val tokenizeCardService = serviceFactory.createTokenizeCardService()
 
-        return tokenizeCardService.tokenizePosCard(
-            track2Data = track2Data,
-            reusable = reusable
-        )
+        return tokenizeCardService.tokenizePosCard(track2Data = track2Data, reusable = reusable)
     }
 
     /**
@@ -223,7 +322,7 @@ class ForageTerminalSDK(
      *     val paymentMethodRef = "020xlaldfh"
      *
      *     fun checkBalance(foragePinEditText: ForagePINEditText) = viewModelScope.launch {
-     *         val response = ForageTerminalSDK().checkBalance(
+     *         val response = forageTerminalSdk.checkBalance(
      *             CheckBalanceParams(
      *                 foragePinEditText = foragePinEditText,
      *                 paymentMethodRef = paymentMethodRef
@@ -255,10 +354,8 @@ class ForageTerminalSDK(
      * to trigger balance inquiry exceptions during testing.
      * @return A [ForageApiResponse] object.
      */
-    override suspend fun checkBalance(
-        params: CheckBalanceParams
-    ): ForageApiResponse<String> {
-        val logger = createLogger()
+    override suspend fun checkBalance(params: CheckBalanceParams): ForageApiResponse<String> {
+        val logger = createLogger(posTerminalId)
         val (foragePinEditText, paymentMethodRef) = params
 
         val illegalVaultException = isIllegalVaultExceptionOrNull(foragePinEditText, logger)
@@ -271,32 +368,42 @@ class ForageTerminalSDK(
         logger.addAttribute("merchant_ref", merchantId)
             .addAttribute("payment_method_ref", paymentMethodRef)
 
-        logger.i("[POS] Called checkBalance for PaymentMethod $paymentMethodRef on Terminal $posTerminalId")
+        logger.i(
+            "[POS] Called checkBalance for PaymentMethod $paymentMethodRef on Terminal $posTerminalId"
+        )
+
+        val initializationException = isInitializationExceptionOrNull(logger, "checkBalance")
+        if (initializationException != null) {
+            return initializationException
+        }
 
         // This block is used for tracking Metrics!
         // ------------------------------------------------------
-        val measurement = CustomerPerceivedResponseMonitor.newMeasurement(
-            vault = foragePinEditText.getVaultType(),
-            vaultAction = UserAction.BALANCE,
-            logger
-        )
+        val measurement =
+            CustomerPerceivedResponseMonitor.newMeasurement(
+                vault = foragePinEditText.getVaultType(),
+                vaultAction = UserAction.BALANCE,
+                logger
+            )
         measurement.start()
         // ------------------------------------------------------
 
         val serviceFactory = createServiceFactory(sessionToken, merchantId, logger)
         val balanceCheckService = serviceFactory.createCheckBalanceRepository(foragePinEditText)
-        val balanceResponse = balanceCheckService.posCheckBalance(
-            merchantId = merchantId,
-            paymentMethodRef = paymentMethodRef,
-            posTerminalId = posTerminalId,
-            sessionToken = sessionToken
-        )
+        val balanceResponse =
+            balanceCheckService.posCheckBalance(
+                merchantId = merchantId,
+                paymentMethodRef = paymentMethodRef,
+                posTerminalId = posTerminalId,
+                sessionToken = sessionToken
+            )
         forageSdk.processApiResponseForMetrics(balanceResponse, measurement)
 
         if (balanceResponse is ForageApiResponse.Failure) {
             logger.e(
                 "[POS] checkBalance failed for PaymentMethod $paymentMethodRef on Terminal $posTerminalId: ${balanceResponse.errors[0]}",
-                attributes = mapOf(
+                attributes =
+                mapOf(
                     "payment_method_ref" to paymentMethodRef,
                     "pos_terminal_id" to posTerminalId
                 )
@@ -305,8 +412,6 @@ class ForageTerminalSDK(
 
         return balanceResponse
     }
-
-    // ======= Same as online-only Forage SDK below =======
 
     /**
      * Immediately captures a payment via a
@@ -330,7 +435,7 @@ class ForageTerminalSDK(
      *
      *     fun capturePayment(foragePinEditText: ForagePINEditText, paymentRef: String) =
      *         viewModelScope.launch {
-     *             val response = ForageTerminalSDK().capturePayment(
+     *             val response = forageTerminalSdk.capturePayment(
      *                 CapturePaymentParams(
      *                     foragePinEditText = foragePinEditText,
      *                     paymentRef = snapPaymentRef
@@ -371,18 +476,26 @@ class ForageTerminalSDK(
      * to trigger payment capture exceptions during testing.
      * @return A [ForageApiResponse] object.
      */
-    override suspend fun capturePayment(
-        params: CapturePaymentParams
-    ): ForageApiResponse<String> {
-        val (_, paymentRef) = params
-
-        val logger = createLogger().addAttribute("payment_ref", paymentRef)
+    override suspend fun capturePayment(params: CapturePaymentParams): ForageApiResponse<String> {
+        val (foragePinEditText, paymentRef) = params
+        val logger = createLogger(posTerminalId).addAttribute("payment_ref", paymentRef)
         logger.i("[POS] Called capturePayment for Payment $paymentRef")
+
+        val illegalVaultException = isIllegalVaultExceptionOrNull(foragePinEditText, logger)
+        if (illegalVaultException != null) {
+            return illegalVaultException
+        }
+        val initializationException = isInitializationExceptionOrNull(logger, "capturePayment")
+        if (initializationException != null) {
+            return initializationException
+        }
 
         val captureResponse = forageSdk.capturePayment(params)
 
         if (captureResponse is ForageApiResponse.Failure) {
-            logger.e("[POS] capturePayment failed for payment $paymentRef on Terminal $posTerminalId: ${captureResponse.errors[0]}")
+            logger.e(
+                "[POS] capturePayment failed for payment $paymentRef on Terminal $posTerminalId: ${captureResponse.errors[0]}"
+            )
         }
         return captureResponse
     }
@@ -407,7 +520,7 @@ class ForageTerminalSDK(
      *
      *     fun deferPaymentCapture(foragePinEditText: ForagePINEditText, paymentRef: String) =
      *         viewModelScope.launch {
-     *             val response = ForageTerminalSDK().deferPaymentCapture(
+     *             val response = forageTerminalSdk.deferPaymentCapture(
      *                 DeferPaymentCaptureParams(
      *                     foragePinEditText = foragePinEditText,
      *                     paymentRef = snapPaymentRef
@@ -443,16 +556,24 @@ class ForageTerminalSDK(
      * on error handling.
      * @return A [ForageApiResponse] object.
      */
-    override suspend fun deferPaymentCapture(params: DeferPaymentCaptureParams): ForageApiResponse<String> {
-        val (_, paymentRef) = params
-
-        val logger = createLogger().addAttribute("payment_ref", paymentRef)
+    override suspend fun deferPaymentCapture(
+        params: DeferPaymentCaptureParams
+    ): ForageApiResponse<String> {
+        val (foragePinEditText, paymentRef) = params
+        val logger = createLogger(posTerminalId).addAttribute("payment_ref", paymentRef)
         logger.i("[POS] Called deferPaymentCapture for Payment $paymentRef")
+
+        val illegalVaultException = isIllegalVaultExceptionOrNull(foragePinEditText, logger)
+        if (illegalVaultException != null) {
+            return illegalVaultException
+        }
 
         val deferCaptureResponse = forageSdk.deferPaymentCapture(params)
 
         if (deferCaptureResponse is ForageApiResponse.Failure) {
-            logger.e("[POS] deferPaymentCapture failed for Payment $paymentRef on Terminal $posTerminalId: ${deferCaptureResponse.errors[0]}")
+            logger.e(
+                "[POS] deferPaymentCapture failed for Payment $paymentRef on Terminal $posTerminalId: ${deferCaptureResponse.errors[0]}"
+            )
         }
         return deferCaptureResponse
     }
@@ -477,7 +598,7 @@ class ForageTerminalSDK(
      *   var metadata: HashMap? = null
      *
      *   fun refundPayment(foragePinEditText: ForagePINEditText) = viewModelScope.launch {
-     *     val forage = ForageTerminalSDK(posTerminalId)
+     *     val forageTerminalSdk = ForageTerminalSDK.init(...) // may throw!
      *     val refundParams = PosRefundPaymentParams(
      *       foragePinEditText,
      *       paymentRef,
@@ -509,7 +630,7 @@ class ForageTerminalSDK(
      * @return A [ForageApiResponse] object.
      */
     suspend fun refundPayment(params: PosRefundPaymentParams): ForageApiResponse<String> {
-        val logger = createLogger()
+        val logger = createLogger(posTerminalId)
         val (foragePinEditText, paymentRef, amount, reason) = params
         val (merchantId, sessionToken) = forageSdk._getForageConfigOrThrow(foragePinEditText)
 
@@ -518,9 +639,7 @@ class ForageTerminalSDK(
             return illegalVaultException
         }
 
-        logger
-            .addAttribute("payment_ref", paymentRef)
-            .addAttribute("merchant_ref", merchantId)
+        logger.addAttribute("payment_ref", paymentRef).addAttribute("merchant_ref", merchantId)
         logger.i(
             """
             [POS] Called refundPayment for Payment $paymentRef
@@ -530,28 +649,37 @@ class ForageTerminalSDK(
             """.trimIndent()
         )
 
+        val initializationException = isInitializationExceptionOrNull(logger, "refundPayment")
+        if (initializationException != null) {
+            return initializationException
+        }
+
         // This block is used for tracking Metrics!
         // ------------------------------------------------------
-        val measurement = CustomerPerceivedResponseMonitor.newMeasurement(
-            vault = foragePinEditText.getVaultType(),
-            vaultAction = UserAction.REFUND,
-            logger
-        )
+        val measurement =
+            CustomerPerceivedResponseMonitor.newMeasurement(
+                vault = foragePinEditText.getVaultType(),
+                vaultAction = UserAction.REFUND,
+                logger
+            )
         measurement.start()
         // ------------------------------------------------------
 
         val serviceFactory = createServiceFactory(sessionToken, merchantId, logger)
         val refundService = serviceFactory.createRefundPaymentRepository(foragePinEditText)
-        val refund = refundService.refundPayment(
-            merchantId = merchantId,
-            posTerminalId = posTerminalId,
-            refundParams = params,
-            sessionToken = sessionToken
-        )
+        val refund =
+            refundService.refundPayment(
+                merchantId = merchantId,
+                posTerminalId = posTerminalId,
+                refundParams = params,
+                sessionToken = sessionToken
+            )
         forageSdk.processApiResponseForMetrics(refund, measurement)
 
         if (refund is ForageApiResponse.Failure) {
-            logger.e("[POS] refundPayment failed for Payment $paymentRef on Terminal $posTerminalId: ${refund.errors[0]}")
+            logger.e(
+                "[POS] refundPayment failed for Payment $paymentRef on Terminal $posTerminalId: ${refund.errors[0]}"
+            )
         }
 
         return refund
@@ -566,7 +694,7 @@ class ForageTerminalSDK(
      *   var paymentRef: String  = ""
      *
      *   fun deferPaymentRefund(foragePinEditText: ForagePINEditText) = viewModelScope.launch {
-     *     val forage = ForageTerminalSDK(posTerminalId)
+     *     val forageTerminalSdk = ForageTerminalSDK.init(...) // may throw!
      *     val deferPaymentRefundParams = PosDeferPaymentRefundParams(
      *       foragePinEditText,
      *       paymentRef
@@ -598,7 +726,7 @@ class ForageTerminalSDK(
      * hasn't had its ForageConfig set via .setForageConfig().
      */
     suspend fun deferPaymentRefund(params: PosDeferPaymentRefundParams): ForageApiResponse<String> {
-        val logger = createLogger()
+        val logger = createLogger(posTerminalId)
         val (foragePinEditText, paymentRef) = params
         val (merchantId, sessionToken) = forageSdk._getForageConfigOrThrow(foragePinEditText)
 
@@ -607,9 +735,7 @@ class ForageTerminalSDK(
             return illegalVaultException
         }
 
-        logger
-            .addAttribute("payment_ref", paymentRef)
-            .addAttribute("merchant_ref", merchantId)
+        logger.addAttribute("payment_ref", paymentRef).addAttribute("merchant_ref", merchantId)
         logger.i(
             """
             [POS] Called deferPaymentRefund for Payment $paymentRef
@@ -617,27 +743,36 @@ class ForageTerminalSDK(
             """.trimIndent()
         )
 
+        val initializationException = isInitializationExceptionOrNull(logger, "deferPaymentRefund")
+        if (initializationException != null) {
+            return initializationException
+        }
+
         // This block is used for tracking Metrics!
         // ------------------------------------------------------
-        val measurement = CustomerPerceivedResponseMonitor.newMeasurement(
-            vault = foragePinEditText.getVaultType(),
-            vaultAction = UserAction.DEFER_REFUND,
-            logger
-        )
+        val measurement =
+            CustomerPerceivedResponseMonitor.newMeasurement(
+                vault = foragePinEditText.getVaultType(),
+                vaultAction = UserAction.DEFER_REFUND,
+                logger
+            )
         measurement.start()
         // ------------------------------------------------------
 
         val serviceFactory = createServiceFactory(sessionToken, merchantId, logger)
         val refundService = serviceFactory.createDeferPaymentRefundRepository(foragePinEditText)
-        val refund = refundService.deferPaymentRefund(
-            merchantId = merchantId,
-            paymentRef = paymentRef,
-            sessionToken = sessionToken
-        )
+        val refund =
+            refundService.deferPaymentRefund(
+                merchantId = merchantId,
+                paymentRef = paymentRef,
+                sessionToken = sessionToken
+            )
         forageSdk.processApiResponseForMetrics(refund, measurement)
 
         if (refund is ForageApiResponse.Failure) {
-            logger.e("[POS] deferPaymentRefund failed for Payment $paymentRef on Terminal $posTerminalId: ${refund.errors[0]}")
+            logger.e(
+                "[POS] deferPaymentRefund failed for Payment $paymentRef on Terminal $posTerminalId: ${refund.errors[0]}"
+            )
         }
 
         return refund
@@ -660,13 +795,23 @@ class ForageTerminalSDK(
         return null
     }
 
+    private fun isInitializationExceptionOrNull(
+        logger: Log,
+        methodName: String
+    ): ForageApiResponse<String>? {
+        // The public distribution of the Forage Terminal SDK does not have an init method.
+        // So we always return null here!
+        return null
+    }
+
     /**
      * Use one of the [tokenizeCard] options instead.
      *
      * @throws NotImplementedError
      */
     @Deprecated(
-        message = "This method is not applicable to the Forage Terminal SDK. Use the other tokenizeEBTCard methods.",
+        message =
+        "This method is not applicable to the Forage Terminal SDK. Use the other tokenizeEBTCard methods.",
         level = DeprecationLevel.ERROR
     )
     override suspend fun tokenizeEBTCard(params: TokenizeEBTCardParams): ForageApiResponse<String> {

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
@@ -24,7 +24,9 @@ import com.joinforage.forage.android.ui.ForagePINEditText
  *
  * A [ForageTerminalSDK] instance interacts with the Forage API.
  *
- * ℹ️ Call [`ForageTerminalSDK.init`][init] before performing operations like:
+ * **You need to call [`ForageTerminalSDK.init`][init] to initialize the SDK.**
+ * Then you can perform operations like:
+ *
  * <br><br>
  *
  * * [Tokenizing card information][tokenizeCard]
@@ -69,10 +71,14 @@ class ForageTerminalSDK internal constructor(private val posTerminalId: String) 
         private var initSucceeded = false
 
         /**
-         * The [ForageTerminalSDK] may perform some long running initialization operations in
+         * A method that initializes the [ForageTerminalSDK].
+         *
+         * **You must call [init] ahead of calling
+         * any other methods on a ForageTerminalSDK instance.**
+         *
+         * Forage may perform some long running initialization operations in
          * certain circumstances. The operations typically last less than 10 seconds and only occur
-         * infrequently. It is required to call [init] ahead of calling any other
-         * methods on a [ForageTerminalSDK] instance.
+         * infrequently.
          *
          * ⚠️The [ForageTerminalSDK.init] method is only available in the private
          * distribution of the Forage Terminal SDK.

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
@@ -26,9 +26,7 @@ import com.joinforage.forage.android.ui.ForagePINEditText
  *
  * **You need to call [`ForageTerminalSDK.init`][init] to initialize the SDK.**
  * Then you can perform operations like:
- *
  * <br><br>
- *
  * * [Tokenizing card information][tokenizeCard]
  * * [Checking the balance of a card][checkBalance]
  * * [Collecting a card PIN for a payment and

--- a/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/pos/ForageTerminalSDK.kt
@@ -41,9 +41,11 @@ import com.joinforage.forage.android.ui.ForagePINEditText
  * // Example: Initialize the Forage Terminal SDK
  * val forageTerminalSdk = ForageTerminalSDK.init(
  *     context = androidContext,
- *     posTerminalId = "<uniquely-identifies-the-pos-terminal>",
- *     merchantId = "mid/<merchant_id>",
- *     sessionToken = "sandbox_ey123..."
+ *     posTerminalId = "<id-that-uniquely-identifies-the-pos-terminal>",
+ *     posForageConfig = PosForageConfig(
+ *         merchantId = "mid/123ab45c67",
+ *         sessionToken = "sandbox_ey123..."
+ *     )
  * )
  * ```
  *
@@ -81,8 +83,10 @@ class ForageTerminalSDK internal constructor(private val posTerminalId: String) 
          *     val forageTerminalSdk = ForageTerminalSDK.init(
          *         context = androidContext,
          *         posTerminalId = "<id-that-uniquely-identifies-the-pos-terminal>",
-         *         merchantId = "mid/<merchant_id>",
-         *         sessionToken = "sandbox_ey123..."
+         *         posForageConfig = PosForageConfig(
+         *             merchantId = "mid/123ab45c67",
+         *             sessionToken = "sandbox_ey123..."
+         *         )
          *     )
          *
          *     // Use the forageTerminalSdk to call other methods
@@ -94,29 +98,18 @@ class ForageTerminalSDK internal constructor(private val posTerminalId: String) 
          *
          * @throws Exception If the initialization fails.
          *
-         * @param context The Android application context.
-         *
+         * @param context **Required**. The Android application context.
          * @param posTerminalId **Required**. A string that uniquely identifies the POS Terminal
          * used for a transaction. The max length of the string is 255 characters.
-         *
-         * @param merchantId **Required**. A unique Merchant ID that Forage provides during onboarding
-         * * preceded by "mid/".
-         * * For example, `mid/123ab45c67`. The Merchant ID can be found in the Forage
-         * * [Sandbox](https://dashboard.sandbox.joinforage.app/login/)
-         * * or [Production](https://dashboard.joinforage.app/login/) Dashboard.
-         *
-         * @param sessionToken **Required**. A short-lived token that authenticates front-end requests to Forage.
-         * * To create one, send a server-side `POST` request from your backend to the
-         * * [`/session_token/`](https://docs.joinforage.app/reference/create-session-token)
-         * endpoint.
+         * @param posForageConfig **Required**. A [PosForageConfig] instance that specifies a
+         * `merchantId` and `sessionToken`.
          */
         @RequiresApi(Build.VERSION_CODES.M)
         @Throws(Exception::class)
         suspend fun init(
             context: Context,
             posTerminalId: String,
-            merchantId: String,
-            sessionToken: String
+            posForageConfig: PosForageConfig
         ): ForageTerminalSDK {
             if (posTerminalId == "pos-sample-app-override") {
                 return ForageTerminalSDK(posTerminalId)
@@ -174,7 +167,6 @@ class ForageTerminalSDK internal constructor(private val posTerminalId: String) 
      *     val sessionToken = "<session_token>"
      *
      *     fun tokenizeCard(foragePanEditText: ForagePANEditText) = viewModelScope.launch {
-     *
      *         val response = forageTerminalSdk.tokenizeCard(
      *           foragePanEditText = foragePanEditText,
      *           reusable = true

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSComposeApp.kt
@@ -214,6 +214,7 @@ fun POSComposeApp(
                         if (panElement != null) {
                             panElement!!.clearFocus()
                             viewModel.tokenizeEBTCard(
+                                context = context,
                                 panElement as ForagePANEditText,
                                 k9SDK.terminalId,
                                 onSuccess = {
@@ -235,7 +236,7 @@ fun POSComposeApp(
                 MagSwipePANEntryScreen(
                     onLaunch = {
                         k9SDK.listenForMagneticCardSwipe { track2Data ->
-                            viewModel.tokenizeEBTCard(track2Data, k9SDK.terminalId) {
+                            viewModel.tokenizeEBTCard(context, track2Data, k9SDK.terminalId) {
                                 if (it?.ref != null) {
                                     Log.i("POSComposeApp", "Successfully tokenized EBT card with ref: $it.ref")
                                     viewModel.resetPinActionErrors()
@@ -256,6 +257,7 @@ fun POSComposeApp(
                         if (pinElement != null && uiState.tokenizedPaymentMethod?.ref != null) {
                             pinElement!!.clearFocus()
                             viewModel.checkEBTCardBalance(
+                                context = context,
                                 pinElement as ForagePINEditText,
                                 paymentMethodRef = uiState.tokenizedPaymentMethod!!.ref,
                                 k9SDK.terminalId,
@@ -396,6 +398,7 @@ fun POSComposeApp(
                         if (panElement != null) {
                             panElement!!.clearFocus()
                             viewModel.tokenizeEBTCard(
+                                context,
                                 panElement as ForagePANEditText,
                                 k9SDK.terminalId,
                                 onSuccess = { tokenizedCard ->
@@ -423,7 +426,7 @@ fun POSComposeApp(
                 MagSwipePANEntryScreen(
                     onLaunch = {
                         k9SDK.listenForMagneticCardSwipe { track2Data ->
-                            viewModel.tokenizeEBTCard(track2Data, k9SDK.terminalId) { tokenizedCard ->
+                            viewModel.tokenizeEBTCard(context, track2Data, k9SDK.terminalId) { tokenizedCard ->
                                 if (tokenizedCard?.ref != null) {
                                     Log.i("POSComposeApp", "Successfully tokenized EBT card with ref: $tokenizedCard.ref")
                                     val payment = uiState.localPayment!!.copy(paymentMethodRef = tokenizedCard.ref)
@@ -449,6 +452,7 @@ fun POSComposeApp(
                         if (pinElement != null && uiState.createPaymentResponse?.ref != null) {
                             pinElement!!.clearFocus()
                             viewModel.capturePayment(
+                                context = context,
                                 foragePinEditText = pinElement as ForagePINEditText,
                                 terminalId = k9SDK.terminalId,
                                 paymentRef = uiState.createPaymentResponse!!.ref!!,
@@ -547,6 +551,7 @@ fun POSComposeApp(
                         if (pinElement != null && uiState.localRefundState != null) {
                             pinElement!!.clearFocus()
                             viewModel.refundPayment(
+                                context = context,
                                 foragePinEditText = pinElement as ForagePINEditText,
                                 terminalId = k9SDK.terminalId,
                                 paymentRef = uiState.localRefundState!!.paymentRef,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -21,6 +21,7 @@ import com.joinforage.forage.android.CapturePaymentParams
 import com.joinforage.forage.android.CheckBalanceParams
 import com.joinforage.forage.android.network.model.ForageApiResponse
 import com.joinforage.forage.android.pos.ForageTerminalSDK
+import com.joinforage.forage.android.pos.PosForageConfig
 import com.joinforage.forage.android.pos.PosRefundPaymentParams
 import com.joinforage.forage.android.pos.PosTokenizeCardParams
 import com.joinforage.forage.android.ui.ForagePANEditText
@@ -376,8 +377,10 @@ class POSViewModel : ViewModel() {
         return ForageTerminalSDK.init(
             context = context,
             posTerminalId = "pos-sample-app-override",
-            merchantId = _uiState.value.merchantId,
-            sessionToken = _uiState.value.sessionToken
+            posForageConfig = PosForageConfig(
+                merchantId = _uiState.value.merchantId,
+                sessionToken = _uiState.value.sessionToken
+            )
         )
     }
 }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/POSViewModel.kt
@@ -1,5 +1,7 @@
 package com.joinforage.android.example.ui.pos
 
+import android.annotation.SuppressLint
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -34,6 +36,7 @@ import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import java.util.UUID
 
+@SuppressLint("NewApi")
 class POSViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(POSUIState())
     val uiState: StateFlow<POSUIState> = _uiState.asStateFlow()
@@ -136,9 +139,10 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun tokenizeEBTCard(foragePanEditText: ForagePANEditText, terminalId: String, onSuccess: (data: PosPaymentMethod?) -> Unit) {
+    fun tokenizeEBTCard(context: Context, foragePanEditText: ForagePANEditText, terminalId: String, onSuccess: (data: PosPaymentMethod?) -> Unit) {
         viewModelScope.launch {
-            val response = ForageTerminalSDK(terminalId).tokenizeCard(
+            val forageTerminalSdk = initForageTerminalSDK(context, terminalId)
+            val response = forageTerminalSdk.tokenizeCard(
                 foragePanEditText = foragePanEditText,
                 reusable = true
             )
@@ -159,10 +163,10 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun tokenizeEBTCard(track2Data: String, terminalId: String, onSuccess: (data: PosPaymentMethod?) -> Unit) {
+    fun tokenizeEBTCard(context: Context, track2Data: String, terminalId: String, onSuccess: (data: PosPaymentMethod?) -> Unit) {
         viewModelScope.launch {
-            val forage = ForageTerminalSDK(terminalId)
-            val response = forage.tokenizeCard(
+            val forageTerminalSdk = initForageTerminalSDK(context, terminalId)
+            val response = forageTerminalSdk.tokenizeCard(
                 PosTokenizeCardParams(
                     uiState.value.posForageConfig,
                     track2Data
@@ -185,9 +189,10 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun checkEBTCardBalance(foragePinEditText: ForagePINEditText, paymentMethodRef: String, terminalId: String, onSuccess: (response: BalanceCheck?) -> Unit) {
+    fun checkEBTCardBalance(context: Context, foragePinEditText: ForagePINEditText, paymentMethodRef: String, terminalId: String, onSuccess: (response: BalanceCheck?) -> Unit) {
         viewModelScope.launch {
-            val response = ForageTerminalSDK(terminalId).checkBalance(
+            val forageTerminalSdk = initForageTerminalSDK(context, terminalId)
+            val response = forageTerminalSdk.checkBalance(
                 CheckBalanceParams(
                     foragePinEditText = foragePinEditText,
                     paymentMethodRef = paymentMethodRef
@@ -220,9 +225,10 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun capturePayment(foragePinEditText: ForagePINEditText, terminalId: String, paymentRef: String, onSuccess: () -> Unit, onFailure: (sequenceNumber: String?) -> Unit) {
+    fun capturePayment(context: Context, foragePinEditText: ForagePINEditText, terminalId: String, paymentRef: String, onSuccess: () -> Unit, onFailure: (sequenceNumber: String?) -> Unit) {
         viewModelScope.launch {
-            val response = ForageTerminalSDK(terminalId).capturePayment(
+            val forageTerminalSdk = initForageTerminalSDK(context, terminalId)
+            val response = forageTerminalSdk.capturePayment(
                 CapturePaymentParams(
                     foragePinEditText = foragePinEditText,
                     paymentRef = paymentRef
@@ -261,9 +267,10 @@ class POSViewModel : ViewModel() {
         }
     }
 
-    fun refundPayment(foragePinEditText: ForagePINEditText, terminalId: String, amount: Float, paymentRef: String, reason: String, onSuccess: () -> Unit, onFailure: () -> Unit) {
+    fun refundPayment(context: Context, foragePinEditText: ForagePINEditText, terminalId: String, amount: Float, paymentRef: String, reason: String, onSuccess: () -> Unit, onFailure: () -> Unit) {
         viewModelScope.launch {
-            val response = ForageTerminalSDK(terminalId).refundPayment(
+            val forageTerminalSdk = initForageTerminalSDK(context, terminalId)
+            val response = forageTerminalSdk.refundPayment(
                 PosRefundPaymentParams(
                     foragePinEditText = foragePinEditText,
                     amount = amount,
@@ -360,5 +367,17 @@ class POSViewModel : ViewModel() {
                 _uiState.update { it.copy(voidRefundError = e.toString(), voidRefundResponse = null) }
             }
         }
+    }
+
+    private suspend fun initForageTerminalSDK(context: Context, terminalId: String): ForageTerminalSDK {
+        // Setting `posTerminalId = "pos-sample-app-override"` allows
+        // us to run the POS sample app from the public repository
+        // without raising a "NotImplementedError".
+        return ForageTerminalSDK.init(
+            context = context,
+            posTerminalId = "pos-sample-app-override",
+            merchantId = _uiState.value.merchantId,
+            sessionToken = _uiState.value.sessionToken
+        )
     }
 }


### PR DESCRIPTION
## What

- [x] Introduced an empty `ForageTerminalSDK.init` method
- [x] Removed outdated constructor info and made the constructor internal
- [x] `init` method throws a `NotImplementedError` if the client calls the `init` method from the wrong SDK distribution, unless an override ID is provided. 
- [x] Corrected sample app to use `init` method 
- [x] Added updated comments for `init` method

## Why 

ℹ️ The method's implementation is not available publicly, but these changes facilitate keeping the different repositories in sync and **build our public-facing documentation**

## Test plan

- [x] Manually ran some POS operations in the sample app
- [x] Unit tests pass
- [x] Unit tests were updated to be in sync with the private repo 
- [x] Built docs locally via `./gradlew dokkaHtml` task 