### PR TITLE
[FX-1225] Support defer capture + defer refund in POS sample app

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/deferred/DeferredPaymentCaptureResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/deferred/DeferredPaymentCaptureResultScreen.kt
@@ -1,0 +1,110 @@
+package com.joinforage.android.example.ui.pos.screens.deferred
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun DeferredPaymentCaptureResultScreen(
+    terminalId: String,
+    paymentRef: String,
+    onBackButtonClicked: () -> Unit,
+    onDoneButtonClicked: () -> Unit
+) {
+    val clipboardManager = LocalClipboardManager.current
+
+    val postRequestPrompt = """
+        Send a POST request to
+        /api/payments/$paymentRef/capture_payment/ 
+        to complete the payment
+    """.trimIndent()
+
+    val docsLink = "https://docs.joinforage.app/docs/capture-ebt-payments-server-side#step-4-capture-the-payment-server-side"
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier.fillMaxSize().padding(16.dp)
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Text("Terminal ID: $terminalId")
+                Button(onClick = {
+                    clipboardManager.setText(AnnotatedString(terminalId))
+                }, colors = ButtonDefaults.elevatedButtonColors()) {
+                    Text("Copy")
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Text("Payment Ref: $paymentRef")
+                Button(onClick = {
+                    clipboardManager.setText(AnnotatedString(paymentRef))
+                }, colors = ButtonDefaults.elevatedButtonColors()) {
+                    Text("Copy")
+                }
+            }
+            Spacer(modifier = Modifier.height(48.dp))
+
+            Text(postRequestPrompt, fontFamily = FontFamily.Monospace)
+
+            Spacer(modifier = Modifier.height(48.dp))
+
+            Button(onClick = {
+                clipboardManager.setText(AnnotatedString(docsLink))
+            }, colors = ButtonDefaults.elevatedButtonColors()) {
+                Text("Copy Documentation Link")
+            }
+        }
+        Row {
+            Column {
+                Button(onClick = onBackButtonClicked) {
+                    Text("Try Again")
+                }
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Column {
+                ElevatedButton(onClick = onDoneButtonClicked) {
+                    Text("Done")
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun DeferredPaymentCaptureResultScreenPreview() {
+    DeferredPaymentCaptureResultScreen(
+        terminalId = "",
+        paymentRef = "",
+        onBackButtonClicked = {},
+        onDoneButtonClicked = {}
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/deferred/DeferredPaymentRefundResultScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/deferred/DeferredPaymentRefundResultScreen.kt
@@ -1,0 +1,110 @@
+package com.joinforage.android.example.ui.pos.screens.deferred
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun DeferredPaymentRefundResultScreen(
+    terminalId: String,
+    paymentRef: String,
+    onBackButtonClicked: () -> Unit,
+    onDoneButtonClicked: () -> Unit
+) {
+    val clipboardManager = LocalClipboardManager.current
+
+    val postRequestPrompt = """
+        Send a POST request to 
+        /api/payments/$paymentRef/refunds/ 
+        to complete the refund
+    """.trimIndent()
+
+    val docsLink = "https://docs.joinforage.app/docs/capture-ebt-payments-server-side#step-2-complete-the-refund-server-side"
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier.fillMaxSize().padding(16.dp)
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Text("Terminal ID: $terminalId")
+                Button(onClick = {
+                    clipboardManager.setText(AnnotatedString(terminalId))
+                }, colors = ButtonDefaults.elevatedButtonColors()) {
+                    Text("Copy")
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Text("Payment Ref: $paymentRef")
+                Button(onClick = {
+                    clipboardManager.setText(AnnotatedString(paymentRef))
+                }, colors = ButtonDefaults.elevatedButtonColors()) {
+                    Text("Copy")
+                }
+            }
+            Spacer(modifier = Modifier.height(48.dp))
+
+            Text(postRequestPrompt, fontFamily = FontFamily.Monospace)
+
+            Spacer(modifier = Modifier.height(48.dp))
+
+            Button(onClick = {
+                clipboardManager.setText(AnnotatedString(docsLink))
+            }, colors = ButtonDefaults.elevatedButtonColors()) {
+                Text("Copy Documentation Link")
+            }
+        }
+        Row {
+            Column {
+                Button(onClick = onBackButtonClicked) {
+                    Text("Try Again")
+                }
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Column {
+                ElevatedButton(onClick = onDoneButtonClicked) {
+                    Text("Done")
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun DeferredPaymentRefundResultScreenPreview() {
+    DeferredPaymentRefundResultScreen(
+        terminalId = "",
+        paymentRef = "",
+        onBackButtonClicked = {},
+        onDoneButtonClicked = {}
+    )
+}

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/PinEntryScreen.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/pos/screens/shared/PinEntryScreen.kt
@@ -1,17 +1,23 @@
 package com.joinforage.android.example.ui.pos.screens.shared
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.joinforage.android.example.ui.extensions.withTestId
 import com.joinforage.android.example.ui.pos.ui.ComposableForagePINEditText
 import com.joinforage.android.example.ui.pos.ui.ErrorText
 import com.joinforage.android.example.ui.pos.ui.ScreenWithBottomRow
@@ -25,6 +31,7 @@ fun PINEntryScreen(
     onSubmitButtonClicked: () -> Unit,
     onBackButtonClicked: () -> Unit,
     withPinElementReference: (element: ForagePINEditText) -> Unit,
+    onDeferButtonClicked: (() -> Unit)? = null,
     errorText: String? = null
 ) {
     ScreenWithBottomRow(
@@ -42,8 +49,27 @@ fun PINEntryScreen(
                     posForageConfig = posForageConfig,
                     withPinElementReference = withPinElementReference
                 )
-                Button(onClick = onSubmitButtonClicked) {
-                    Text("Submit")
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    OutlinedButton(
+                        onClick = onSubmitButtonClicked,
+                        modifier = Modifier.withTestId("pos_client_complete_pin_transaction_button")
+                    ) {
+                        Text("Complete Now")
+                    }
+
+                    if (onDeferButtonClicked != null) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Button(
+                            onClick = onDeferButtonClicked,
+                            modifier = Modifier.withTestId("pos_collect_pin_defer_button")
+                        ) {
+                            Text("Defer to Server")
+                        }
+                    }
                 }
             } else {
                 Text("There was an issue adding your card")

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -52,5 +52,7 @@
     <string name="title_pos_void_refund">Void a Refund</string>
     <string name="title_pos_void_payment_result">Void Payment Result</string>
     <string name="title_pos_void_refund_result">Void Refund Result</string>
+    <string name="title_pos_defer_payment_result">Deferred Payment Capture Result</string>
+    <string name="title_pos_defer_refund_result">Deferred Payment Refund Result</string>
     <string name="pos_restart">Restart</string>
 </resources>


### PR DESCRIPTION
## What

- See title

## Why/How

- Deferred actions are the primary (primary Material Design color + shape + position) CTAs, since deferring actions to server is the preferred flow
- Based on #236 since PR 236 includes changes for invoking the `init` method from the sample app, to facilitate keeping the private POS repo in sync

## Test plan

- Manually tried some captures + refunds in the sample app
- Ensured existing non-deferred POS flows still work :)

## Screenshots

<img src="https://github.com/teamforage/forage-android-sdk/assets/32694765/d0818d24-5983-4fdf-849a-4b0ee3514fee" width="400px">

<img src="https://github.com/teamforage/forage-android-sdk/assets/32694765/013e8405-82dc-49db-b79d-051c3ba1984a" width="400px">

<img src="https://github.com/teamforage/forage-android-sdk/assets/32694765/36fa4c91-3acc-45b0-aad1-795ac515d1ab" width="400px">

<img src="https://github.com/teamforage/forage-android-sdk/assets/32694765/d579e09e-1522-4297-bcb6-6ae0a3d01760" width="400px">




