### PR TITLE
[FX-1254] Expose `showKeyboard()` method on `ForageElement`s

### DIFF
--- a/forage-android/build.gradle
+++ b/forage-android/build.gradle
@@ -122,7 +122,7 @@ dependencies {
     api 'com.verygoodsecurity:vgscollect:1.7.3'
 
     // Basis Theory SDK
-    implementation ('com.github.basis-theory:basistheory-android:2.5.0') {
+    implementation ('com.github.basis-theory:basistheory-android:4.2.0') {
         // Unable to build without excluding this dependency
         // based on advice from this thread: https://github.com/gradle/gradle/issues/3065#issuecomment-341418873
         exclude group: 'javax.ws.rs'

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageElement.kt
@@ -92,6 +92,14 @@ interface ForageElement<T : ElementState> {
     fun setPosForageConfig(posForageConfig: PosForageConfig)
 
     /**
+     * Explicitly request that the current input method's soft
+     * input be shown to the user, if needed. This only has an
+     * effect if the ForageElement is focussed, which can be
+     * done using `.requestFocus()`
+     */
+    fun showKeyboard()
+
+    /**
      * Clears the text input field of the ForageElement.
      */
     fun clearText()

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForageElement.kt
@@ -94,7 +94,7 @@ interface ForageElement<T : ElementState> {
     /**
      * Explicitly request that the current input method's soft
      * input be shown to the user, if needed. This only has an
-     * effect if the ForageElement is focussed, which can be
+     * effect if the ForageElement is focused, which can be
      * done using `.requestFocus()`
      */
     fun showKeyboard()

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePANEditText.kt
@@ -7,6 +7,8 @@ import android.text.InputType
 import android.text.method.DigitsKeyListener
 import android.util.AttributeSet
 import android.util.TypedValue
+import android.view.inputmethod.InputMethodManager
+import androidx.core.content.getSystemService
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.joinforage.forage.android.ForageConfigNotSetException
@@ -171,6 +173,11 @@ class ForagePANEditText @JvmOverloads constructor(
                     recycle()
                 }
             }
+    }
+
+    override fun showKeyboard() {
+        val imm = context.getSystemService<InputMethodManager>()
+        imm!!.showSoftInput(textInputEditText, 0)
     }
 
     override fun initWithForageConfig(forageConfig: ForageConfig, isPos: Boolean) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -66,10 +66,11 @@ class ForagePINEditText @JvmOverloads constructor(
     private val forageVaultWrapper: ForageVaultWrapper
 
     override fun showKeyboard() {
-        if (vault.getVaultType() == VaultType.VGS_VAULT_TYPE)
+        if (vault.getVaultType() == VaultType.VGS_VAULT_TYPE) {
             vault.getVGSEditText().showKeyboard()
+        }
         if (vault.getVaultType() == VaultType.BT_VAULT_TYPE) {
-            TODO("currently blocked by BT's lack of this functionality")
+            vault.getTextElement().showKeyboard(0)
         }
     }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ui/ForagePINEditText.kt
@@ -65,6 +65,14 @@ class ForagePINEditText @JvmOverloads constructor(
     private val vgsVaultWrapper: VGSVaultWrapper
     private val forageVaultWrapper: ForageVaultWrapper
 
+    override fun showKeyboard() {
+        if (vault.getVaultType() == VaultType.VGS_VAULT_TYPE)
+            vault.getVGSEditText().showKeyboard()
+        if (vault.getVaultType() == VaultType.BT_VAULT_TYPE) {
+            TODO("currently blocked by BT's lack of this functionality")
+        }
+    }
+
     /**
      * The `vault` property acts as an abstraction for the actual code
      * in ForagePINEditText, allowing it to work with a non-nullable

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
@@ -28,6 +28,13 @@ class FlowBalanceFragment : Fragment() {
     private lateinit var snap: TextView
     private lateinit var nonSnap: TextView
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        foragePinEditText.requestFocus()
+        foragePinEditText.showKeyboard()
+    }
+
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -56,8 +63,6 @@ class FlowBalanceFragment : Fragment() {
                 sessionToken = viewModel.bearer
             )
         )
-
-        foragePinEditText.requestFocus()
 
         val isFocused: TextView = binding.isFocused
         val isComplete: TextView = binding.isComplete

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
@@ -31,7 +31,11 @@ class FlowBalanceFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         foragePinEditText.requestFocus()
-        foragePinEditText.showKeyboard()
+        // our CI tests fail when we automatically show the keyboard
+        // because it covers certain elements. So this code is
+        // commented out by default. Uncomment it to make your
+        // dev experience slightly better :)
+//        foragePinEditText.showKeyboard()
     }
 
     override fun onCreateView(

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
@@ -34,7 +34,6 @@ class FlowBalanceFragment : Fragment() {
         foragePinEditText.showKeyboard()
     }
 
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeFragment.kt
@@ -24,6 +24,12 @@ class FlowTokenizeFragment : Fragment() {
 
     private val binding get() = _binding!!
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.tokenizeForagePanEditText.requestFocus()
+        binding.tokenizeForagePanEditText.showKeyboard()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeFragment.kt
@@ -27,7 +27,11 @@ class FlowTokenizeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.tokenizeForagePanEditText.requestFocus()
-        binding.tokenizeForagePanEditText.showKeyboard()
+        // our CI tests fail when we automatically show the keyboard
+        // because it covers certain elements. So this code is
+        // commented out by default. Uncomment it to make your
+        // dev experience slightly better :)
+//        foragePinEditText.showKeyboard()
     }
 
     override fun onCreateView(


### PR DESCRIPTION
## What

- Added `showKeyboard` method to `ForageElement` interface
- Implemented `showKeyboard` method in `ForagePANEditText` and `ForagePINEditText`
- Updated `FlowBalanceFragment` and `FlowTokenizeFragment` to use `showKeyboard` method

## Why

- To provide a way to show the soft keyboard when needed explicitly

## Test Plan

- ❌ I've added unit tests for this change.
- ✅ The reviewer should manually test the changes in this PR.

## Demo
[Show Keyboard Demo.webm](https://github.com/teamforage/forage-android-sdk/assets/12377418/65f68891-839c-4e34-86ed-ca98c2aa38f5)

## How
~This PR is blocked until we hear back from BT about how to support the show-keyboard functionality with BT inputs. Otherwise the behavior will differ based on the backing vault.~
This PR can now be readily merged 🥳 