### PR TITLE
[FX-1383] Use `SecurePinCollector` to decouple PinSubmitters from `ForagePINEditText`

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/VaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/VaultWrapper.kt
@@ -10,7 +10,6 @@ import com.joinforage.forage.android.core.services.EnvConfig
 import com.joinforage.forage.android.core.services.VaultType
 import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.services.vault.AbstractVaultSubmitter
-import com.joinforage.forage.android.core.ui.element.ForagePinElement
 import com.joinforage.forage.android.core.ui.element.SimpleElementListener
 import com.joinforage.forage.android.core.ui.element.StatefulElementListener
 import com.joinforage.forage.android.core.ui.element.state.PinElementState
@@ -42,7 +41,6 @@ internal abstract class VaultWrapper @JvmOverloads constructor(
     abstract fun showKeyboard()
 
     abstract fun getVaultSubmitter(
-        foragePinElement: ForagePinElement,
         envConfig: EnvConfig,
         logger: Log
     ): AbstractVaultSubmitter

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/vault/bt/BasisTheoryPinSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/vault/bt/BasisTheoryPinSubmitter.kt
@@ -11,18 +11,19 @@ import com.joinforage.forage.android.core.services.forageapi.network.ForageApiRe
 import com.joinforage.forage.android.core.services.forageapi.paymentmethod.PaymentMethod
 import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.services.vault.AbstractVaultSubmitter
+import com.joinforage.forage.android.core.services.vault.SecurePinCollector
 import com.joinforage.forage.android.core.services.vault.VaultProxyRequest
 import com.joinforage.forage.android.core.services.vault.VaultSubmitterParams
-import com.joinforage.forage.android.core.ui.element.ForagePinElement
 
 internal typealias BasisTheoryResponse = Result<Any?>
 
 internal class BasisTheoryPinSubmitter(
-    foragePinEditText: ForagePinElement,
+    private val btTextElement: TextElement,
+    collector: SecurePinCollector,
     private val envConfig: EnvConfig,
     logger: Log
 ) : AbstractVaultSubmitter(
-    foragePinEditText = foragePinEditText,
+    collector = collector,
     logger = logger
 ) {
     override val vaultType: VaultType = VaultType.BT_VAULT_TYPE
@@ -51,7 +52,7 @@ internal class BasisTheoryPinSubmitter(
         val proxyRequest: ProxyRequest = ProxyRequest().apply {
             headers = vaultProxyRequest.headers
             body = ProxyRequestObject(
-                pin = foragePinEditText.getTextElement() as TextElement,
+                pin = btTextElement,
                 card_number_token = vaultProxyRequest.vaultToken
             )
             path = vaultProxyRequest.path

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/vault/vgs/VgsPinSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/vault/vgs/VgsPinSubmitter.kt
@@ -10,8 +10,8 @@ import com.joinforage.forage.android.core.services.forageapi.network.UnknownErro
 import com.joinforage.forage.android.core.services.forageapi.paymentmethod.PaymentMethod
 import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.services.vault.AbstractVaultSubmitter
+import com.joinforage.forage.android.core.services.vault.SecurePinCollector
 import com.joinforage.forage.android.core.services.vault.VaultProxyRequest
-import com.joinforage.forage.android.core.ui.element.ForagePinElement
 import com.verygoodsecurity.vgscollect.VGSCollectLogger
 import com.verygoodsecurity.vgscollect.core.HTTPMethod
 import com.verygoodsecurity.vgscollect.core.VGSCollect
@@ -23,23 +23,21 @@ import org.json.JSONException
 import kotlin.coroutines.suspendCoroutine
 
 internal class VgsPinSubmitter(
-    foragePinEditText: ForagePinElement,
+    private val vgsEditText: VGSEditText,
+    collector: SecurePinCollector,
     private val envConfig: EnvConfig,
     logger: Log
-) : AbstractVaultSubmitter(
-    foragePinEditText = foragePinEditText,
-    logger = logger
-) {
+) : AbstractVaultSubmitter(collector, logger) {
     override val vaultType: VaultType = VaultType.VGS_VAULT_TYPE
     override suspend fun submitProxyRequest(
         vaultProxyRequest: VaultProxyRequest
     ): ForageApiResponse<String> = suspendCoroutine { continuation ->
         VGSCollectLogger.isEnabled = false
         val vgsCollect = VGSCollect
-            .Builder(foragePinEditText.context, envConfig.vgsVaultId)
+            .Builder(vgsEditText.context, envConfig.vgsVaultId)
             .setEnvironment(envConfig.vgsVaultType)
             .create()
-        vgsCollect.bindView(foragePinEditText.getTextElement() as VGSEditText)
+        vgsCollect.bindView(vgsEditText)
 
         vgsCollect.addOnResponseListeners(object : VgsCollectResponseListener {
             override fun onResponse(response: VGSResponse?) {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/ForagePINEditText.kt
@@ -160,7 +160,6 @@ class ForagePINEditText @JvmOverloads constructor(
 
     internal fun getVaultSubmitter(logger: Log): AbstractVaultSubmitter =
         vault.getVaultSubmitter(
-            this,
             // ForageSDK is responsible for checking whether
             // the user has called .setForageConfig so here
             // we assume that forageConfig is non-null

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/bt/BTVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/bt/BTVaultWrapper.kt
@@ -14,8 +14,8 @@ import com.joinforage.forage.android.core.services.EnvConfig
 import com.joinforage.forage.android.core.services.VaultType
 import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.services.vault.AbstractVaultSubmitter
+import com.joinforage.forage.android.core.services.vault.SecurePinCollector
 import com.joinforage.forage.android.core.ui.VaultWrapper
-import com.joinforage.forage.android.core.ui.element.ForagePinElement
 import com.joinforage.forage.android.core.ui.element.state.PinElementStateManager
 import com.joinforage.forage.android.core.ui.getBoxCornerRadiusBottomEnd
 import com.joinforage.forage.android.core.ui.getBoxCornerRadiusBottomStart
@@ -113,11 +113,16 @@ internal class BTVaultWrapper @JvmOverloads constructor(
     }
 
     override fun getVaultSubmitter(
-        foragePinElement: ForagePinElement,
         envConfig: EnvConfig,
         logger: Log
     ): AbstractVaultSubmitter = BasisTheoryPinSubmitter(
-        foragePinElement,
+        _internalTextElement,
+        object : SecurePinCollector {
+            override fun clearText() {
+                clearText()
+            }
+            override fun isComplete(): Boolean = manager.isComplete
+        },
         envConfig,
         logger
     )

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/bt/BTVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/bt/BTVaultWrapper.kt
@@ -119,7 +119,7 @@ internal class BTVaultWrapper @JvmOverloads constructor(
         _internalTextElement,
         object : SecurePinCollector {
             override fun clearText() {
-                clearText()
+                this@BTVaultWrapper.clearText()
             }
             override fun isComplete(): Boolean = manager.isComplete
         },

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/vgs/VGSVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/vgs/VGSVaultWrapper.kt
@@ -139,7 +139,7 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
         _internalEditText,
         object : SecurePinCollector {
             override fun clearText() {
-                clearText()
+                this@VGSVaultWrapper.clearText()
             }
             override fun isComplete(): Boolean = manager.isComplete
         },

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/vgs/VGSVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/vgs/VGSVaultWrapper.kt
@@ -14,8 +14,8 @@ import com.joinforage.forage.android.core.services.ForageConstants
 import com.joinforage.forage.android.core.services.VaultType
 import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.services.vault.AbstractVaultSubmitter
+import com.joinforage.forage.android.core.services.vault.SecurePinCollector
 import com.joinforage.forage.android.core.ui.VaultWrapper
-import com.joinforage.forage.android.core.ui.element.ForagePinElement
 import com.joinforage.forage.android.core.ui.element.state.PinElementStateManager
 import com.joinforage.forage.android.core.ui.getBoxCornerRadiusBottomEnd
 import com.joinforage.forage.android.core.ui.getBoxCornerRadiusBottomStart
@@ -133,11 +133,16 @@ internal class VGSVaultWrapper @JvmOverloads constructor(
     override fun getTextElement(): VGSEditText = _internalEditText
 
     override fun getVaultSubmitter(
-        foragePinElement: ForagePinElement,
         envConfig: EnvConfig,
         logger: Log
     ): AbstractVaultSubmitter = VgsPinSubmitter(
-        foragePinElement,
+        _internalEditText,
+        object : SecurePinCollector {
+            override fun clearText() {
+                clearText()
+            }
+            override fun isComplete(): Boolean = manager.isComplete
+        },
         envConfig,
         logger
     )


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Introduce `SecurePinCollector` interface for passing backing-vault facilities to pin-submitter logic
<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
All of the pin submitter facilities are coupled to `ForagePINEditText`. That wasn't an issue before, but now we need the flexibility of passing non-EditText-based UI components to pin submitters to support the `ForagePinPad` in the Pos SDK.
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
- ❌ I did not add tests since these are view-layer changes with no logic branches
- ❌ No need to manually review as passing CI tests are sufficient<!-- If so, please describe how to test below. -->

## Demo
N/A since this just changes implementation details
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
This can be merged in once #254 is merged.
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
