### PR TITLE
Pass session-token to vault calls

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/Utils.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/Utils.kt
@@ -32,6 +32,7 @@ internal object ForageConstants {
         const val API_VERSION = "API-VERSION"
         const val BT_PROXY_KEY = "BT-PROXY-KEY"
         const val CONTENT_TYPE = "Content-Type"
+        const val SESSION_TOKEN = "Session-Token"
     }
 
     object RequestBody {

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/vault/AbstractVaultSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/vault/AbstractVaultSubmitter.kt
@@ -114,6 +114,7 @@ internal abstract class AbstractVaultSubmitter(
         .setHeader(ForageConstants.Headers.IDEMPOTENCY_KEY, params.idempotencyKey)
         .setHeader(ForageConstants.Headers.TRACE_ID, logger.getTraceIdValue())
         .setHeader(ForageConstants.Headers.API_VERSION, "default")
+        .setHeader(ForageConstants.Headers.SESSION_TOKEN, "${ForageConstants.Headers.BEARER} ${params.sessionToken}")
         .setToken(vaultToken)
 
     // PaymentMethod.card.token is in the comma-separated format <vgs-token>,<basis-theory-token>,<forage-token>


### PR DESCRIPTION
Pass Session-Token header through to vault calls

## Testing:
- Send balance check to vgs and bt, confirm that `Session-Token` header is attached as expected