### PR TITLE
[FX-1376] Fetch rosetta-traffic-percentage to determine vault provider

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/launchdarkly/LDManager.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/launchdarkly/LDManager.kt
@@ -22,10 +22,6 @@ internal object LDContextKind {
     const val SERVICE = "service"
 }
 
-// vault-primary-traffic-percentage
-internal val ALWAYS_BT_PERCENT = 100.0
-internal val ALWAYS_VGS_PERCENT = 0.0
-
 // rosetta-traffic-percentage
 internal val ALWAYS_ROSETTA_PERCENT = 100.0
 internal val ALWAYS_THIRD_PARTY_PERCENT = 0.0

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/launchdarkly/LDManager.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/launchdarkly/LDManager.kt
@@ -61,9 +61,9 @@ internal object LDManager {
             ALWAYS_ROSETTA_PERCENT
         ) ?: ALWAYS_ROSETTA_PERCENT
         logger.i("[LaunchDarkly] Rosetta percent of $rosettaPercent returned from LD")
-        val usingRosetta = shouldUseRosetta(rosettaPercent)
 
-        if (usingRosetta) return VaultType.FORAGE_VAULT_TYPE
+        // return early if we're using rosetta since we don't need to check the vault traffic percentage
+        if (shouldUseRosetta(rosettaPercent)) return VaultType.FORAGE_VAULT_TYPE
 
         val vaultPercent = client?.doubleVariation(
             LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG,

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/ForagePINEditText.kt
@@ -94,6 +94,8 @@ class ForagePINEditText @JvmOverloads constructor(
         return if (vaultType == VaultType.BT_VAULT_TYPE) {
             btVaultWrapper
         } else {
+            // TODO: Update this to the ForageVaultWrapper once it's back in this codebase
+            // https://linear.app/joinforage/issue/FX-1368/re-introduce-the-foragevaultwrapper-into-the-coreui-module-in-the
             vgsVaultWrapper
         }
     }

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
@@ -37,13 +37,13 @@ class LaunchDarklyTest() {
     }
 
     @Test
-    fun `Test computeVaultType returns BT percent is 100f`() {
-        assertThat(computeVaultType(ALWAYS_BT_PERCENT)).isEqualTo(VaultType.BT_VAULT_TYPE)
+    fun `Test computeVaultType returns Forage Vault if percent is 100f`() {
+        assertThat(computeVaultType(ALWAYS_ROSETTA_PERCENT)).isEqualTo(VaultType.FORAGE_VAULT_TYPE)
     }
 
     @Test
-    fun `Test computeVaultType returns VGS percent is 0f`() {
-        assertThat(computeVaultType(ALWAYS_VGS_PERCENT)).isEqualTo(VaultType.VGS_VAULT_TYPE)
+    fun `Test computeVaultType returns BT percent is 0f`() {
+        assertThat(computeVaultType(ALWAYS_THIRD_PARTY_PERCENT)).isEqualTo(VaultType.BT_VAULT_TYPE)
     }
 
     @Test
@@ -78,35 +78,9 @@ class LaunchDarklyTest() {
             )
         )
 
-        // it should default to BT
+        // it should use BT
         val post3PUpdate = LDManager.getVaultProvider()
         assertThat(post3PUpdate).isEqualTo(VaultType.BT_VAULT_TYPE)
-
-        // Set the test data to send all traffic to BT
-        td.update(
-            td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(
-                LDValue.of(
-                    ALWAYS_BT_PERCENT
-                )
-            )
-        )
-
-        // it should consume the flag and return BT
-        val postBTUpdate = LDManager.getVaultProvider()
-        assertThat(postBTUpdate).isEqualTo(VaultType.BT_VAULT_TYPE)
-
-        // Set the test data to send all traffic to VGS
-        td.update(
-            td.flag(LDFlags.VAULT_PRIMARY_TRAFFIC_PERCENTAGE_FLAG).variations(
-                LDValue.of(
-                    ALWAYS_VGS_PERCENT
-                )
-            )
-        )
-
-        // it should consume the flag and choose VGS
-        val postVgsUpdate = LDManager.getVaultProvider()
-        assertThat(postVgsUpdate).isEqualTo(VaultType.VGS_VAULT_TYPE)
     }
 
     @Test

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
@@ -3,10 +3,8 @@ package com.joinforage.forage.android.network.data
 import android.app.Application
 import androidx.test.platform.app.InstrumentationRegistry
 import com.joinforage.forage.android.core.services.VaultType
-import com.joinforage.forage.android.core.services.launchdarkly.ALWAYS_BT_PERCENT
 import com.joinforage.forage.android.core.services.launchdarkly.ALWAYS_ROSETTA_PERCENT
 import com.joinforage.forage.android.core.services.launchdarkly.ALWAYS_THIRD_PARTY_PERCENT
-import com.joinforage.forage.android.core.services.launchdarkly.ALWAYS_VGS_PERCENT
 import com.joinforage.forage.android.core.services.launchdarkly.LDFlags
 import com.joinforage.forage.android.core.services.launchdarkly.LDManager
 import com.joinforage.forage.android.core.services.launchdarkly.computeVaultType


### PR DESCRIPTION
## What
- Checks `rosetta-traffic-percentage` in LaunchDarkly to determine vault provider, only checking `vault-primary-traffic-percentage` if we aren't using rosetta based on the initial flag check.
- Changes the default third-party vault provider to be BT instead of VGS
- Updates tests to reflect new behavior

## Why
https://linear.app/joinforage/issue/FX-1376/fetch-rosetta-traffic-percentage-to-determine-whether-to-route-between

## Test Plan
- Added unit tests

## How
Can be merged as-is, as far as I know? 