### PR TITLE
[1461] Move `Forage*EditText`s to `ecom.ui.element`

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
@@ -19,7 +19,7 @@ import com.joinforage.forage.android.core.services.vault.DeferPaymentCaptureRepo
 import com.joinforage.forage.android.core.services.vault.TokenizeCardService
 import com.joinforage.forage.android.core.ui.element.ForageConfig
 import com.joinforage.forage.android.core.ui.element.ForagePanElement
-import com.joinforage.forage.android.ecom.ui.ForagePINEditText
+import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
 
 /**
  * The entry point to the Forage SDK.

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePANEditText.kt
@@ -1,4 +1,4 @@
-package com.joinforage.forage.android.ecom.ui
+package com.joinforage.forage.android.ecom.ui.element
 
 import android.content.Context
 import android.util.AttributeSet

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePINEditText.kt
@@ -1,4 +1,4 @@
-package com.joinforage.forage.android.ecom.ui
+package com.joinforage.forage.android.ecom.ui.element
 
 import android.app.Application
 import android.content.Context

--- a/forage-android/src/test/java/com/joinforage/forage/android/mock/MockServiceFactory.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/mock/MockServiceFactory.kt
@@ -15,7 +15,7 @@ import com.joinforage.forage.android.core.services.vault.DeferPaymentCaptureRepo
 import com.joinforage.forage.android.core.services.vault.TokenizeCardService
 import com.joinforage.forage.android.core.ui.element.state.pan.USState
 import com.joinforage.forage.android.ecom.services.ForageSDK
-import com.joinforage.forage.android.ecom.ui.ForagePINEditText
+import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
 import okhttp3.mockwebserver.MockWebServer
 
 internal class MockServiceFactory(

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/CapturePaymentRepositoryTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/CapturePaymentRepositoryTest.kt
@@ -5,7 +5,7 @@ import com.joinforage.forage.android.core.services.forageapi.network.ForageError
 import com.joinforage.forage.android.core.services.forageapi.payment.Payment
 import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.services.vault.CapturePaymentRepository
-import com.joinforage.forage.android.ecom.ui.ForagePINEditText
+import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
 import com.joinforage.forage.android.fixtures.givenContentId
 import com.joinforage.forage.android.fixtures.givenEncryptionKey
 import com.joinforage.forage.android.fixtures.givenPaymentMethodRef

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/CheckBalanceRepositoryTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/CheckBalanceRepositoryTest.kt
@@ -5,7 +5,7 @@ import com.joinforage.forage.android.core.services.forageapi.network.ForageError
 import com.joinforage.forage.android.core.services.forageapi.paymentmethod.EbtBalance
 import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.services.vault.CheckBalanceRepository
-import com.joinforage.forage.android.ecom.ui.ForagePINEditText
+import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
 import com.joinforage.forage.android.fixtures.givenContentId
 import com.joinforage.forage.android.fixtures.givenEncryptionKey
 import com.joinforage.forage.android.fixtures.givenPaymentMethodRef

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/DeferPaymentCaptureRepositoryTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/DeferPaymentCaptureRepositoryTest.kt
@@ -4,7 +4,7 @@ import com.joinforage.forage.android.core.services.forageapi.network.ForageApiRe
 import com.joinforage.forage.android.core.services.forageapi.network.ForageError
 import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.services.vault.DeferPaymentCaptureRepository
-import com.joinforage.forage.android.ecom.ui.ForagePINEditText
+import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
 import com.joinforage.forage.android.fixtures.givenEncryptionKey
 import com.joinforage.forage.android.fixtures.givenPaymentMethodRef
 import com.joinforage.forage.android.fixtures.givenPaymentRef

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
@@ -12,7 +12,7 @@ import androidx.navigation.fragment.findNavController
 import com.joinforage.android.example.databinding.FragmentFlowBalanceBinding
 import com.joinforage.android.example.ext.hideKeyboard
 import com.joinforage.forage.android.core.ui.element.ForageConfig
-import com.joinforage.forage.android.ecom.ui.ForagePINEditText
+import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceViewModel.kt
@@ -11,7 +11,7 @@ import com.joinforage.forage.android.core.services.forageapi.network.ForageApiRe
 import com.joinforage.forage.android.core.services.forageapi.paymentmethod.EbtBalance
 import com.joinforage.forage.android.ecom.services.CheckBalanceParams
 import com.joinforage.forage.android.ecom.services.ForageSDK
-import com.joinforage.forage.android.ecom.ui.ForagePINEditText
+import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/payment/capture/FlowCapturePaymentViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/payment/capture/FlowCapturePaymentViewModel.kt
@@ -11,7 +11,7 @@ import com.joinforage.forage.android.core.services.forageapi.network.ForageApiRe
 import com.joinforage.forage.android.ecom.services.CapturePaymentParams
 import com.joinforage.forage.android.ecom.services.DeferPaymentCaptureParams
 import com.joinforage.forage.android.ecom.services.ForageSDK
-import com.joinforage.forage.android.ecom.ui.ForagePINEditText
+import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeFragment.kt
@@ -12,7 +12,7 @@ import androidx.navigation.fragment.findNavController
 import com.joinforage.android.example.databinding.FragmentFlowTokenizeBinding
 import com.joinforage.android.example.ext.hideKeyboard
 import com.joinforage.forage.android.core.ui.element.ForageConfig
-import com.joinforage.forage.android.ecom.ui.ForagePANEditText
+import com.joinforage.forage.android.ecom.ui.element.ForagePANEditText
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeViewModel.kt
@@ -12,7 +12,7 @@ import com.joinforage.forage.android.core.services.forageapi.paymentmethod.EbtCa
 import com.joinforage.forage.android.core.services.forageapi.paymentmethod.PaymentMethod
 import com.joinforage.forage.android.ecom.services.ForageSDK
 import com.joinforage.forage.android.ecom.services.TokenizeEBTCardParams
-import com.joinforage.forage.android.ecom.ui.ForagePANEditText
+import com.joinforage.forage.android.ecom.ui.element.ForagePANEditText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/sample-app/src/main/res/layout/fragment_catalog.xml
+++ b/sample-app/src/main/res/layout/fragment_catalog.xml
@@ -24,7 +24,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-            <com.joinforage.forage.android.ecom.ui.ForagePANEditText
+            <com.joinforage.forage.android.ecom.ui.element.ForagePANEditText
                 android:id="@+id/firstForageEditText"
                 style="?attr/catalogFirstForagePanEditTextStyle"
                 android:layout_width="0dp"
@@ -36,7 +36,7 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintVertical_bias="0.0" />
 
-            <com.joinforage.forage.android.ecom.ui.ForagePANEditText
+            <com.joinforage.forage.android.ecom.ui.element.ForagePANEditText
                 android:id="@+id/secondEditText"
                 style="?catalogSecondForagePanEditTextStyle"
                 android:layout_width="0dp"
@@ -46,7 +46,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/firstForageEditText" />
 
-            <com.joinforage.forage.android.ecom.ui.ForagePANEditText
+            <com.joinforage.forage.android.ecom.ui.element.ForagePANEditText
                 android:id="@+id/thirdEditText"
                 style="?catalogThirdForagePanEditTextStyle"
                 android:layout_width="0dp"
@@ -56,7 +56,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/secondEditText" />
 
-            <com.joinforage.forage.android.ecom.ui.ForagePANEditText
+            <com.joinforage.forage.android.ecom.ui.element.ForagePANEditText
                 android:id="@+id/fourthEditText"
                 style="?catalogFourthForagePanEditTextStyle"
                 android:layout_width="200dp"
@@ -65,7 +65,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/thirdEditText" />
 
-            <com.joinforage.forage.android.ecom.ui.ForagePINEditText
+            <com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
                 android:id="@+id/foragePinEditText"
                 style="@style/ForagePINEditTextStyle"
                 android:layout_width="0dp"
@@ -76,7 +76,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/fourthEditText" />
 
-            <com.joinforage.forage.android.ecom.ui.ForagePINEditText
+            <com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
                 android:id="@+id/secondForagePINEditText"
                 style="@style/SecondForagePINEditTextStyle"
                 android:layout_width="0dp"
@@ -87,7 +87,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/foragePinEditText" />
 
-            <com.joinforage.forage.android.ecom.ui.ForagePINEditText
+            <com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
                 android:id="@+id/thirdForagePINEditText"
                 style="@style/ThirdForagePINEditTextStyle"
                 android:layout_width="80dp"

--- a/sample-app/src/main/res/layout/fragment_flow_balance.xml
+++ b/sample-app/src/main/res/layout/fragment_flow_balance.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".ui.complete.flow.balance.FlowBalanceFragment">
 
-    <com.joinforage.forage.android.ecom.ui.ForagePINEditText
+    <com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
         android:id="@+id/foragePinEditText"
         style="@style/ForagePINEditTextStyle"
         android:layout_width="0dp"

--- a/sample-app/src/main/res/layout/fragment_flow_capture_payment.xml
+++ b/sample-app/src/main/res/layout/fragment_flow_capture_payment.xml
@@ -17,7 +17,7 @@
             android:layout_marginTop="@dimen/activity_vertical_margin"
             tools:context=".ui.complete.flow.tokens.FlowTokensFragment">
 
-            <com.joinforage.forage.android.ecom.ui.ForagePINEditText
+            <com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
                 android:id="@+id/snapPinEditText"
                 style="@style/ForagePINEditTextStyle"
                 isVisible="@{viewModel.uiState.captureSnapVisible}"
@@ -74,7 +74,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintBottom_toTopOf="@id/cashPinEditText" />
 
-            <com.joinforage.forage.android.ecom.ui.ForagePINEditText
+            <com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
                 android:id="@+id/cashPinEditText"
                 style="@style/ForagePINEditTextStyle"
                 isVisible="@{viewModel.uiState.captureCashVisible}"

--- a/sample-app/src/main/res/layout/fragment_flow_tokenize.xml
+++ b/sample-app/src/main/res/layout/fragment_flow_tokenize.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".ui.tokenize.TokenizeFragment">
 
-    <com.joinforage.forage.android.ecom.ui.ForagePANEditText
+    <com.joinforage.forage.android.ecom.ui.element.ForagePANEditText
         android:id="@+id/tokenizeForagePanEditText"
         style="?tokenizeForagePANEditTextStyle"
         android:layout_width="0dp"

--- a/sample-app/src/main/res/layout/fragment_ui_components_pan.xml
+++ b/sample-app/src/main/res/layout/fragment_ui_components_pan.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.joinforage.forage.android.ecom.ui.ForagePANEditText
+    <com.joinforage.forage.android.ecom.ui.element.ForagePANEditText
         android:id="@+id/foragePanEditText"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/sample-app/src/main/res/layout/fragment_ui_components_pin.xml
+++ b/sample-app/src/main/res/layout/fragment_ui_components_pin.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.joinforage.forage.android.ecom.ui.ForagePINEditText
+    <com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
         android:id="@+id/foragePinEditText"
         android:layout_width="0dp"
         android:layout_height="wrap_content"


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Moves both `ForagePANEditText` and `ForagePINEditText`:
* from `ecom.ui.`
* to `ecom.ui.element`

<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
Keeps the semantics of the package structure sensical ("Elements live in `.elements`") and aligned with `.core`. Since these elements are public surface area, it is better to re-home them in a future-looking way now since it's a breaking change to do it later

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
- ❌ No but the test suite has been updated to reflect the new paths. <!-- If not, why? -->
- ❌ No need to manually review with the CI tests passing. <!-- If so, please describe how to test below. -->

## Demo
N/A as it's just an implementation change
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
Can be merged after #267 
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
