### PR TITLE
[FX-1462] Use shared OkHttpClient instance

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/forageapi/network/OkHttpClientBuilder.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/forageapi/network/OkHttpClientBuilder.kt
@@ -5,64 +5,71 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 
 internal object OkHttpClientBuilder {
+    // use a singleton OkHttpClient to share connection
+    // and thread pools across instances. However, we are
+    // able to customize the interceptors and headers for
+    // derived clients using the `.newBuilder()` pattern
+    // (see provideOkHttpClient implementation). The
+    // derived instances share the same resources but retrain
+    // distinct configurations. See this SO thread
+    // https://stackoverflow.com/questions/72348948/okhttp-newbuilder-per-request
+    private val singletonClient: OkHttpClient = OkHttpClient()
+
     fun provideOkHttpClient(
         sessionToken: String,
         merchantId: String? = null,
         idempotencyKey: String? = null,
         traceId: String? = null
-    ): OkHttpClient {
-        val okHttpClient = OkHttpClient().newBuilder()
-            .addInterceptor(
-                Interceptor { chain ->
-                    val request = chain.request()
-                        .newBuilder()
-                        .addHeader(
-                            ForageConstants.Headers.AUTHORIZATION,
-                            "${ForageConstants.Headers.BEARER} $sessionToken"
-                        )
-                        .run {
-                            // If the API_VERSION header has already been appended, don't override it!
-                            chain.request().headers[ForageConstants.Headers.API_VERSION]?.let {
-                                this
-                            }
-                                // Otherwise, set the default API_VERSION header
-                                ?: addHeader(
-                                    ForageConstants.Headers.API_VERSION,
-                                    "default"
-                                )
+    ): OkHttpClient = singletonClient.newBuilder()
+        .addInterceptor(
+            Interceptor { chain ->
+                val request = chain.request()
+                    .newBuilder()
+                    .addHeader(
+                        ForageConstants.Headers.AUTHORIZATION,
+                        "${ForageConstants.Headers.BEARER} $sessionToken"
+                    )
+                    .run {
+                        // If the API_VERSION header has already been appended, don't override it!
+                        chain.request().headers[ForageConstants.Headers.API_VERSION]?.let {
+                            this
                         }
-                        .run {
-                            merchantId?.let {
-                                addHeader(
-                                    ForageConstants.Headers.MERCHANT_ACCOUNT,
-                                    merchantId
-                                )
-                            }
-                                ?: this
+                            // Otherwise, set the default API_VERSION header
+                            ?: addHeader(
+                                ForageConstants.Headers.API_VERSION,
+                                "default"
+                            )
+                    }
+                    .run {
+                        merchantId?.let {
+                            addHeader(
+                                ForageConstants.Headers.MERCHANT_ACCOUNT,
+                                merchantId
+                            )
                         }
-                        .run {
-                            idempotencyKey?.let {
-                                addHeader(
-                                    ForageConstants.Headers.IDEMPOTENCY_KEY,
-                                    idempotencyKey
-                                )
-                            }
-                                ?: this
+                            ?: this
+                    }
+                    .run {
+                        idempotencyKey?.let {
+                            addHeader(
+                                ForageConstants.Headers.IDEMPOTENCY_KEY,
+                                idempotencyKey
+                            )
                         }
-                        .run {
-                            traceId?.let {
-                                addHeader(
-                                    ForageConstants.Headers.TRACE_ID,
-                                    traceId
-                                )
-                            }
-                                ?: this
+                            ?: this
+                    }
+                    .run {
+                        traceId?.let {
+                            addHeader(
+                                ForageConstants.Headers.TRACE_ID,
+                                traceId
+                            )
                         }
-                        .build()
+                            ?: this
+                    }
+                    .build()
 
-                    chain.proceed(request)
-                }
-            ).build()
-        return okHttpClient
-    }
+                chain.proceed(request)
+            }
+        ).build()
 }


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What (and Why)
We need the ability to modify the several request headers on
a per request basis using an `OkHttpClient` instance.

The previous usage of `OkHttpClient().newBuilder()` had the
effect of creating a new `OkHttpClient` instance with distinct
thread and connection pool resources for each `OkHttpClient`
instance created. This caused some concern about excessive
resource consumption.

Originally, we were considering shutting down each
`okHttpClient` instance manually after using it. However,
there were thread complications because shutting down an
`okHttpClient` requires dispatching a separate thread but
we also do some view manipulation when we clear the PIN
field and Android doesn't allow view manipulation across
threads.

But then, after further examining [the OkHttpClient docs](https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.html#:~:text=Customize%20your%20client%20with%20newBuilder()), it became clear that we could get our desired behavior by using the `.newBuilder()` method.

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Why
See above

## Test Plan
- ❌ No unit tests added / modified since this change has no business logic
- ❌ No manual review is necessary. Passing CI tests should be sufficient <!-- If so, please describe how to test below. -->

## Demo
N/A since it's just implementation details
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
Can be rolled out whenever 
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
