### PR TITLE
[FX-1463] Add types to `ForagePINEditText` custom styles

### DIFF
--- a/forage-android/src/main/res/values/attrs.xml
+++ b/forage-android/src/main/res/values/attrs.xml
@@ -29,10 +29,10 @@
         <!-- Style attribute for the TextInputLayout  -->
         <attr name="pinInputLayoutStyle" format="reference" />
 
-        <attr name="hint" format="string"/>
-        <attr name="text" format="string"/>
-        <attr name="textSize" format="dimension"/>
-        <attr name="textColor" format="color"/>
+        <attr name="hint" format="string" />
+        <attr name="text" format="string" />
+        <attr name="textSize" format="dimension" />
+        <attr name="textColor" format="color" />
         <attr format="color" name="pinBoxStrokeColor" />
         <attr name="boxBackgroundColor" format="color" />
         <attr name="hintTextColor" format="color" />

--- a/forage-android/src/main/res/values/attrs.xml
+++ b/forage-android/src/main/res/values/attrs.xml
@@ -4,7 +4,7 @@
     <!-- Theme attribute for the default style for the ForagePanEditText component. -->
     <attr name="foragePanEditTextStyle" format="reference" />
 
-    <!-- Style attributes for the ForagePanEditText component. -->
+    <!-- Style attributes for the ForagePANEditText component. -->
     <declare-styleable name="ForagePANEditText">
         <!-- Style attribute for the TextInputLayout  -->
         <attr name="textInputLayoutStyle" format="reference" />
@@ -24,15 +24,15 @@
         <attr format="dimension" name="panBoxStrokeWidthFocused" />
     </declare-styleable>
 
-    <!-- Style attributes for the ForagePanEditText component. -->
+    <!-- Style attributes for the ForagePINEditText component. -->
     <declare-styleable name="ForagePINEditText">
         <!-- Style attribute for the TextInputLayout  -->
         <attr name="pinInputLayoutStyle" format="reference" />
 
-        <attr name="hint" />
-        <attr name="text" />
-        <attr name="textSize" />
-        <attr name="textColor" />
+        <attr name="hint" format="string"/>
+        <attr name="text" format="string"/>
+        <attr name="textSize" format="dimension"/>
+        <attr name="textColor" format="color"/>
         <attr format="color" name="pinBoxStrokeColor" />
         <attr name="boxBackgroundColor" format="color" />
         <attr name="hintTextColor" format="color" />


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Adds missing types to `<attr />`s on the `ForagePINEditText`'s `<declare-styleable>.

<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
Overcommunicate to SDK users the intended type of these `<attr />`.
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
- ❌ I've added unit tests for this change. <!-- If not, why? -->
- ❌ Manual testing is unnecessary since these changes do not affect runtime; they are largely just for documentation. <!-- If so, please describe how to test below. -->

## Demo
N/A These changes don't have an affect on runtime so nothing to demo
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
Can be rolled out immediately 
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
