### PR TITLE
[FX-1459] Move EditText methods to `EditTextElement` interface

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForageElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForageElement.kt
@@ -80,41 +80,6 @@ internal interface EditTextElement {
      * @param l The [SimpleElementListener] to be fired on blur events.
      */
     fun setOnBlurEventListener(l: SimpleElementListener)
-}
-
-/**
- * The interface that defines methods for configuring and interacting with a [ForageElement].
- * A ForageElement is a secure, client-side entity that accepts and submits customer input for a
- * transaction.
- * Both [ForagePANEditText] and [ForagePINEditText] adhere to the [ForageElement] interface.
- *
- * @property typeface The [Typeface](https://developer.android.com/reference/android/graphics/Typeface)
- * that is used to render text within the ForageElement.
- * @see * [Online-only Android Quickstart](https://docs.joinforage.app/docs/forage-android-quickstart)
- * * [POS Terminal Android Quickstart](https://docs.joinforage.app/docs/forage-terminal-android)
- * * [Guide to styling Forage Android Elements](https://docs.joinforage.app/docs/forage-android-styling-guide)
- */
-internal interface ForageElement<T : ElementState> {
-    var typeface: Typeface?
-
-    /**
-     * Clears the text input field of the ForageElement.
-     */
-    fun clearText()
-
-    /**
-     * Sets the text color for the ForageElement.
-     *
-     * @param textColor The color value in the form `0xAARRGGBB`.
-     */
-    fun setTextColor(textColor: Int)
-
-    /**
-     * Sets the text size for the ForageElement.
-     *
-     * @param textSize The scaled pixel size.
-     */
-    fun setTextSize(textSize: Float)
 
     /**
      * Sets the text to be displayed when the ForageElement input field is empty.
@@ -150,6 +115,41 @@ internal interface ForageElement<T : ElementState> {
      * @param boxStrokeWidth The scaled pixel size.
      */
     fun setBoxStrokeWidthFocused(boxStrokeWidth: Int)
+}
+
+/**
+ * The interface that defines methods for configuring and interacting with a [ForageElement].
+ * A ForageElement is a secure, client-side entity that accepts and submits customer input for a
+ * transaction.
+ * Both [ForagePANEditText] and [ForagePINEditText] adhere to the [ForageElement] interface.
+ *
+ * @property typeface The [Typeface](https://developer.android.com/reference/android/graphics/Typeface)
+ * that is used to render text within the ForageElement.
+ * @see * [Online-only Android Quickstart](https://docs.joinforage.app/docs/forage-android-quickstart)
+ * * [POS Terminal Android Quickstart](https://docs.joinforage.app/docs/forage-terminal-android)
+ * * [Guide to styling Forage Android Elements](https://docs.joinforage.app/docs/forage-android-styling-guide)
+ */
+internal interface ForageElement<T : ElementState> {
+    var typeface: Typeface?
+
+    /**
+     * Clears the text input field of the ForageElement.
+     */
+    fun clearText()
+
+    /**
+     * Sets the text color for the ForageElement.
+     *
+     * @param textColor The color value in the form `0xAARRGGBB`.
+     */
+    fun setTextColor(textColor: Int)
+
+    /**
+     * Sets the text size for the ForageElement.
+     *
+     * @param textSize The scaled pixel size.
+     */
+    fun setTextSize(textSize: Float)
 
     /**
      * Gets the current [ElementState] state of the ForageElement.


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Move EditText-specific methods out of `ForageElment` interface and into `EditTextElement` interface.
<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
Leaving these methods on the `ForageElement` would force the Pos SDK's non-EditText-based UI components to implement these methods, which makes no sense. Methods that make sense for EditText UI components should live on the EditText-specific interface and not on the base ForageElement interface that even non-EditText UI components implement.
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
- ❌ No unit tests are necessary here
- ❌ Nothing runtime-related changed manually testing is unnecessary. <!-- If so, please describe how to test below. -->

## Demo
N/A as this is just implementation
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
Can be merged after #265 is merged
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
