### PR TITLE
Move ForageConfig to core.services

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/EnvConfig.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/EnvConfig.kt
@@ -1,7 +1,6 @@
 package com.joinforage.forage.android.core.services
 
 import com.joinforage.forage.android.BuildConfig
-import com.joinforage.forage.android.core.ui.element.ForageConfig
 
 internal enum class EnvOption(val value: String) {
     LOCAL("local"),

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/ForageConfig.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/ForageConfig.kt
@@ -1,0 +1,26 @@
+package com.joinforage.forage.android.core.services
+
+/**
+ * The configuration details that Forage needs to create a functional [ForageElement].
+ *
+ * Pass a [ForageConfig] instance in a call to
+ * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] to
+ * configure an Element.
+ *
+ * @property merchantId A unique Merchant ID that Forage provides during onboarding
+ * onboarding preceded by "mid/". For example, `mid/123ab45c67`.
+ * The Merchant ID can be found in the Forage [Sandbox](https://dashboard.sandbox.joinforage.app/login/)
+ * or [Production](https://dashboard.joinforage.app/login/) Dashboard.
+ *
+ * @property sessionToken A short-lived token that authenticates front-end requests to Forage.
+ * To create one, send a server-side `POST` request from your backend to the
+ * [`/session_token/`](https://docs.joinforage.app/reference/create-session-token) endpoint.
+ *
+ * @constructor Creates an instance of the [ForageConfig] data class.
+ */
+data class ForageConfig(
+    val merchantId: String,
+    val sessionToken: String
+) {
+    internal val envConfig = EnvConfig.fromForageConfig(this)
+}

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/telemetry/Log.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/telemetry/Log.kt
@@ -8,7 +8,7 @@ import com.joinforage.datadog.android.log.Logs
 import com.joinforage.datadog.android.log.LogsConfiguration
 import com.joinforage.datadog.android.privacy.TrackingConsent
 import com.joinforage.forage.android.core.services.EnvConfig
-import com.joinforage.forage.android.core.ui.element.ForageConfig
+import com.joinforage.forage.android.core.services.ForageConfig
 import kotlin.random.Random
 
 internal interface Log {

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForageConfigManager.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForageConfigManager.kt
@@ -1,5 +1,7 @@
 package com.joinforage.forage.android.core.ui.element
 
+import com.joinforage.forage.android.core.services.ForageConfig
+
 internal class ForageConfigManager(
     // designated method that subclass can run all the
     // side-effect things exactly once the first time

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForageElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForageElement.kt
@@ -1,33 +1,8 @@
 package com.joinforage.forage.android.core.ui.element
 
 import android.graphics.Typeface
-import com.joinforage.forage.android.core.services.EnvConfig
+import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.core.ui.element.state.ElementState
-
-/**
- * The configuration details that Forage needs to create a functional [ForageElement].
- *
- * Pass a [ForageConfig] instance in a call to
- * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] to
- * configure an Element.
- *
- * @property merchantId A unique Merchant ID that Forage provides during onboarding
- * onboarding preceded by "mid/". For example, `mid/123ab45c67`.
- * The Merchant ID can be found in the Forage [Sandbox](https://dashboard.sandbox.joinforage.app/login/)
- * or [Production](https://dashboard.joinforage.app/login/) Dashboard.
- *
- * @property sessionToken A short-lived token that authenticates front-end requests to Forage.
- * To create one, send a server-side `POST` request from your backend to the
- * [`/session_token/`](https://docs.joinforage.app/reference/create-session-token) endpoint.
- *
- * @constructor Creates an instance of the [ForageConfig] data class.
- */
-data class ForageConfig(
-    val merchantId: String,
-    val sessionToken: String
-) {
-    internal val envConfig = EnvConfig.fromForageConfig(this)
-}
 
 internal interface DynamicEnvElement {
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePanElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePanElement.kt
@@ -14,6 +14,7 @@ import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.joinforage.forage.android.R
 import com.joinforage.forage.android.core.services.EnvConfig
+import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.core.services.ForageConfigNotSetException
 import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.ui.element.state.FocusState

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
@@ -1,6 +1,7 @@
 package com.joinforage.forage.android.ecom.services
 
 import com.joinforage.forage.android.core.services.EnvConfig
+import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.core.services.ForageConfigNotSetException
 import com.joinforage.forage.android.core.services.forageapi.encryptkey.EncryptionKeyService
 import com.joinforage.forage.android.core.services.forageapi.network.ForageApiResponse
@@ -17,7 +18,6 @@ import com.joinforage.forage.android.core.services.vault.CapturePaymentRepositor
 import com.joinforage.forage.android.core.services.vault.CheckBalanceRepository
 import com.joinforage.forage.android.core.services.vault.DeferPaymentCaptureRepository
 import com.joinforage.forage.android.core.services.vault.TokenizeCardService
-import com.joinforage.forage.android.core.ui.element.ForageConfig
 import com.joinforage.forage.android.core.ui.element.ForagePanElement
 import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePINEditText.kt
@@ -6,6 +6,7 @@ import android.graphics.Typeface
 import android.util.AttributeSet
 import com.joinforage.forage.android.R
 import com.joinforage.forage.android.core.services.EnvConfig
+import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.core.services.ForageConfigNotSetException
 import com.joinforage.forage.android.core.services.VaultType
 import com.joinforage.forage.android.core.services.launchdarkly.LDManager
@@ -13,7 +14,6 @@ import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.services.vault.AbstractVaultSubmitter
 import com.joinforage.forage.android.core.ui.VaultWrapper
 import com.joinforage.forage.android.core.ui.element.DynamicEnvElement
-import com.joinforage.forage.android.core.ui.element.ForageConfig
 import com.joinforage.forage.android.core.ui.element.ForageConfigManager
 import com.joinforage.forage.android.core.ui.element.ForagePinElement
 import com.joinforage.forage.android.core.ui.getLogoImageViewLayout

--- a/forage-android/src/test/java/com/joinforage/forage/android/core/env/EnvConfigTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/core/env/EnvConfigTest.kt
@@ -1,7 +1,7 @@
 package com.joinforage.forage.android.core.env
 
 import com.joinforage.forage.android.core.services.EnvConfig
-import com.joinforage.forage.android.core.ui.element.ForageConfig
+import com.joinforage.forage.android.core.services.ForageConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 

--- a/forage-android/src/test/java/com/joinforage/forage/android/mock/MockLogger.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/mock/MockLogger.kt
@@ -1,8 +1,8 @@
 package com.joinforage.forage.android.mock
 
 import android.content.Context
+import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.core.services.telemetry.Log
-import com.joinforage.forage.android.core.ui.element.ForageConfig
 
 internal class LogEntry(message: String, attributes: Map<String, Any?>) {
     private var message = ""

--- a/forage-android/src/test/java/com/joinforage/forage/android/ui/ForageConfigManagerTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/ui/ForageConfigManagerTest.kt
@@ -1,6 +1,6 @@
 package com.joinforage.forage.android.ui
 
-import com.joinforage.forage.android.core.ui.element.ForageConfig
+import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.core.ui.element.ForageConfigManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/catalog/CatalogFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/catalog/CatalogFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.joinforage.android.example.databinding.FragmentCatalogBinding
-import com.joinforage.forage.android.core.ui.element.ForageConfig
+import com.joinforage.forage.android.core.services.ForageConfig
 
 class CatalogFragment : Fragment() {
 

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
@@ -11,7 +11,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.joinforage.android.example.databinding.FragmentFlowBalanceBinding
 import com.joinforage.android.example.ext.hideKeyboard
-import com.joinforage.forage.android.core.ui.element.ForageConfig
+import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/payment/capture/FlowCapturePaymentFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/payment/capture/FlowCapturePaymentFragment.kt
@@ -7,7 +7,7 @@ import com.joinforage.android.example.R
 import com.joinforage.android.example.databinding.FragmentFlowCapturePaymentBinding
 import com.joinforage.android.example.ext.hideKeyboard
 import com.joinforage.android.example.ui.base.BaseFragment
-import com.joinforage.forage.android.core.ui.element.ForageConfig
+import com.joinforage.forage.android.core.services.ForageConfig
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeFragment.kt
@@ -11,7 +11,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.joinforage.android.example.databinding.FragmentFlowTokenizeBinding
 import com.joinforage.android.example.ext.hideKeyboard
-import com.joinforage.forage.android.core.ui.element.ForageConfig
+import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.ecom.ui.element.ForagePANEditText
 import dagger.hilt.android.AndroidEntryPoint
 


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Moves `ForageConfig`:
* from: `core.ui.element.ForageConfig`
* to: `core.services.ForageConfig`
<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
`ForageConfig`,  while consumed by UI components, is a standalone data structure making the `core.services` package a more appropriate home. This also aligns with the Pos SDK because the `ForageTerminalSDK`, a service, also consumes the `ForageConfig`. The philosophy here is:

_UI may depend on services but services should never depend on UI else those services ought to live in the`.ui` package!!_
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
- ✅ Test suites have been updated to reflect the new `ForageConfig` home.
<!-- If not, why? -->
- ❌ There is no need to manually test these changes with passing CI. <!-- If so, please describe how to test below. -->

## Demo
N/A just changes implementation details
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
Can be rolled out after #262
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
