### PR TITLE
[FX-1508] Deprecate PIN hint and hint color customization

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePinElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePinElement.kt
@@ -111,12 +111,6 @@ abstract class ForagePinElement @JvmOverloads constructor(
         vault.setTextSize(textSize)
     }
 
-    override fun setHint(hint: String) {
-        vault.setHint(hint)
-    }
-    override fun setHintTextColor(hintTextColor: Int) {
-        vault.setHintTextColor(hintTextColor)
-    }
     override fun setBoxStrokeColor(boxStrokeColor: Int) {
         // no-ops for now
     }
@@ -125,5 +119,23 @@ abstract class ForagePinElement @JvmOverloads constructor(
     }
     override fun setBoxStrokeWidthFocused(boxStrokeWidth: Int) {
         // no-ops for now
+    }
+
+    @Deprecated(
+        message = "setHint (for *PIN* elements) is deprecated.",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith("")
+    )
+    override fun setHint(hint: String) {
+        // no-op, deprecated!
+    }
+
+    @Deprecated(
+        message = "setHintTextColor (for *PIN* elements) is deprecated.",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith("")
+    )
+    override fun setHintTextColor(hintTextColor: Int) {
+        // no-op, deprecated!
     }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/bt/BTVaultWrapper.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/bt/BTVaultWrapper.kt
@@ -156,11 +156,19 @@ internal class BTVaultWrapper @JvmOverloads constructor(
         _internalTextElement.textSize = textSize
     }
 
+    @Deprecated(
+        message = "setHint (for *PIN* elements) is deprecated and will be removed in a future major release.",
+        level = DeprecationLevel.WARNING
+    )
     override fun setHint(hint: String) {
-        _internalTextElement.hint = hint
+        // no-op, deprecated!
     }
 
+    @Deprecated(
+        message = "setHintTextColor (for *PIN* elements) is deprecated and will be removed in a future major release.",
+        level = DeprecationLevel.WARNING
+    )
     override fun setHintTextColor(hintTextColor: Int) {
-        _internalTextElement.hintTextColor = hintTextColor
+        // no-op, deprecated!
     }
 }

--- a/forage-android/src/main/res/values/attrs.xml
+++ b/forage-android/src/main/res/values/attrs.xml
@@ -29,13 +29,13 @@
         <!-- Style attribute for the TextInputLayout  -->
         <attr name="pinInputLayoutStyle" format="reference" />
 
-        <attr name="hint" format="string" />
         <attr name="text" format="string" />
         <attr name="textSize" format="dimension" />
         <attr name="textColor" format="color" />
         <attr format="color" name="pinBoxStrokeColor" />
         <attr name="boxBackgroundColor" format="color" />
-        <attr name="hintTextColor" format="color" />
+
+
         <attr format="dimension" name="boxCornerRadiusTopEnd" />
 
         <attr format="dimension" name="boxCornerRadiusTopStart" />
@@ -50,5 +50,10 @@
 
         <attr format="dimension" name="elementHeight" />
         <attr format="dimension" name="elementWidth" />
+
+        <!-- {@deprecated hint customization for ForagePINEditText elements is no longer supported} -->
+        <attr name="hint" format="string" />
+        <!-- {@deprecated hintTextColor customization for ForagePINEditText elements is no longer supported} -->
+        <attr name="hintTextColor" format="color" />
     </declare-styleable>
 </resources>

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
@@ -80,6 +80,7 @@ class FlowBalanceFragment : Fragment() {
             isValid.text = "isValid: ${state.isValid}"
         }
 
+        foragePinEditText.setHint("I AM A HINT!")
         foragePinEditText.setOnFocusEventListener { setState() }
         foragePinEditText.setOnBlurEventListener { setState() }
         foragePinEditText.setOnChangeEventListener { setState() }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceFragment.kt
@@ -80,7 +80,6 @@ class FlowBalanceFragment : Fragment() {
             isValid.text = "isValid: ${state.isValid}"
         }
 
-        foragePinEditText.setHint("I AM A HINT!")
         foragePinEditText.setOnFocusEventListener { setState() }
         foragePinEditText.setOnBlurEventListener { setState() }
         foragePinEditText.setOnChangeEventListener { setState() }

--- a/sample-app/src/main/res/values/styles.xml
+++ b/sample-app/src/main/res/values/styles.xml
@@ -88,19 +88,15 @@
         <item name="android:layout_marginEnd">@dimen/pin_field_margin</item>
         <item name="android:layout_marginTop">@dimen/pin_field_margin</item>
         <item name="android:layout_marginBottom">@dimen/pin_field_margin</item>
-        <item name="hint">@string/pin</item>
         <item name="textSize">@dimen/pin_text_size</item>
         <item name="pinBoxStrokeColor">@color/purple_700</item>
-        <item name="hintTextColor">@color/purple_700</item>
         <item name="boxCornerRadius">@dimen/corner_radius</item>
     </style>
 
     <style name="SecondForagePINEditTextStyle" parent="">
         <item name="android:layout_margin">@dimen/pin_field_margin</item>
-        <item name="hint">@string/pin</item>
         <item name="textSize">@dimen/pin_text_size</item>
         <item name="pinBoxStrokeColor">@color/purple_200</item>
-        <item name="hintTextColor">@color/purple_200</item>
         <item name="boxCornerRadiusTopStart">@dimen/box_corner_radius_top_start</item>
         <item name="boxCornerRadiusTopEnd">@dimen/box_corner_radius_top_end</item>
         <item name="boxCornerRadiusBottomStart">@dimen/box_corner_radius_bottom_start</item>
@@ -114,10 +110,8 @@
 
     <style name="ThirdForagePINEditTextStyle" parent="">
         <item name="android:layout_margin">@dimen/pin_field_margin</item>
-        <item name="hint">@string/pin</item>
         <item name="textSize">@dimen/pin_text_size</item>
         <item name="pinBoxStrokeColor">@color/colorAccent</item>
-        <item name="hintTextColor">@color/colorAccent</item>
         <item name="boxCornerRadius">@dimen/corner_radius</item>
     </style>
 


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

- [x] Deprecate hint and hint color customization for only *PIN* elements
- [x] Make `setHint` and `setHintTextColor` no-ops

<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why

- https://joinforage.slack.com/archives/C056QGRF6S3/p1712687133981029?thread_ts=1712680102.191409&cid=C056QGRF6S3

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- ✅ See demo below
- ✅  Can still call `setHint` and `setHintTextColor` (no code change needed), but it will be no-op and show a warning message.

## Demo

![image](https://github.com/teamforage/forage-android-sdk/assets/32694765/f7e11e11-4b9d-4aa7-92e8-ef04bb357c4d)

![image](https://github.com/teamforage/forage-android-sdk/assets/32694765/ee58742a-42f8-4f4b-806c-53f52dfa31a2)

![image](https://github.com/teamforage/forage-android-sdk/assets/32694765/f7a5549d-2554-4d35-8cc0-0d793db23d98)


<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How

<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->

Successor of https://github.com/teamforage/forage-android-sdk/pull/244