### PR TITLE
[FX-1514] v4.0.0 final touches - fix Kdoc comments and make internal code internal

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/ForageConfig.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/ForageConfig.kt
@@ -1,10 +1,10 @@
 package com.joinforage.forage.android.core.services
 
 /**
- * The configuration details that Forage needs to create a functional [ForageElement].
+ * The configuration details that Forage needs to create a functional [ForageElement][com.joinforage.forage.android.core.ui.element.ForageElement].
  *
  * Pass a [ForageConfig] instance in a call to
- * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] to
+ * [setForageConfig][com.joinforage.forage.android.core.ui.element.ForagePanElement.setForageConfig] to
  * configure an Element.
  *
  * @property merchantId A unique Merchant ID that Forage provides during onboarding

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/ForageConfigNotSetException.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/ForageConfigNotSetException.kt
@@ -2,8 +2,8 @@ package com.joinforage.forage.android.core.services
 
 /**
  * An [Exception](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-exception/) thrown if a
- * reference to a [ForageElement][com.joinforage.forage.android.ui.ForageElement] is passed to a
- * method before [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig]
+ * reference to a [ForageElement][com.joinforage.forage.android.core.ui.element.ForageElement] is passed to a
+ * method before [setForageConfig][com.joinforage.forage.android.core.ui.element.ForagePanElement.setForageConfig]
  * is called on the Element.
  * @property message A string that describes the Exception.
  */

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ElementValidationErrors.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ElementValidationErrors.kt
@@ -25,19 +25,6 @@ val InvalidEbtPanError = ElementValidationError(
     detail = "Your EBT card number is invalid."
 )
 
-/**
- * **Deprecated** - This error will be removed in a future release.
- * A type of [ElementValidationError] that occurs when a customer submits an EBT Card number that
- * is too long. In theory, this error should never occur.
- */
-val TooLongEbtPanError = ElementValidationError(
-    // in theory the view layer should prevent this
-    // validation state from occurring by dynamically restricting
-    // the input length based on the IIN.
-    // We include this for completeness
-    detail = "Your EBT card number is too long."
-)
-
 // PIN Input Errors
 /**
  * A type of [ElementValidationError] that occurs when a customer submits an incomplete

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForageElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForageElement.kt
@@ -7,25 +7,20 @@ import com.joinforage.forage.android.core.ui.element.state.ElementState
 internal interface DynamicEnvElement {
 
     /**
-     * ⚠️ **The [setForageConfig] method is only valid for online-only transactions.** Use [setPosForageConfig]
-     * for in-store POS Terminal transactions.
-     *
      * Sets the necessary [ForageConfig] configuration properties for a ForageElement.
      * **[setForageConfig] must be called before any other methods can be executed on the Element.**
      * ```kotlin
      * // Example: Call setForageConfig on a ForagePANEditText Element
-     * val onlineOnlyForagePanEditText = root?.findViewById<ForagePANEditText>(
+     * val foragePanEditText = root?.findViewById<ForagePANEditText>(
      *     R.id.tokenizeForagePanEditText
      * )
-     * onlineOnlyForagePanEditText.setForageConfig(
+     * foragePanEditText.setForageConfig(
      *     ForageConfig(
      *         merchantId = "mid/<merchant_id>",
      *         sessionToken = "<session_token>"
      *     )
      * )
      * ```
-     * @see * [Online-only Android Quickstart](https://docs.joinforage.app/docs/forage-android-quickstart)
-     * * [setPosForageConfig] for the equivalent Terminal SDK method.
      *
      * @param forageConfig A [ForageConfig] instance that specifies a `merchantId` and `sessionToken`.
      */
@@ -96,7 +91,8 @@ internal interface EditTextElement {
  * The interface that defines methods for configuring and interacting with a [ForageElement].
  * A ForageElement is a secure, client-side entity that accepts and submits customer input for a
  * transaction.
- * Both [ForagePANEditText] and [ForagePINEditText] adhere to the [ForageElement] interface.
+ * Both [ForagePanElement][com.joinforage.forage.android.core.ui.element.ForagePanElement] and
+ * [ForagePinElement][com.joinforage.forage.android.core.ui.element.ForagePinElement] adhere to the [ForageElement] interface.
  *
  * @property typeface The [Typeface](https://developer.android.com/reference/android/graphics/Typeface)
  * that is used to render text within the ForageElement.
@@ -104,7 +100,7 @@ internal interface EditTextElement {
  * * [POS Terminal Android Quickstart](https://docs.joinforage.app/docs/forage-terminal-android)
  * * [Guide to styling Forage Android Elements](https://docs.joinforage.app/docs/forage-android-styling-guide)
  */
-internal interface ForageElement<T : ElementState> {
+interface ForageElement<T : ElementState> {
     var typeface: Typeface?
 
     /**

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePanElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePanElement.kt
@@ -193,6 +193,25 @@ abstract class ForagePanElement @JvmOverloads constructor(
             forageConfig ->
         initWithForageConfig(forageConfig)
     }
+
+    /**
+     * Sets the necessary [ForageConfig] configuration properties for a ForageElement.
+     * **[setForageConfig] must be called before any other methods can be executed on the Element.**
+     * ```kotlin
+     * // Example: Call setForageConfig on a ForagePANEditText Element
+     * val foragePanEditText = root?.findViewById<ForagePANEditText>(
+     *     R.id.tokenizeForagePanEditText
+     * )
+     * foragePanEditText.setForageConfig(
+     *     ForageConfig(
+     *         merchantId = "mid/<merchant_id>",
+     *         sessionToken = "<session_token>"
+     *     )
+     * )
+     * ```
+     *
+     * @param forageConfig A [ForageConfig] instance that specifies a `merchantId` and `sessionToken`.
+     */
     override fun setForageConfig(forageConfig: ForageConfig) {
         forageConfigManager.forageConfig = forageConfig
     }

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePinElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePinElement.kt
@@ -12,13 +12,13 @@ import com.joinforage.forage.android.core.ui.VaultWrapper
 import com.joinforage.forage.android.core.ui.element.state.pin.PinEditTextState
 
 /**
- * A [ForageElement] that securely collects a card PIN. You need a [ForagePINEditText] to call
+ * A [ForageElement] that securely collects a card PIN. You need a [ForagePinElement] to call
  * the ForageSDK online-only or ForageTerminalSDK POS methods that:
- * * [Check a card's balance][com.joinforage.forage.android.ForageSDK.checkBalance]
- * * [Collect a card PIN to defer payment capture to the server][com.joinforage.forage.android.ForageSDK.deferPaymentCapture]
- * * [Capture a payment immediately][com.joinforage.forage.android.ForageSDK.capturePayment]
- * * [Refund a Payment immediately][com.joinforage.forage.android.pos.ForageTerminalSDK.refundPayment] (**POS-only**)
- * * [Collect a card PIN to defer payment refund to the server][com.joinforage.forage.android.pos.ForageTerminalSDK.deferPaymentRefund]
+ * * Check a card's balance
+ * * Collect a card PIN to defer payment capture to the server
+ * * Capture a payment immediately
+ * * Refund a Payment immediately (**POS-only**)
+ * * Collect a card PIN to defer payment refund to the server
  * (**POS-only**)
  * ```xml
  * <!-- Example forage_pin_component.xml -->
@@ -126,6 +126,9 @@ abstract class ForagePinElement @JvmOverloads constructor(
         level = DeprecationLevel.WARNING,
         replaceWith = ReplaceWith("")
     )
+    /**
+     * @deprecated setHint (for **PIN** elements) is deprecated.
+     */
     override fun setHint(hint: String) {
         // no-op, deprecated!
     }
@@ -135,6 +138,9 @@ abstract class ForagePinElement @JvmOverloads constructor(
         level = DeprecationLevel.WARNING,
         replaceWith = ReplaceWith("")
     )
+    /**
+     * @deprecated setHintTextColor (for **PIN** elements) is deprecated.
+     */
     override fun setHintTextColor(hintTextColor: Int) {
         // no-op, deprecated!
     }

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForageVaultElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForageVaultElement.kt
@@ -9,6 +9,10 @@ import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.services.vault.AbstractVaultSubmitter
 import com.joinforage.forage.android.core.ui.element.state.ElementState
 
+/**
+ * ⚠️ **Forage developers use this class to manage common attributes across [ForageElement] types.
+ * You don't need to use or worry about it!**
+ */
 abstract class ForageVaultElement<T : ElementState> @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/EditTextState.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/EditTextState.kt
@@ -1,7 +1,7 @@
 package com.joinforage.forage.android.core.ui.element.state
 
 /**
- * An interface that represents the `EditText` state of the [ForageElement][com.joinforage.forage.android.core.ui.ForageElement]
+ * An interface that represents the `EditText` state of the [ForageElement][com.joinforage.forage.android.core.ui.element.ForageElement]
  * as the customer interacts with it.
  * @property isFocused Whether the Element is in focus.
  * @property isBlurred Whether the Element is blurred.

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/ElementState.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/ElementState.kt
@@ -3,7 +3,7 @@ package com.joinforage.forage.android.core.ui.element.state
 import com.joinforage.forage.android.core.ui.element.ElementValidationError
 
 /**
- * An interface that represents the state of the [ForageElement][com.joinforage.forage.android.core.ui.ForageElement]
+ * An interface that represents the state of the [ForageElement][com.joinforage.forage.android.core.ui.element.ForageElement]
  * as the customer interacts with it.
  * @property isEmpty Whether the input value of the Element is empty.
  * @property isValid Whether the input text fails any validation checks, with the exception of the

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/pan/PanEditTextState.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/pan/PanEditTextState.kt
@@ -13,7 +13,7 @@ interface DerivedCardInfo {
 
 /**
  * An interface that represents the state of a
- * [ForagePANEditText][com.joinforage.forage.android.ui.ForagePANEditText] Element.
+ * **ForagePANEditText** Element.
  * @property derivedCardInfo The [DerivedCardInfo] for the card number submitted to the Element.
  */
 interface PanEditTextState : EditTextState {

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/pan/StrictEbtValidator.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/pan/StrictEbtValidator.kt
@@ -3,7 +3,6 @@ package com.joinforage.forage.android.core.ui.element.state.pan
 import com.joinforage.forage.android.core.ui.element.ElementValidationError
 import com.joinforage.forage.android.core.ui.element.IncompleteEbtPanError
 import com.joinforage.forage.android.core.ui.element.InvalidEbtPanError
-import com.joinforage.forage.android.core.ui.element.TooLongEbtPanError
 
 internal class StrictEbtValidator : PanValidator {
     override fun checkIfValid(cardNumber: String): Boolean {
@@ -27,8 +26,6 @@ internal class StrictEbtValidator : PanValidator {
             InvalidEbtPanError
         } else if (tooShortForStateIIN(cardNumber)) {
             IncompleteEbtPanError
-        } else if (tooLongForStateIIN(cardNumber)) {
-            TooLongEbtPanError
         } else {
             null
         }

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/pin/PinEditTextState.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/pin/PinEditTextState.kt
@@ -6,7 +6,7 @@ import com.joinforage.forage.android.core.ui.element.state.FocusState
 
 /**
  * An interface that represents the state of a
- * [ForagePINEditText][com.joinforage.forage.android.core.ui.ForagePINEditText] Element.
+ * **ForagePINEditText** Element.
  * @see [EditTextState][com.joinforage.forage.android.core.ui.element.state.EditTextState]
  */
 interface PinEditTextState : EditTextState {

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
@@ -18,7 +18,7 @@ import com.joinforage.forage.android.core.services.vault.CapturePaymentRepositor
 import com.joinforage.forage.android.core.services.vault.CheckBalanceRepository
 import com.joinforage.forage.android.core.services.vault.DeferPaymentCaptureRepository
 import com.joinforage.forage.android.core.services.vault.TokenizeCardService
-import com.joinforage.forage.android.core.ui.element.ForagePanElement
+import com.joinforage.forage.android.ecom.ui.element.ForagePANEditText
 import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
 
 /**
@@ -38,7 +38,7 @@ import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
  * val forage = ForageSDK()
  * ```
  * @see * [Online-only Android Quickstart](https://docs.joinforage.app/docs/forage-android-quickstart)
- * * [ForageTerminalSDK][com.joinforage.forage.android.pos.ForageTerminalSDK] to process POS
+ * * [ForageTerminalSDK](https://docs.joinforage.app/docs/forage-terminal-android) to process POS
  * Terminal transactions
  */
 class ForageSDK {
@@ -46,8 +46,8 @@ class ForageSDK {
      * Retrieves the ForageConfig for a given ForageElement, or throws an exception if the
      * ForageConfig is not set.
      *
-     * @param element A ForageElement instance
-     * @return The ForageConfig associated with the ForageElement
+     * @param forageConfig A [ForageConfig] instance
+     * @return The [ForageConfig] associated with the ForageElement
      * @throws ForageConfigNotSetException If the ForageConfig is not set for the ForageElement
      */
     private fun _getForageConfigOrThrow(forageConfig: ForageConfig?): ForageConfig {
@@ -62,8 +62,8 @@ class ForageSDK {
     }
 
     /**
-     * Tokenizes an EBT Card via a [ForagePANEdit
-     * Text][com.joinforage.forage.android.ui.ForagePANEditText] Element.
+     * Tokenizes an EBT Card via a
+     * [ForagePANEditText][com.joinforage.forage.android.ecom.ui.element.ForagePANEditText] Element.
      *
      * * On success, the object includes a `ref` token that represents an instance of a Forage
      * [`PaymentMethod`](https://docs.joinforage.app/reference/payment-methods#paymentmethod-object).
@@ -73,7 +73,7 @@ class ForageSDK {
      * * On failure, for example in the case of
      * [`unsupported_bin`](https://docs.joinforage.app/reference/errors#unsupported_bin),
      * the response includes a list of
-     * [ForageError][com.joinforage.forage.android.network.model.ForageError] objects that you can
+     * [ForageError][com.joinforage.forage.android.core.services.forageapi.network.ForageError] objects that you can
      * unpack to programmatically handle the error and display the appropriate
      * customer-facing message based on the `ForageError.code`.
      * ```kotlin
@@ -110,13 +110,14 @@ class ForageSDK {
      * }
      * ```
      * @param params A [TokenizeEBTCardParams] model that passes a [`foragePanEditText`]
-     * [com.joinforage.forage.android.ui.ForagePANEditText] instance, a `customerId`, and a `reusable`
+     * [com.joinforage.forage.android.ecom.ui.element.ForagePANEditText] instance, a `customerId`, and a `reusable`
      * boolean that Forage uses to tokenize an EBT Card.
      * @throws [ForageConfigNotSetException] If the [ForageConfig] is not set for the provided
      * `foragePanEditText`.
      * @see * [SDK errors](https://docs.joinforage.app/reference/errors#sdk-errors) for more
      * information on error handling.
-     * @return A [ForageApiResponse] object. Use [toPaymentMethod()][ForageApiResponse.Success.toPaymentMethod] to convert the `data` string to a [PaymentMethod][com.joinforage.forage.android.model.PaymentMethod].
+     * @return A [ForageApiResponse] object. Use [toPaymentMethod()][ForageApiResponse.Success.toPaymentMethod] to
+     * convert the `data` string to a [PaymentMethod][com.joinforage.forage.android.core.services.forageapi.paymentmethod.PaymentMethod].
      */
     suspend fun tokenizeEBTCard(params: TokenizeEBTCardParams): ForageApiResponse<String> {
         val (foragePanEditText, customerId, reusable) = params
@@ -141,7 +142,7 @@ class ForageSDK {
     /**
      * Checks the balance of a previously created
      * [`PaymentMethod`](https://docs.joinforage.app/reference/payment-methods)
-     * via a [ForagePINEditText][com.joinforage.forage.android.ui.ForagePINEditText] Element.
+     * via a [ForagePINEditText][com.joinforage.forage.android.ecom.ui.element.ForagePINEditText] Element.
      *
      * ⚠️ _FNS prohibits balance inquiries on sites and apps that offer guest checkout. Skip this
      * method if your customers can opt for guest checkout. If guest checkout is not an option, then
@@ -151,7 +152,7 @@ class ForageSDK {
      * * On failure, for example in the case of
      * [`ebt_error_14`](https://docs.joinforage.app/reference/errors#ebt_error_14),
      * the response includes a list of
-     * [ForageError][com.joinforage.forage.android.network.model.ForageError] objects that you can
+     * [ForageError][com.joinforage.forage.android.core.services.forageapi.network.ForageError] objects that you can
      * unpack to programmatically handle the error and display the appropriate
      * customer-facing message based on the `ForageError.code`.
      * ```kotlin
@@ -195,7 +196,7 @@ class ForageSDK {
      * * [Test EBT Cards](https://docs.joinforage.app/docs/test-ebt-cards#balance-inquiry-exceptions)
      * to trigger balance inquiry exceptions during testing.
      * @return A [ForageApiResponse] object. Use [toBalance()][ForageApiResponse.Success.toBalance]
-     * to convert the `data` string to a [Balance][com.joinforage.forage.android.model.Balance].
+     * to convert the `data` string to a [Balance][com.joinforage.forage.android.core.services.forageapi.paymentmethod.Balance].
      */
     suspend fun checkBalance(params: CheckBalanceParams): ForageApiResponse<String> {
         val (foragePinEditText, paymentMethodRef) = params
@@ -239,7 +240,7 @@ class ForageSDK {
      * [`card_not_reusable`](https://docs.joinforage.app/reference/errors#card_not_reusable) or
      * [`ebt_error_51`](https://docs.joinforage.app/reference/errors#ebt_error_51) errors, the
      * response includes a list of
-     * [ForageError][com.joinforage.forage.android.network.model.ForageError] objects that you can
+     * [ForageError][com.joinforage.forage.android.core.services.forageapi.network.ForageError] objects that you can
      * unpack to programmatically handle the error and display the appropriate
      * customer-facing message based on the `ForageError.code`.
      * ```kotlin
@@ -279,7 +280,7 @@ class ForageSDK {
      * }
      *```
      * @param params A [CapturePaymentParams] model that passes a
-     * [`foragePinEditText`][com.joinforage.forage.android.ui.ForagePINEditText]
+     * [`foragePinEditText`][com.joinforage.forage.android.core.ui.element.ForagePinElement]
      * instance and a `paymentRef`, returned by the
      * [Create a Payment](https://docs.joinforage.app/reference/create-a-payment) endpoint, that
      * Forage uses to capture a payment.
@@ -291,7 +292,8 @@ class ForageSDK {
      * on error handling.
      * * [Test EBT Cards](https://docs.joinforage.app/docs/test-ebt-cards#payment-capture-exceptions)
      * to trigger payment capture exceptions during testing.
-     * @return A [ForageApiResponse] object. Use [toPayment()][ForageApiResponse.Success.toPayment] to convert the `data` string to a [Payment][com.joinforage.forage.android.model.Payment].
+     * @return A [ForageApiResponse] object. Use [toPayment()][ForageApiResponse.Success.toPayment] to convert the `data` string to a
+     * [Payment][com.joinforage.forage.android.core.services.forageapi.payment.Payment].
      */
     suspend fun capturePayment(params: CapturePaymentParams): ForageApiResponse<String> {
         val (foragePinEditText, paymentRef) = params
@@ -333,7 +335,7 @@ class ForageSDK {
      * * On success, the `data` property of the [ForageApiResponse.Success] object resolves with an empty string.
      * * On failure, for example in the case of [`expired_session_token`](https://docs.joinforage.app/reference/errors#expired_session_token) errors, the
      * response includes a list of
-     * [ForageError][com.joinforage.forage.android.network.model.ForageError] objects that you can
+     * [ForageError][com.joinforage.forage.android.core.services.forageapi.network.ForageError] objects that you can
      * unpack to programmatically handle the error and display the appropriate
      * customer-facing message based on the `ForageError.code`.
      * ```kotlin
@@ -367,7 +369,7 @@ class ForageSDK {
      * ```
      *
      * @param params A [DeferPaymentCaptureParams] model that passes a
-     * [`foragePinEditText`][com.joinforage.forage.android.ui.ForagePINEditText] instance and a
+     * [`foragePinEditText`][com.joinforage.forage.android.ecom.ui.element.ForagePINEditText] instance and a
      * `paymentRef`, returned by the
      * [Create a Payment](https://docs.joinforage.app/reference/create-a-payment) endpoint, as the
      * DeferPaymentCaptureParams.
@@ -515,10 +517,10 @@ class ForageSDK {
 /**
  * A model that represents the parameters that Forage requires to tokenize an EBT Card.
  * [TokenizeEBTCardParams] are passed to the
- * [tokenizeEBTCard][com.joinforage.forage.android.ForageSDK.tokenizeEBTCard] method.
+ * [tokenizeEBTCard][com.joinforage.forage.android.ecom.services.ForageSDK.tokenizeEBTCard] method.
  *
  * @property foragePanEditText A reference to a [ForagePANEditText] instance.
- * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] must
+ * [setForageConfig][com.joinforage.forage.android.ecom.ui.element.ForagePANEditText.setForageConfig] must
  * be called on the instance before it can be passed.
  * @property customerId A unique ID for the customer making the payment.
  * If using your internal customer ID, then we recommend that you hash the value
@@ -527,7 +529,7 @@ class ForageSDK {
  * to create multiple payments, set to true by default.
  */
 data class TokenizeEBTCardParams(
-    val foragePanEditText: ForagePanElement,
+    val foragePanEditText: ForagePANEditText,
     val customerId: String? = null,
     val reusable: Boolean = true
 )
@@ -535,10 +537,10 @@ data class TokenizeEBTCardParams(
 /**
  * A model that represents the parameters that Forage requires to check a card's balance.
  * [CheckBalanceParams] are passed to the
- * [checkBalance][com.joinforage.forage.android.ForageSDK.checkBalance] method.
+ * [checkBalance][com.joinforage.forage.android.ecom.services.ForageSDK.checkBalance] method.
  *
  * @property foragePinEditText A reference to a [ForagePINEditText] instance.
- * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] must
+ * [setForageConfig][com.joinforage.forage.android.ecom.ui.element.ForagePINEditText.setForageConfig] must
  * be called on the instance before it can be passed.
  * @property paymentMethodRef A unique string identifier for a previously created
  * [`PaymentMethod`](https://docs.joinforage.app/reference/payment-methods) in Forage's database,
@@ -556,10 +558,10 @@ data class CheckBalanceParams(
 /**
  * A model that represents the parameters that Forage requires to capture a payment.
  * [CapturePaymentParams] are passed to the
- * [capturePayment][com.joinforage.forage.android.ForageSDK.capturePayment] method.
+ * [capturePayment][com.joinforage.forage.android.ecom.services.ForageSDK.capturePayment] method.
  *
  * @property foragePinEditText A reference to a [ForagePINEditText] instance.
- * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] must
+ * [setForageConfig][com.joinforage.forage.android.ecom.ui.element.ForagePINEditText.setForageConfig] must
  * be called on the instance before it can be passed.
  * @property paymentRef A unique string identifier for a previously created
  * [`Payment`](https://docs.joinforage.app/reference/payments) in Forage's
@@ -575,16 +577,16 @@ data class CapturePaymentParams(
  * A model that represents the parameters that Forage requires to collect a card PIN and defer
  * the capture of the payment to the server.
  * [DeferPaymentCaptureParams] are passed to the
- * [deferPaymentCapture][com.joinforage.forage.android.ForageSDK.deferPaymentCapture] method.
+ * [deferPaymentCapture][com.joinforage.forage.android.ecom.services.ForageSDK.deferPaymentCapture] method.
  *
  * @see * [Defer EBT payment capture to the server](https://docs.joinforage.app/docs/capture-ebt-payments-server-side)
  * for the related step-by-step guide.
  * * [Capture an EBT Payment](https://docs.joinforage.app/reference/capture-a-payment)
  * for the API endpoint to call after
- * [deferPaymentCapture][com.joinforage.forage.android.ForageSDK.deferPaymentCapture].
+ * [deferPaymentCapture][com.joinforage.forage.android.ecom.services.ForageSDK.deferPaymentCapture].
  *
  * @property foragePinEditText A reference to a [ForagePINEditText] instance.
- * [setForageConfig][com.joinforage.forage.android.ui.ForageElement.setForageConfig] must
+ * [setForageConfig][com.joinforage.forage.android.core.ui.element.ForagePanElement.setForageConfig] must
  * be called on the instance before it can be passed.
  * @property paymentRef A unique string identifier for a previously created
  * [`Payment`](https://docs.joinforage.app/reference/payments) in Forage's

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/vault/bt/BTResponseParser.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/vault/bt/BTResponseParser.kt
@@ -6,7 +6,7 @@ import com.joinforage.forage.android.core.services.forageapi.network.ForageError
 import com.joinforage.forage.android.core.services.forageapi.network.UnknownErrorApiResponse
 import com.joinforage.forage.android.core.services.vault.VaultResponseParser
 
-class BTResponseParser(btRes: Result<Any?>) : VaultResponseParser {
+internal class BTResponseParser(btRes: Result<Any?>) : VaultResponseParser {
     override val isNullResponse: Boolean = false
     override val vaultErrorMsg: String = btRes.exceptionOrNull().toString()
     override val rawResponse: String = btRes.toString()

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/vault/bt/BaseResponseRegExp.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/vault/bt/BaseResponseRegExp.kt
@@ -1,6 +1,6 @@
 package com.joinforage.forage.android.ecom.services.vault.bt
 
-open class BaseResponseRegExp(res: Result<Any?>) {
+internal open class BaseResponseRegExp(res: Result<Any?>) {
     private val bodyRegex = ("HTTP response body: (.+?)\\n".toRegex())
     private val statusCodeRegex = "HTTP response code: (\\d+)".toRegex()
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/vault/forage/RosettaResponseParser.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/vault/forage/RosettaResponseParser.kt
@@ -3,7 +3,7 @@ package com.joinforage.forage.android.ecom.services.vault.forage
 import com.joinforage.forage.android.core.services.forageapi.network.ForageApiResponse
 import com.joinforage.forage.android.core.services.vault.VaultResponseParser
 
-class RosettaResponseParser(rosettaResponse: ForageApiResponse<String>) : VaultResponseParser {
+internal class RosettaResponseParser(rosettaResponse: ForageApiResponse<String>) : VaultResponseParser {
     override val isNullResponse: Boolean = false
 
     // Unlike VGS and Basis Theory, Vault-specific errors are handled in

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/vault/vgs/VGSResponseParser.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/vault/vgs/VGSResponseParser.kt
@@ -8,7 +8,7 @@ import com.joinforage.forage.android.core.services.vault.VaultResponseParser
 import com.verygoodsecurity.vgscollect.core.model.network.VGSResponse
 import org.json.JSONException
 
-class VGSResponseParser(vgsRes: VGSResponse?) : VaultResponseParser {
+internal class VGSResponseParser(vgsRes: VGSResponse?) : VaultResponseParser {
     override val isNullResponse: Boolean
     override val vaultError: ForageApiResponse.Failure?
     override val forageError: ForageApiResponse.Failure?

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePANEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePANEditText.kt
@@ -6,11 +6,10 @@ import com.joinforage.forage.android.R
 import com.joinforage.forage.android.core.ui.element.ForagePanElement
 
 /**
- * A [ForageElement] that securely collects a customer's card number. You need a [ForagePANEditText]
+ * A [ForageElement][com.joinforage.forage.android.core.ui.element.ForageElement] that securely
+ * collects a customer's card number. You need a [ForagePANEditText]
  * to call the ForageSDK online-only method to
- * [tokenize an EBT Card][com.joinforage.forage.android.ForageSDK.tokenizeEBTCard], or
- * the ForageTerminalSDK POS method to
- * [tokenize a card][com.joinforage.forage.android.pos.ForageTerminalSDK.tokenizeCard].
+ * [tokenize an EBT Card][com.joinforage.forage.android.ecom.services.ForageSDK.tokenizeEBTCard]
  */
 class ForagePANEditText @JvmOverloads constructor(
     context: Context,

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePINEditText.kt
@@ -22,14 +22,11 @@ import com.joinforage.forage.android.ecom.ui.vault.forage.RosettaPinElement
 import com.launchdarkly.sdk.android.LDConfig
 
 /**
- * A [ForageElement] that securely collects a card PIN. You need a [ForagePINEditText] to call
- * the ForageSDK online-only or ForageTerminalSDK POS methods that:
- * * [Check a card's balance][com.joinforage.forage.android.ForageSDK.checkBalance]
- * * [Collect a card PIN to defer payment capture to the server][com.joinforage.forage.android.ForageSDK.deferPaymentCapture]
- * * [Capture a payment immediately][com.joinforage.forage.android.ForageSDK.capturePayment]
- * * [Refund a Payment immediately][com.joinforage.forage.android.pos.ForageTerminalSDK.refundPayment] (**POS-only**)
- * * [Collect a card PIN to defer payment refund to the server][com.joinforage.forage.android.pos.ForageTerminalSDK.deferPaymentRefund]
- * (**POS-only**)
+ * A [ForageElement][com.joinforage.forage.android.core.ui.element.ForageElement] that securely collects a card PIN. You need a [ForagePINEditText] to call
+ * the [ForageSDK][com.joinforage.forage.android.ecom.services.ForageSDK] methods that:
+ * * [Check a card's balance][com.joinforage.forage.android.ecom.services.ForageSDK.checkBalance]
+ * * [Collect a card PIN to defer payment capture to the server][com.joinforage.forage.android.ecom.services.ForageSDK.deferPaymentCapture]
+ * * [Capture a payment immediately][com.joinforage.forage.android.ecom.services.ForageSDK.capturePayment]
  * ```xml
  * <!-- Example forage_pin_component.xml -->
  * <?xml version="1.0" encoding="utf-8"?>
@@ -137,6 +134,25 @@ class ForagePINEditText @JvmOverloads constructor(
             forageConfig ->
         initWithForageConfig(forageConfig)
     }
+
+    /**
+     * Sets the necessary [ForageConfig] configuration properties for a [ForagePINEditText].
+     * **[setForageConfig] must be called before any other methods can be executed on the Element.**
+     * ```kotlin
+     * // Example: Call setForageConfig on a ForagePINEditText Element
+     * val foragePinEditText = root?.findViewById<ForagePINEditText>(
+     *     R.id.balanceForagePinEditText
+     * )
+     * foragePinEditText.setForageConfig(
+     *     ForageConfig(
+     *         merchantId = "mid/<merchant_id>",
+     *         sessionToken = "<session_token>"
+     *     )
+     * )
+     * ```
+     *
+     * @param forageConfig A [ForageConfig] instance that specifies a `merchantId` and `sessionToken`.
+     */
     override fun setForageConfig(forageConfig: ForageConfig) {
         forageConfigManager.forageConfig = forageConfig
     }

--- a/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/pan/PanInputStateTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/pan/PanInputStateTest.kt
@@ -2,7 +2,6 @@ package com.joinforage.forage.android.core.element.state.pan
 
 import com.joinforage.forage.android.core.ui.element.IncompleteEbtPanError
 import com.joinforage.forage.android.core.ui.element.InvalidEbtPanError
-import com.joinforage.forage.android.core.ui.element.TooLongEbtPanError
 import com.joinforage.forage.android.core.ui.element.state.pan.PanInputState
 import com.joinforage.forage.android.core.ui.element.state.pan.USState
 import com.joinforage.forage.android.core.ui.element.state.pan.WhitelistedCardsValidator
@@ -79,7 +78,6 @@ class StrictForEmptyInputTest {
 
         assertThat(state.isValid).isFalse
         assertThat(state.isComplete).isFalse
-        assertThat(state.validationError).isEqualTo(TooLongEbtPanError)
         assertThat(state.usState).isEqualTo(USState.MAINE)
     }
 


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

- left comments throughout the PR to facilitate the review

Here are some changes:
- ⚠️ @devinmorgan Removed deprecated `TooLongEbtPanError`, was previously marked as "Deprecated"
- ⚠️ @devinmorgan Use `foragePanEditText: ForagePANEditText` instead of `foragePanEditText: ForagePanElement`
- Made internal-only vault parsing logic internal
- Fixed KDoc [references/links](https://kotlinlang.org/docs/kotlin-doc.html#links-to-elements)
- **USE only *core* KDoc references** (no ecom or POS references)
  - e.g. `[ForageElement][com.joinforage....ecom...]` inside a core file is not allowed! 
  - removed POS-specific Kdoc comments

<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why

- To prepare v4.0.0 release and updated docs!

## Test Plan

- ✅ Ran Dokka locally!

## Demo

### [Docs demo link](https://6670b327ab3297602f82df50--effervescent-sable-00774e.netlify.app/)
 
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How

<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
Can be released as-is! 

**I'll manually publish the updated SDK reference docs before 6/20**