### PR TITLE
Support `@styles/...` on `RosettaPinElement`

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/forage/RosettaPinElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/forage/RosettaPinElement.kt
@@ -38,14 +38,8 @@ internal class RosettaPinElement @JvmOverloads constructor(
     private val _editText: EditText
 
     init {
-        context.obtainStyledAttributes(attrs, R.styleable.ForagePINEditText, defStyleAttr, 0).apply {
-            try {
-                _editText = buildEditText(attrs)
-                registerEventListeners()
-            } finally {
-                recycle()
-            }
-        }
+        _editText = buildEditText(attrs, defStyleAttr)
+        registerEventListeners()
     }
 
     override fun getVaultSubmitter(
@@ -98,9 +92,9 @@ internal class RosettaPinElement @JvmOverloads constructor(
         _editText.setHintTextColor(hintTextColor)
     }
 
-    private fun buildEditText(attrs: AttributeSet? = null): EditText {
+    private fun buildEditText(attrs: AttributeSet? = null, defStyleAttr: Int): EditText {
         val defaultRadius = resources.getDimension(R.dimen.default_horizontal_field)
-        val typedArray: TypedArray = context.obtainStyledAttributes(attrs, R.styleable.ForagePINEditText)
+        val typedArray: TypedArray = context.obtainStyledAttributes(attrs, R.styleable.ForagePINEditText, defStyleAttr, 0)
         val boxCornerRadius = typedArray.getDimension(R.styleable.ForagePINEditText_boxCornerRadius, defaultRadius)
 
         try {

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/catalog/CatalogFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/catalog/CatalogFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import com.joinforage.android.example.R
 import com.joinforage.android.example.databinding.FragmentCatalogBinding
 import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
@@ -42,7 +43,7 @@ class CatalogFragment : Fragment() {
         // the other ForagePINEditText in the catalog which was
         // created via XML and has some XML styles associated
         // with it.
-        val dynamicPinEditText = ForagePINEditText(requireContext(), null)
+        val dynamicPinEditText = ForagePINEditText(requireContext(), null, R.attr.catalogPinStyleRef)
         binding.root.addView(dynamicPinEditText)
 
         dynamicPinEditText.setForageConfig(forageConfig)

--- a/sample-app/src/main/res/layout/fragment_catalog.xml
+++ b/sample-app/src/main/res/layout/fragment_catalog.xml
@@ -21,7 +21,7 @@
 
     <com.joinforage.forage.android.ecom.ui.element.ForagePINEditText
             android:id="@+id/foragePinEditText"
-            style="@style/ForagePINEditTextStyle"
+            style="@style/CatalogPinStyle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent"

--- a/sample-app/src/main/res/values/attrs.xml
+++ b/sample-app/src/main/res/values/attrs.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <attr name="catalogPinStyleRef" format="reference" />
+
     <!-- TokenizeFragment -->
     <!-- Theme attribute for the ForagePANEditText on the tokenize fragment. -->
     <attr name="tokenizeForagePANEditTextStyle" format="reference" />

--- a/sample-app/src/main/res/values/styles.xml
+++ b/sample-app/src/main/res/values/styles.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <style name="CatalogPinStyle">
+        <!--        <item name="elementHeight">120dp</item>-->
+        <!--        <item name="elementWidth">120dp</item>-->
+        <!--        <item name="inputHeight">80dp</item>-->
+        <!--        <item name="inputWidth">100dp</item>-->
+        <item name="boxBackgroundColor">#85DE6B</item>
+        <item name="textColor">#ffffff</item>
+        <item name="boxStrokeWidth">8dp</item>
+        <item name="textSize">16sp</item>
+        <item name="pinBoxStrokeColor">#800080</item>
+        <item name="boxCornerRadius">8dp</item>
+    </style>
+
     <style name="DefaultForagePANEditTextStyle" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
         <item name="panBoxStrokeColor">@color/purple_700</item>
         <item name="cornerRadius">@dimen/corner_radius</item>

--- a/sample-app/src/main/res/values/themes.xml
+++ b/sample-app/src/main/res/values/themes.xml
@@ -1,6 +1,10 @@
 <resources>
     <!-- Base application theme. -->
     <style name="Theme.ForageAndroid" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <item name="catalogPinStyleRef" type="style">
+            @style/CatalogPinStyle
+        </item>
+
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Modifies `RosettaPinElement` to support styling via `@style/...`. This PR also updates the Catalog view of the the Sample App so that the xml-rendered `ForagePINEditText` and the dynamically created `ForagPINEditText` point to the same style.
 
<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
Previously, the `RosettaPinElement` could not be styled this way, which made it cumbersome to style dynamically created `ForagePINEditTexts`. 
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
- ❌ No new tests since this is just styling changes
- ✅ By the time this PR get's merged in, both Devin and Danilo will have manually tested this extensively.

## Demo

### Before the Fix
In the dynamically rendered `ForagePINEditText`, the `RosettaPinElement` does not show the intended style.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/IfyQmT9sZxXL1kIgYI4y/f25d00e1-9805-48dd-a6a1-9fd097998398.png)


### After the Fix
Now both `RosettaPinElement` and BT's `TextElement` show the desired styles for the xml-rendered and dynamically-rendered `ForagePINEditText`s
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/IfyQmT9sZxXL1kIgYI4y/992edf4a-3996-42a9-9da7-319ee9511776.png)


<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
Can be rolled out immediately
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
