### PR TITLE
Move LD facilities into /ecom

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/forageapi/polling/PollingService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/forageapi/polling/PollingService.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.delay
 // this variable was introduced to break the dependence
 // on Launch Darkly so LD can be moved to Ecom
 // from core since Pos does not use LD
-val TEMPOARAY_polling_intervals = longArrayOf(1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000)
+internal val TEMPOARAY_polling_intervals = longArrayOf(1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000)
 
 internal class PollingService(
     private val messageStatusService: MessageStatusService,

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/forageapi/polling/PollingService.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/forageapi/polling/PollingService.kt
@@ -3,9 +3,14 @@ package com.joinforage.forage.android.core.services.forageapi.polling
 import com.joinforage.forage.android.core.services.forageapi.network.ForageApiResponse
 import com.joinforage.forage.android.core.services.forageapi.network.ForageError
 import com.joinforage.forage.android.core.services.getJitterAmount
-import com.joinforage.forage.android.core.services.launchdarkly.LDManager
 import com.joinforage.forage.android.core.services.telemetry.Log
 import kotlinx.coroutines.delay
+
+// we'll be nuking the whole concept of polling soon
+// this variable was introduced to break the dependence
+// on Launch Darkly so LD can be moved to Ecom
+// from core since Pos does not use LD
+val TEMPOARAY_polling_intervals = longArrayOf(1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000)
 
 internal class PollingService(
     private val messageStatusService: MessageStatusService,
@@ -23,7 +28,7 @@ internal class PollingService(
         logger.addAttribute("content_id", contentId)
 
         var attempt = 1
-        val pollingIntervals = LDManager.getPollingIntervals(logger)
+        val pollingIntervals = TEMPOARAY_polling_intervals
 
         while (true) {
             logger.i(

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/launchdarkly/LDManager.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/launchdarkly/LDManager.kt
@@ -1,4 +1,4 @@
-package com.joinforage.forage.android.core.services.launchdarkly
+package com.joinforage.forage.android.ecom.services.launchdarkly
 
 import android.app.Application
 import com.joinforage.forage.android.core.services.VaultType

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePINEditText.kt
@@ -10,7 +10,7 @@ import com.joinforage.forage.android.core.services.EnvConfig
 import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.core.services.ForageConfigNotSetException
 import com.joinforage.forage.android.core.services.VaultType
-import com.joinforage.forage.android.core.services.launchdarkly.LDManager
+import com.joinforage.forage.android.ecom.services.launchdarkly.LDManager
 import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.services.vault.AbstractVaultSubmitter
 import com.joinforage.forage.android.core.ui.VaultWrapper

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/LaunchDarklyTest.kt
@@ -3,11 +3,11 @@ package com.joinforage.forage.android.network.data
 import android.app.Application
 import androidx.test.platform.app.InstrumentationRegistry
 import com.joinforage.forage.android.core.services.VaultType
-import com.joinforage.forage.android.core.services.launchdarkly.ALWAYS_ROSETTA_PERCENT
-import com.joinforage.forage.android.core.services.launchdarkly.ALWAYS_THIRD_PARTY_PERCENT
-import com.joinforage.forage.android.core.services.launchdarkly.LDFlags
-import com.joinforage.forage.android.core.services.launchdarkly.LDManager
-import com.joinforage.forage.android.core.services.launchdarkly.computeVaultType
+import com.joinforage.forage.android.ecom.services.launchdarkly.ALWAYS_ROSETTA_PERCENT
+import com.joinforage.forage.android.ecom.services.launchdarkly.ALWAYS_THIRD_PARTY_PERCENT
+import com.joinforage.forage.android.ecom.services.launchdarkly.LDFlags
+import com.joinforage.forage.android.ecom.services.launchdarkly.LDManager
+import com.joinforage.forage.android.ecom.services.launchdarkly.computeVaultType
 import com.launchdarkly.sdk.LDValue
 import com.launchdarkly.sdk.android.LDConfig
 import com.launchdarkly.sdk.android.integrations.TestData


### PR DESCRIPTION
## What
* Moves `LDManager` and related LaunchDarkly functionality from the core services to the Ecom services.

<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
Only the Ecom repo uses LD. To reflect this truth, the LD service needs to live in `/ecom` instead of `/core` 
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- ✅ Unit tests have been updated
- ❌ Passing CI tests and unit tests are sufficient

## Demo
N/A just implementation details
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
I've marked this PR to merge when ready
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
