### PR TITLE
Simplify PinTextWatcher

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/textwatcher/PinTextWatcher.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/textwatcher/PinTextWatcher.kt
@@ -2,11 +2,8 @@ package com.joinforage.forage.android.core.ui.textwatcher
 
 import android.text.Editable
 import android.text.TextWatcher
-import android.widget.EditText
 
-internal class PinTextWatcher(
-    private val editText: EditText
-) : TextWatcher {
+internal class PinTextWatcher : TextWatcher {
     private var onInputChangeEvent: ((Boolean, Boolean) -> Unit)? = null
 
     fun onInputChangeEvent(callback: (Boolean, Boolean) -> Unit) {
@@ -22,8 +19,9 @@ internal class PinTextWatcher(
     }
 
     override fun afterTextChanged(editable: Editable) {
-        val isValidAndComplete = editText.length() == 4
-        val isEmpty = editText.length() == 0
+        val len = editable.toString().length
+        val isValidAndComplete = len == 4
+        val isEmpty = len == 0
         onInputChangeEvent?.invoke(isValidAndComplete, isEmpty)
     }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/rosetta/RosettaPinElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/vault/rosetta/RosettaPinElement.kt
@@ -200,7 +200,7 @@ internal class RosettaPinElement @JvmOverloads constructor(
     }
 
     private fun registerTextWatcher() {
-        val pinTextWatcher = PinTextWatcher(_editText)
+        val pinTextWatcher = PinTextWatcher()
         pinTextWatcher.onInputChangeEvent { isComplete, isEmpty ->
             inputState = inputState.handleChangeEvent(
                 isComplete = isComplete,

--- a/forage-android/src/test/java/com/joinforage/forage/android/ui/PinTextWatcherTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/ui/PinTextWatcherTest.kt
@@ -13,7 +13,7 @@ class PinTextWatcherTest {
     @Test
     fun `ensure afterTextChanged event is fired correctly`() {
         val editText = EditText(ApplicationProvider.getApplicationContext())
-        val watcher = PinTextWatcher(editText)
+        val watcher = PinTextWatcher()
         editText.addTextChangedListener(watcher)
 
         // mutable state to help us test the callback


### PR DESCRIPTION
## What
Drop `PinTextWatcher` 's internal `EditText` field and just use passed `editable` argument instead

<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
Reduce implementation complexity
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- ✅ I've updated the appropriate unit tests
- ❌ CI tests and unit tests are sufficient

## Demo
N/A it's just implementation details
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
I've marked this PR to merge when ready
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
