### PR TITLE
Support method chaining in forage Logger

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/telemetry/Log.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/telemetry/Log.kt
@@ -13,10 +13,10 @@ import kotlin.random.Random
 
 internal interface Log {
     fun initializeDD(context: Context, config: ForageConfig)
-    fun d(msg: String, attributes: Map<String, Any?> = emptyMap())
-    fun i(msg: String, attributes: Map<String, Any?> = emptyMap())
-    fun w(msg: String, attributes: Map<String, Any?> = emptyMap())
-    fun e(msg: String, throwable: Throwable? = null, attributes: Map<String, Any?> = emptyMap())
+    fun d(msg: String, attributes: Map<String, Any?> = emptyMap()): Log
+    fun i(msg: String, attributes: Map<String, Any?> = emptyMap()): Log
+    fun w(msg: String, attributes: Map<String, Any?> = emptyMap()): Log
+    fun e(msg: String, throwable: Throwable? = null, attributes: Map<String, Any?> = emptyMap()): Log
     fun getTraceIdValue(): String
     fun addAttribute(key: String, value: Any?): Log
 
@@ -70,20 +70,24 @@ internal interface Log {
                 logger?.addAttribute(TRACE_ID, traceId)
             }
 
-            override fun d(msg: String, attributes: Map<String, Any?>) {
-                logger?.d(msg, attributes = attributes)
+            override fun d(msg: String, attributes: Map<String, Any?>): Log {
+                logger!!.d(msg, attributes = attributes)
+                return this
             }
 
-            override fun i(msg: String, attributes: Map<String, Any?>) {
-                logger?.i(msg, attributes = attributes)
+            override fun i(msg: String, attributes: Map<String, Any?>): Log {
+                logger!!.i(msg, attributes = attributes)
+                return this
             }
 
-            override fun w(msg: String, attributes: Map<String, Any?>) {
-                logger?.w(msg, attributes = attributes)
+            override fun w(msg: String, attributes: Map<String, Any?>): Log {
+                logger!!.w(msg, attributes = attributes)
+                return this
             }
 
-            override fun e(msg: String, throwable: Throwable?, attributes: Map<String, Any?>) {
-                logger?.e(msg, throwable, attributes)
+            override fun e(msg: String, throwable: Throwable?, attributes: Map<String, Any?>): Log {
+                logger!!.e(msg, throwable, attributes)
+                return this
             }
 
             override fun getTraceIdValue(): String {
@@ -102,13 +106,13 @@ internal interface Log {
         private val SILENT = object : Log {
             override fun initializeDD(context: Context, config: ForageConfig) {}
 
-            override fun d(msg: String, attributes: Map<String, Any?>) {}
+            override fun d(msg: String, attributes: Map<String, Any?>): Log = this
 
-            override fun i(msg: String, attributes: Map<String, Any?>) {}
+            override fun i(msg: String, attributes: Map<String, Any?>): Log = this
 
-            override fun w(msg: String, attributes: Map<String, Any?>) {}
+            override fun w(msg: String, attributes: Map<String, Any?>): Log = this
 
-            override fun e(msg: String, throwable: Throwable?, attributes: Map<String, Any?>) {}
+            override fun e(msg: String, throwable: Throwable?, attributes: Map<String, Any?>): Log = this
 
             override fun getTraceIdValue(): String { return "" }
 

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
@@ -127,7 +127,7 @@ class ForageSDK {
         val logger = Log.getInstance()
             .addAttribute("merchant_ref", merchantId)
             .addAttribute("customer_id", customerId)
-        logger.i("[ForageSDK] Tokenizing Payment Method")
+            .i("[ForageSDK] Tokenizing Payment Method")
 
         val tokenizeCardService = ServiceFactory(sessionToken, merchantId, logger)
             .createTokenizeCardService()
@@ -206,7 +206,7 @@ class ForageSDK {
         val logger = Log.getInstance()
             .addAttribute("merchant_ref", merchantId)
             .addAttribute("payment_method_ref", paymentMethodRef)
-        logger.i("[ForageSDK] Called checkBalance for Payment Method $paymentMethodRef")
+            .i("[ForageSDK] Called checkBalance for Payment Method $paymentMethodRef")
 
         // This block is used for Metrics Tracking!
         // ------------------------------------------------------
@@ -303,7 +303,7 @@ class ForageSDK {
         val logger = Log.getInstance()
             .addAttribute("merchant_ref", merchantId)
             .addAttribute("payment_ref", paymentRef)
-        logger.i("[ForageSDK] Called capturePayment for Payment $paymentRef")
+            .i("[ForageSDK] Called capturePayment for Payment $paymentRef")
 
         // This block is used for Metrics Tracking!
         // ------------------------------------------------------
@@ -392,7 +392,7 @@ class ForageSDK {
         val logger = Log.getInstance()
             .addAttribute("merchant_ref", merchantId)
             .addAttribute("payment_ref", paymentRef)
-        logger.i("[ForageSDK] Called deferPaymentCapture for Payment $paymentRef")
+            .i("[ForageSDK] Called deferPaymentCapture for Payment $paymentRef")
 
         val deferPaymentCaptureService = ServiceFactory(sessionToken, merchantId, logger)
             .createDeferPaymentCaptureRepository(foragePinEditText)

--- a/forage-android/src/test/java/com/joinforage/forage/android/mock/MockLogger.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/mock/MockLogger.kt
@@ -41,19 +41,21 @@ internal class MockLogger : Log {
         return
     }
 
-    override fun d(msg: String, attributes: Map<String, Any?>) {
-        return
+    override fun d(msg: String, attributes: Map<String, Any?>): MockLogger {
+        return this
     }
 
-    override fun i(msg: String, attributes: Map<String, Any?>) {
+    override fun i(msg: String, attributes: Map<String, Any?>): MockLogger {
         infoLogs.add(LogEntry(msg, cumulativeAttributes.plus(attributes)))
+        return this
     }
 
-    override fun w(msg: String, attributes: Map<String, Any?>) {
+    override fun w(msg: String, attributes: Map<String, Any?>): MockLogger {
         warnLogs.add(LogEntry(msg, cumulativeAttributes.plus(attributes)))
+        return this
     }
 
-    override fun e(msg: String, throwable: Throwable?, attributes: Map<String, Any?>) {
+    override fun e(msg: String, throwable: Throwable?, attributes: Map<String, Any?>): MockLogger {
         errorLogs.add(
             LogEntry(
                 msg,
@@ -61,6 +63,7 @@ internal class MockLogger : Log {
                 error = throwable
             )
         )
+        return this
     }
 
     override fun addAttribute(key: String, value: Any?): Log {


### PR DESCRIPTION

<!-- Update your title to prefix with your ticket number -->

## What
1. Each `Log` method now returns the current instance (`this`).
2. Updated implementations of `Log` interface to reflect this change.
<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
This change allows for a fluent interface when using the `Log` methods, making the logging implementation more expressive and chaining multiple log actions in a more concise way.

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- ✅ Existing unit tests have been updated
- ❌ Passing CI and unit tests are sufficient 

## Demo
N/A implementation detail

## How
I've marked this PR to merge once eligibility
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
