### PR TITLE
Reduce verbosity of Metrics facilities

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/telemetry/Metrics.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/telemetry/Metrics.kt
@@ -1,6 +1,7 @@
 package com.joinforage.forage.android.core.services.telemetry
 
 import com.joinforage.forage.android.core.services.VaultType
+import com.joinforage.forage.android.core.services.forageapi.network.ForageApiResponse
 
 internal object MetricsConstants {
     const val PATH = "path"
@@ -72,22 +73,8 @@ internal enum class EventName(val value: String) {
     }
 }
 
-internal interface PerformanceMeasurer {
-    fun start()
-    fun end()
-    fun logResult()
-}
-
-internal interface NetworkMonitor : PerformanceMeasurer {
-    fun setPath(path: String): NetworkMonitor
-    fun setMethod(method: String): NetworkMonitor
-    fun setHttpStatusCode(code: Int): NetworkMonitor
-    fun setForageErrorCode(errorCode: String): NetworkMonitor
-}
-
-internal abstract class ResponseMonitor(metricsLogger: Log? = Log.getInstance()) : NetworkMonitor {
-    private var startTime: Long? = null
-    private var endTime: Long? = null
+internal abstract class ResponseMonitor<T>(metricsLogger: Log? = Log.getInstance()) {
+    private var startTime: Long
 
     private var logger: Log? = null
     private var responseAttributes: MutableMap<String, Any> = mutableMapOf()
@@ -95,48 +82,32 @@ internal abstract class ResponseMonitor(metricsLogger: Log? = Log.getInstance())
     init {
         logger = metricsLogger
         responseAttributes[MetricsConstants.LOG_TYPE] = LogType.METRIC
-    }
-
-    override fun start() {
         startTime = System.nanoTime()
     }
 
-    override fun end() {
-        endTime = System.nanoTime()
-    }
-
-    override fun setPath(path: String): NetworkMonitor {
+    fun setPath(path: String): ResponseMonitor<T> {
         responseAttributes[MetricsConstants.PATH] = path
         return this
     }
 
-    override fun setMethod(method: String): NetworkMonitor {
+    fun setMethod(method: String): ResponseMonitor<T> {
         responseAttributes[MetricsConstants.METHOD] = method
         return this
     }
 
-    override fun setHttpStatusCode(code: Int): NetworkMonitor {
+    fun setHttpStatusCode(code: Int): ResponseMonitor<T> {
         responseAttributes[MetricsConstants.HTTP_STATUS] = code
         return this
     }
 
-    override fun setForageErrorCode(errorCode: String): NetworkMonitor {
+    fun setForageErrorCode(errorCode: String): ResponseMonitor<T> {
         responseAttributes[MetricsConstants.FORAGE_ERROR_CODE] = errorCode
         return this
     }
 
-    override fun logResult() {
-        val defaultVal = Long.MIN_VALUE
-        val start = startTime ?: defaultVal
-        val end = endTime ?: defaultVal
-
-        if (start == defaultVal || end == defaultVal) {
-            logger?.e("[Metrics] Missing startTime or endTime. Could not log metric.")
-            return
-        }
-
-        responseAttributes[MetricsConstants.RESPONSE_TIME_MS] = calculateDuration(start, end)
-
+    fun logResult() {
+        val end = System.nanoTime()
+        responseAttributes[MetricsConstants.RESPONSE_TIME_MS] = calculateDuration(startTime, end)
         logWithResponseAttributes(metricsLogger = logger, responseAttributes = responseAttributes)
     }
 
@@ -153,7 +124,7 @@ internal abstract class ResponseMonitor(metricsLogger: Log? = Log.getInstance())
     functions. The timer begins when a balance or capture request is submitted to VGS/BT
     and ends when a response is received by the SDK.
      */
-internal class VaultProxyResponseMonitor(vault: VaultType, userAction: UserAction, metricsLogger: Log?) : ResponseMonitor(metricsLogger) {
+internal class VaultProxyResponseMonitor(vault: VaultType, userAction: UserAction, metricsLogger: Log?) : ResponseMonitor<VaultProxyResponseMonitor>(metricsLogger) {
     private var vaultType: VaultType? = null
     private var userAction: UserAction? = null
     private var eventName: EventName = EventName.VAULT_RESPONSE
@@ -161,12 +132,6 @@ internal class VaultProxyResponseMonitor(vault: VaultType, userAction: UserActio
     init {
         this.vaultType = vault
         this.userAction = userAction
-    }
-
-    internal companion object {
-        internal fun newMeasurement(vault: VaultType, userAction: UserAction, metricsLogger: Log?): VaultProxyResponseMonitor {
-            return VaultProxyResponseMonitor(vault, userAction, metricsLogger)
-        }
     }
 
     override fun logWithResponseAttributes(
@@ -216,7 +181,7 @@ internal class VaultProxyResponseMonitor(vault: VaultType, userAction: UserActio
     Timer Begins -> [GET] EncryptionKey -> [GET] PaymentMethod -> [POST] to VGS/BT ->
     [GET] Poll for Response -> [GET] PaymentMethod -> Timer Ends -> Return Balance
      */
-internal class CustomerPerceivedResponseMonitor(vault: VaultType, userAction: UserAction, metricsLogger: Log?) : ResponseMonitor(metricsLogger) {
+internal class CustomerPerceivedResponseMonitor(vault: VaultType, userAction: UserAction, metricsLogger: Log?) : ResponseMonitor<CustomerPerceivedResponseMonitor>(metricsLogger) {
     private var vaultType: VaultType? = null
     private var userAction: UserAction? = null
     private var eventOutcome: EventOutcome? = null
@@ -227,15 +192,31 @@ internal class CustomerPerceivedResponseMonitor(vault: VaultType, userAction: Us
         this.userAction = userAction
     }
 
-    internal companion object {
-        internal fun newMeasurement(vault: VaultType, vaultAction: UserAction, metricsLogger: Log?): CustomerPerceivedResponseMonitor {
-            return CustomerPerceivedResponseMonitor(vault, vaultAction, metricsLogger)
-        }
-    }
-
     fun setEventOutcome(eventOutcome: EventOutcome): CustomerPerceivedResponseMonitor {
         this.eventOutcome = eventOutcome
         return this
+    }
+
+    /**
+     * Determines the outcome of a Forage API response,
+     * to report the measurement to the Telemetry service.
+     *
+     * This involves stopping the measurement timer,
+     * marking the Metrics event as a success or failure,
+     * and if the event is a failure, setting the Forage error code.
+     */
+    fun setEventOutcome(apiResponse: ForageApiResponse<String>): CustomerPerceivedResponseMonitor {
+        val outcome = if (apiResponse is ForageApiResponse.Failure) {
+            if (apiResponse.errors.isNotEmpty()) {
+                setForageErrorCode(apiResponse.errors[0].code)
+                setHttpStatusCode(apiResponse.errors[0].httpStatusCode)
+            }
+            EventOutcome.FAILURE
+        } else {
+            setHttpStatusCode(200)
+            EventOutcome.SUCCESS
+        }
+        return setEventOutcome(outcome)
     }
 
     override fun logWithResponseAttributes(

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/vault/AbstractVaultSubmitter.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/vault/AbstractVaultSubmitter.kt
@@ -73,7 +73,6 @@ internal abstract class AbstractVaultSubmitter(
         proxyResponseMonitor
             .setPath(params.path)
             .setMethod("POST")
-            .start()
         // ==========================================================
 
         val vaultProxyRequest = buildProxyRequest(
@@ -83,7 +82,6 @@ internal abstract class AbstractVaultSubmitter(
         ).setPath(params.path).setParams(params)
 
         val forageResponse = submitProxyRequest(vaultProxyRequest)
-        proxyResponseMonitor.end()
 
         // FNS requirement to clear the PIN after each submission
         collector.clearText()

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
@@ -224,7 +224,7 @@ class ForageSDK {
             paymentMethodRef = paymentMethodRef,
             sessionToken = sessionToken
         )
-        measurement.setEventOutcome(response)
+        measurement.setEventOutcome(response).logResult()
 
         return response
     }
@@ -320,7 +320,7 @@ class ForageSDK {
             paymentRef = paymentRef,
             sessionToken = sessionToken
         )
-        measurement.setEventOutcome(response)
+        measurement.setEventOutcome(response).logResult()
 
         return response
     }

--- a/forage-android/src/test/java/com/joinforage/forage/android/core/telemetry/metrics/ResponseMonitorTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/core/telemetry/metrics/ResponseMonitorTest.kt
@@ -17,7 +17,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
-internal class TestResponseMonitor(metricsLogger: Log?) : ResponseMonitor(metricsLogger) {
+internal class TestResponseMonitor(metricsLogger: Log?) : ResponseMonitor<TestResponseMonitor>(metricsLogger) {
     override fun logWithResponseAttributes(
         metricsLogger: Log?,
         responseAttributes: Map<String, Any>
@@ -28,36 +28,13 @@ internal class TestResponseMonitor(metricsLogger: Log?) : ResponseMonitor(metric
 
 @RunWith(RobolectricTestRunner::class)
 class ResponseMonitorTest {
-    @Test
-    fun `Test response monitor should log error if start isn't called`() {
-        val mockLogger = MockLogger()
-        val testResponseMonitor = TestResponseMonitor(mockLogger)
-        testResponseMonitor.end()
-        testResponseMonitor.logResult()
-        Assertions.assertThat(mockLogger.errorLogs.count()).isEqualTo(1)
-        Assertions.assertThat(mockLogger.infoLogs.count()).isEqualTo(0)
-        Assertions.assertThat(mockLogger.errorLogs[0].getMessage()).isEqualTo("[Metrics] Missing startTime or endTime. Could not log metric.")
-    }
-
-    @Test
-    fun `Test response monitor should log error if end isn't called`() {
-        val mockLogger = MockLogger()
-        val testResponseMonitor = TestResponseMonitor(mockLogger)
-        testResponseMonitor.end()
-        testResponseMonitor.logResult()
-        Assertions.assertThat(mockLogger.errorLogs.count()).isEqualTo(1)
-        Assertions.assertThat(mockLogger.infoLogs.count()).isEqualTo(0)
-        Assertions.assertThat(mockLogger.errorLogs[0].getMessage()).isEqualTo("[Metrics] Missing startTime or endTime. Could not log metric.")
-    }
 
     @Test
     fun `Test response monitor should calculate duration`() {
         val mockLogger = MockLogger()
         val testResponseMonitor = TestResponseMonitor(mockLogger)
-        testResponseMonitor.start()
         // Simulate some network delay
         Thread.sleep(100)
-        testResponseMonitor.end()
         testResponseMonitor.logResult()
         Assertions.assertThat(mockLogger.errorLogs.count()).isEqualTo(0)
         Assertions.assertThat(mockLogger.infoLogs.count()).isEqualTo(1)
@@ -71,8 +48,6 @@ class ResponseMonitorTest {
     fun `Vault proxy monitor should log error if path is not set`() {
         val mockLogger = MockLogger()
         val vaultProxyResponseMonitor = VaultProxyResponseMonitor(vault = VaultType.VGS_VAULT_TYPE, userAction = UserAction.CAPTURE, mockLogger)
-        vaultProxyResponseMonitor.start()
-        vaultProxyResponseMonitor.end()
         vaultProxyResponseMonitor.setMethod("POST").setHttpStatusCode(200).logResult()
         Assertions.assertThat(mockLogger.errorLogs.count()).isEqualTo(1)
         Assertions.assertThat(mockLogger.infoLogs.count()).isEqualTo(0)
@@ -83,8 +58,6 @@ class ResponseMonitorTest {
     fun `Vault proxy monitor should log error if method is not set`() {
         val mockLogger = MockLogger()
         val vaultProxyResponseMonitor = VaultProxyResponseMonitor(vault = VaultType.VGS_VAULT_TYPE, userAction = UserAction.CAPTURE, mockLogger)
-        vaultProxyResponseMonitor.start()
-        vaultProxyResponseMonitor.end()
         vaultProxyResponseMonitor.setPath("this/is/test/path/").setHttpStatusCode(200).logResult()
         Assertions.assertThat(mockLogger.errorLogs.count()).isEqualTo(1)
         Assertions.assertThat(mockLogger.infoLogs.count()).isEqualTo(0)
@@ -95,8 +68,6 @@ class ResponseMonitorTest {
     fun `Vault proxy monitor should log error if status code is not set`() {
         val mockLogger = MockLogger()
         val vaultProxyResponseMonitor = VaultProxyResponseMonitor(vault = VaultType.VGS_VAULT_TYPE, userAction = UserAction.CAPTURE, mockLogger)
-        vaultProxyResponseMonitor.start()
-        vaultProxyResponseMonitor.end()
         vaultProxyResponseMonitor.setPath("this/is/test/path/").setMethod("POST").logResult()
         Assertions.assertThat(mockLogger.errorLogs.count()).isEqualTo(1)
         Assertions.assertThat(mockLogger.infoLogs.count()).isEqualTo(0)
@@ -112,8 +83,6 @@ class ResponseMonitorTest {
         val path = "this/is/test/path/"
         val method = "POST"
         val statusCode = 200
-        vaultProxyResponseMonitor.start()
-        vaultProxyResponseMonitor.end()
         vaultProxyResponseMonitor.setPath(path).setMethod(method).setHttpStatusCode(statusCode).logResult()
 
         Assertions.assertThat(mockLogger.errorLogs.count()).isEqualTo(0)
@@ -145,8 +114,6 @@ class ResponseMonitorTest {
     fun `Customer perceived monitor should log error if outcome type is not set`() {
         val mockLogger = MockLogger()
         val customerPerceivedResponseMonitor = CustomerPerceivedResponseMonitor(vault = VaultType.VGS_VAULT_TYPE, userAction = UserAction.CAPTURE, mockLogger)
-        customerPerceivedResponseMonitor.start()
-        customerPerceivedResponseMonitor.end()
         customerPerceivedResponseMonitor.logResult()
         Assertions.assertThat(mockLogger.errorLogs.count()).isEqualTo(1)
         Assertions.assertThat(mockLogger.infoLogs.count()).isEqualTo(0)
@@ -159,8 +126,6 @@ class ResponseMonitorTest {
         val vaultType = VaultType.VGS_VAULT_TYPE
         val userAction = UserAction.CAPTURE
         val roundTripResponseMonitor = CustomerPerceivedResponseMonitor(vault = vaultType, userAction = userAction, mockLogger)
-        roundTripResponseMonitor.start()
-        roundTripResponseMonitor.end()
         roundTripResponseMonitor.setEventOutcome(EventOutcome.SUCCESS).setHttpStatusCode(200).logResult()
 
         Assertions.assertThat(mockLogger.errorLogs.count()).isEqualTo(0)


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
This pull request refactors the telemetry metrics logic in the Forage Android SDK. The key changes include:

- Removed redundant `start` and `end` methods from `PerformanceMeasurer` and `NetworkMonitor` interfaces.
- Support method chaining in abstract `ResponseMonitor` class  (via generics)
- Drop unnecessary factory methods and interfaces from `VaultProxyResponseMonitor` and `CustomerPerceivedResponseMonitor`.
- Move `processApiResponseForMetrics` logic from `ForageSDK` to `Metrics`
<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
Reduce implementation and usage complexity, improve maintainability, and enhance the flexibility.
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- ✅ I've updated unit tests for this change. <!-- If not, why? -->
- ❌ Passing CI tests and unit tests is sufficient<!-- If so, please describe how to test below. -->

## Demo
N/A just implementation details
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
I've marked this PR to merge when ready
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
