### PR TITLE
Move two methods up one level in class hierarchy

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePinElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePinElement.kt
@@ -7,7 +7,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import com.joinforage.forage.android.R
+import com.joinforage.forage.android.core.services.EnvConfig
 import com.joinforage.forage.android.core.services.VaultType
+import com.joinforage.forage.android.core.services.telemetry.Log
+import com.joinforage.forage.android.core.services.vault.AbstractVaultSubmitter
 import com.joinforage.forage.android.core.ui.VaultWrapper
 import com.joinforage.forage.android.core.ui.element.state.pin.PinEditTextState
 
@@ -77,6 +80,13 @@ abstract class ForagePinElement @JvmOverloads constructor(
     override fun clearText() {
         vault.clearText()
     }
+
+    override fun showKeyboard() = vault.showKeyboard()
+
+    override fun getVaultSubmitter(
+        envConfig: EnvConfig,
+        logger: Log
+    ): AbstractVaultSubmitter = vault.getVaultSubmitter(envConfig, logger)
 
     // While the events that ForageElements expose mirrors the
     // blur, focus, change etc events of an Android view,

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePinElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePinElement.kt
@@ -81,12 +81,16 @@ abstract class ForagePinElement @JvmOverloads constructor(
         vault.clearText()
     }
 
-    override fun showKeyboard() = vault.showKeyboard()
+    override fun showKeyboard() {
+        vault.showKeyboard()
+    }
 
     override fun getVaultSubmitter(
         envConfig: EnvConfig,
         logger: Log
-    ): AbstractVaultSubmitter = vault.getVaultSubmitter(envConfig, logger)
+    ): AbstractVaultSubmitter {
+        return vault.getVaultSubmitter(envConfig, logger)
+    }
 
     // While the events that ForageElements expose mirrors the
     // blur, focus, change etc events of an Android view,

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
@@ -11,7 +11,6 @@ import com.joinforage.forage.android.core.services.forageapi.paymentmethod.Payme
 import com.joinforage.forage.android.core.services.forageapi.polling.MessageStatusService
 import com.joinforage.forage.android.core.services.forageapi.polling.PollingService
 import com.joinforage.forage.android.core.services.telemetry.CustomerPerceivedResponseMonitor
-import com.joinforage.forage.android.core.services.telemetry.EventOutcome
 import com.joinforage.forage.android.core.services.telemetry.Log
 import com.joinforage.forage.android.core.services.telemetry.UserAction
 import com.joinforage.forage.android.core.services.vault.CapturePaymentRepository

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePINEditText.kt
@@ -10,14 +10,13 @@ import com.joinforage.forage.android.core.services.EnvConfig
 import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.core.services.ForageConfigNotSetException
 import com.joinforage.forage.android.core.services.VaultType
-import com.joinforage.forage.android.ecom.services.launchdarkly.LDManager
 import com.joinforage.forage.android.core.services.telemetry.Log
-import com.joinforage.forage.android.core.services.vault.AbstractVaultSubmitter
 import com.joinforage.forage.android.core.ui.VaultWrapper
 import com.joinforage.forage.android.core.ui.element.DynamicEnvElement
 import com.joinforage.forage.android.core.ui.element.ForageConfigManager
 import com.joinforage.forage.android.core.ui.element.ForagePinElement
 import com.joinforage.forage.android.core.ui.getLogoImageViewLayout
+import com.joinforage.forage.android.ecom.services.launchdarkly.LDManager
 import com.joinforage.forage.android.ecom.ui.vault.bt.BTVaultWrapper
 import com.joinforage.forage.android.ecom.ui.vault.rosetta.RosettaPinElement
 import com.launchdarkly.sdk.android.LDConfig
@@ -201,11 +200,6 @@ class ForagePINEditText @JvmOverloads constructor(
 
     internal fun getForageConfig() = forageConfigManager.forageConfig
 
-    override fun getVaultSubmitter(
-        envConfig: EnvConfig,
-        logger: Log
-    ): AbstractVaultSubmitter = vault.getVaultSubmitter(envConfig, logger)
-
     override var typeface: Typeface?
         get() = if (vault == btVaultWrapper) btVaultWrapper.typeface else rosettaPinElement.typeface
         set(value) {
@@ -214,6 +208,4 @@ class ForagePINEditText @JvmOverloads constructor(
             btVaultWrapper.typeface = value
             rosettaPinElement.typeface = value
         }
-
-    override fun showKeyboard() = vault.showKeyboard()
 }


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Move `getVaultSubmitter()` and `showKeyboard()` methods from `ForagePINEditText` to parent `ForagePinElement` class.
<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
These methods do not care about the specific vault or details that `ForagePINEditText` would specify in Pos or Ecom land. Moving these methods to the parent is a small reducing code duplication / maintenance burden win
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
CI tests pass

## Demo
N/A

## How
Can be rolled out immediately 
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
