### PR TITLE
Update sdk + sample app to use single error

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
@@ -99,7 +99,7 @@ class ForageSDK {
      *                 }
      *             }
      *             is ForageApiResponse.Failure -> {
-     *                 val error = response.errors[0]
+     *                 val error = response.error
      *                 // handle error.code here
      *             }
      *         }
@@ -173,7 +173,7 @@ class ForageSDK {
      *                 }
      *             }
      *             is ForageApiResponse.Failure -> {
-     *                 val error = response.errors[0]
+     *                 val error = response.error
      *                 // handle error.code here
      *             }
      *         }
@@ -261,7 +261,7 @@ class ForageSDK {
      *                     // Unpack payment.ref, payment.receipt, etc.
      *                 }
      *                 is ForageApiResponse.Failure -> {
-     *                     val error = response.errors[0]
+     *                     val error = response.error
      *
      *                     // handle Insufficient Funds error
      *                     if (error.code == "ebt_error_51") {

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/EncryptionKeyServiceTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/EncryptionKeyServiceTest.kt
@@ -74,6 +74,6 @@ class EncryptionKeyServiceTest : MockServerSuite() {
         val clientError = response as ForageApiResponse.Failure
         val expectedDetail = "Authentication credentials were not provided."
 
-        assertThat(clientError.errors[0].message).isEqualTo(expectedDetail)
+        assertThat(clientError.error.message).isEqualTo(expectedDetail)
     }
 }

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/TokenizeCardServiceTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/TokenizeCardServiceTest.kt
@@ -164,7 +164,7 @@ class TokenizeCardServiceTest : MockServerSuite() {
         assertThat(paymentMethodResponse).isExactlyInstanceOf(ForageApiResponse.Failure::class.java)
 
         val response = paymentMethodResponse as ForageApiResponse.Failure
-        assertThat(response.errors[0]).isEqualTo(
+        assertThat(response.error).isEqualTo(
             ForageError(400, "cannot_parse_request_body", "EBT Cards must be 16-19 digits long!")
         )
     }

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/CapturePaymentRepositoryTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/CapturePaymentRepositoryTest.kt
@@ -65,7 +65,7 @@ class CapturePaymentRepositoryTest : MockServerSuite() {
         assertThat(response).isExactlyInstanceOf(ForageApiResponse.Failure::class.java)
         val clientError = response as ForageApiResponse.Failure
 
-        assertThat(clientError.errors[0].message).contains("Authentication credentials were not provided.")
+        assertThat(clientError.error.message).contains("Authentication credentials were not provided.")
     }
 
     @Test
@@ -93,9 +93,9 @@ class CapturePaymentRepositoryTest : MockServerSuite() {
         val expectedMessage = "Cannot find payment."
         val expectedForageCode = "not_found"
         val expectedStatusCode = 404
-        assertThat(failureResponse.errors[0].message).isEqualTo(expectedMessage)
-        assertThat(failureResponse.errors[0].code).isEqualTo(expectedForageCode)
-        assertThat(failureResponse.errors[0].httpStatusCode).isEqualTo(expectedStatusCode)
+        assertThat(failureResponse.error.message).isEqualTo(expectedMessage)
+        assertThat(failureResponse.error.code).isEqualTo(expectedForageCode)
+        assertThat(failureResponse.error.httpStatusCode).isEqualTo(expectedStatusCode)
     }
 
     @Test
@@ -112,9 +112,9 @@ class CapturePaymentRepositoryTest : MockServerSuite() {
         val expectedForageCode = "not_found"
         val expectedStatusCode = 404
 
-        assertThat(failureResponse.errors[0].message).isEqualTo(expectedMessage)
-        assertThat(failureResponse.errors[0].code).isEqualTo(expectedForageCode)
-        assertThat(failureResponse.errors[0].httpStatusCode).isEqualTo(expectedStatusCode)
+        assertThat(failureResponse.error.message).isEqualTo(expectedMessage)
+        assertThat(failureResponse.error.code).isEqualTo(expectedForageCode)
+        assertThat(failureResponse.error.httpStatusCode).isEqualTo(expectedStatusCode)
     }
 
     companion object {

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/CheckBalanceRepositoryTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/CheckBalanceRepositoryTest.kt
@@ -45,7 +45,7 @@ class CheckBalanceRepositoryTest : MockServerSuite() {
         assertThat(response).isExactlyInstanceOf(ForageApiResponse.Failure::class.java)
         val clientError = response as ForageApiResponse.Failure
 
-        assertThat(clientError.errors[0].message).contains("Authentication credentials were not provided.")
+        assertThat(clientError.error.message).contains("Authentication credentials were not provided.")
     }
 
     @Test

--- a/forage-android/src/test/java/com/joinforage/forage/android/network/data/DeferPaymentCaptureRepositoryTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/network/data/DeferPaymentCaptureRepositoryTest.kt
@@ -49,7 +49,7 @@ class DeferPaymentCaptureRepositoryTest : MockServerSuite() {
         assertThat(response).isExactlyInstanceOf(ForageApiResponse.Failure::class.java)
         val clientError = response as ForageApiResponse.Failure
 
-        assertThat(clientError.errors[0].message).contains("Authentication credentials were not provided.")
+        assertThat(clientError.error.message).contains("Authentication credentials were not provided.")
     }
 
     @Test
@@ -78,9 +78,9 @@ class DeferPaymentCaptureRepositoryTest : MockServerSuite() {
         val expectedMessage = "Cannot find payment."
         val expectedForageCode = "not_found"
         val expectedStatusCode = 404
-        assertThat(failureResponse.errors[0].message).isEqualTo(expectedMessage)
-        assertThat(failureResponse.errors[0].code).isEqualTo(expectedForageCode)
-        assertThat(failureResponse.errors[0].httpStatusCode).isEqualTo(expectedStatusCode)
+        assertThat(failureResponse.error.message).isEqualTo(expectedMessage)
+        assertThat(failureResponse.error.code).isEqualTo(expectedForageCode)
+        assertThat(failureResponse.error.httpStatusCode).isEqualTo(expectedStatusCode)
     }
 
     @Test
@@ -97,9 +97,9 @@ class DeferPaymentCaptureRepositoryTest : MockServerSuite() {
         val expectedForageCode = "not_found"
         val expectedStatusCode = 404
 
-        assertThat(failureResponse.errors[0].message).isEqualTo(expectedMessage)
-        assertThat(failureResponse.errors[0].code).isEqualTo(expectedForageCode)
-        assertThat(failureResponse.errors[0].httpStatusCode).isEqualTo(expectedStatusCode)
+        assertThat(failureResponse.error.message).isEqualTo(expectedMessage)
+        assertThat(failureResponse.error.code).isEqualTo(expectedForageCode)
+        assertThat(failureResponse.error.httpStatusCode).isEqualTo(expectedStatusCode)
     }
 
     @Test
@@ -119,9 +119,9 @@ class DeferPaymentCaptureRepositoryTest : MockServerSuite() {
         assertThat(response).isExactlyInstanceOf(ForageApiResponse.Failure::class.java)
         val failureResponse = response as ForageApiResponse.Failure
 
-        assertThat(failureResponse.errors[0].message).isEqualTo(expectedMessage)
-        assertThat(failureResponse.errors[0].code).isEqualTo(expectedForageCode)
-        assertThat(failureResponse.errors[0].httpStatusCode).isEqualTo(expectedStatusCode)
+        assertThat(failureResponse.error.message).isEqualTo(expectedMessage)
+        assertThat(failureResponse.error.code).isEqualTo(expectedForageCode)
+        assertThat(failureResponse.error.httpStatusCode).isEqualTo(expectedStatusCode)
     }
 
     @Test

--- a/forage-android/src/test/java/com/joinforage/forage/android/vault/BasisTheoryPinSubmitterTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/vault/BasisTheoryPinSubmitterTest.kt
@@ -138,11 +138,11 @@ class BasisTheoryPinSubmitterTest() : MockServerSuite() {
         val result = submitter.submitProxyRequest(VaultProxyRequest.emptyRequest())
 
         assertTrue(result is ForageApiResponse.Failure)
-        val firstError = (result as ForageApiResponse.Failure).errors[0]
+        val error = (result as ForageApiResponse.Failure).error
         assertEquals("[basis_theory] Received error from basis_theory: $basisTheoryErrorMessage", mockLogger.errorLogs.last().getMessage())
-        assertEquals("Unknown Server Error", firstError.message)
-        assertEquals(500, firstError.httpStatusCode)
-        assertEquals("unknown_server_error", firstError.code)
+        assertEquals("Unknown Server Error", error.message)
+        assertEquals(500, error.httpStatusCode)
+        assertEquals("unknown_server_error", error.code)
     }
 
     @Test
@@ -159,7 +159,7 @@ class BasisTheoryPinSubmitterTest() : MockServerSuite() {
         val result = submitter.submitProxyRequest(VaultProxyRequest.emptyRequest())
 
         assertTrue(result is ForageApiResponse.Failure)
-        val firstError = (result as ForageApiResponse.Failure).errors[0]
+        val error = (result as ForageApiResponse.Failure).error
         assertEquals(
             """
         [basis_theory] Received ForageError from basis_theory: Code: too_many_requests
@@ -170,9 +170,9 @@ class BasisTheoryPinSubmitterTest() : MockServerSuite() {
             """.trimIndent(),
             mockLogger.errorLogs.last().getMessage()
         )
-        assertEquals("Request was throttled, please try again later.", firstError.message)
-        assertEquals(400, firstError.httpStatusCode)
-        assertEquals("too_many_requests", firstError.code)
+        assertEquals("Request was throttled, please try again later.", error.message)
+        assertEquals(400, error.httpStatusCode)
+        assertEquals("too_many_requests", error.code)
     }
 
     @Test
@@ -186,13 +186,13 @@ class BasisTheoryPinSubmitterTest() : MockServerSuite() {
         val result = submitter.submitProxyRequest(VaultProxyRequest.emptyRequest())
 
         assertTrue(result is ForageApiResponse.Failure)
-        val firstError = (result as ForageApiResponse.Failure).errors[0]
+        val error = (result as ForageApiResponse.Failure).error
         assertEquals(
             "[basis_theory] Received malformed response from basis_theory: Failure(java.lang.RuntimeException: Malformed error!)",
             mockLogger.errorLogs.last().getMessage()
         )
-        assertEquals("Unknown Server Error", firstError.message)
-        assertEquals(500, firstError.httpStatusCode)
-        assertEquals("unknown_server_error", firstError.code)
+        assertEquals("Unknown Server Error", error.message)
+        assertEquals(500, error.httpStatusCode)
+        assertEquals("unknown_server_error", error.code)
     }
 }

--- a/forage-android/src/test/java/com/joinforage/forage/android/vault/RosettaPinSubmitterTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/vault/RosettaPinSubmitterTest.kt
@@ -137,7 +137,7 @@ class RosettaPinSubmitterTest() : MockServerSuite() {
         val result = executeSubmit(paymentRef)
         assertTrue(result is ForageApiResponse.Failure)
 
-        val firstError = (result as ForageApiResponse.Failure).errors[0]
+        val error = (result as ForageApiResponse.Failure).error
 
         assertEquals(
             """
@@ -149,9 +149,9 @@ class RosettaPinSubmitterTest() : MockServerSuite() {
             """.trimIndent(),
             mockLogger.errorLogs.last().getMessage()
         )
-        assertEquals("authorization header malformed", firstError.message)
-        assertEquals(401, firstError.httpStatusCode)
-        assertEquals("auth_header_malformed", firstError.code)
+        assertEquals("authorization header malformed", error.message)
+        assertEquals(401, error.httpStatusCode)
+        assertEquals("auth_header_malformed", error.code)
     }
 
     @Test
@@ -162,7 +162,7 @@ class RosettaPinSubmitterTest() : MockServerSuite() {
         val result = executeSubmit(paymentRef)
 
         assertTrue(result is ForageApiResponse.Failure)
-        val firstError = (result as ForageApiResponse.Failure).errors[0]
+        val error = (result as ForageApiResponse.Failure).error
         assertEquals(
             """
             [forage] Received ForageError from forage: Code: missing_merchant_account
@@ -173,9 +173,9 @@ class RosettaPinSubmitterTest() : MockServerSuite() {
             """.trimIndent(),
             mockLogger.errorLogs.last().getMessage()
         )
-        assertEquals("No merchant account FNS number was provided.", firstError.message)
-        assertEquals(401, firstError.httpStatusCode)
-        assertEquals("missing_merchant_account", firstError.code)
+        assertEquals("No merchant account FNS number was provided.", error.message)
+        assertEquals(401, error.httpStatusCode)
+        assertEquals("missing_merchant_account", error.code)
     }
 
     @Test
@@ -186,14 +186,14 @@ class RosettaPinSubmitterTest() : MockServerSuite() {
         val result = executeSubmit(paymentRef)
 
         assertTrue(result is ForageApiResponse.Failure)
-        val firstError = (result as ForageApiResponse.Failure).errors[0]
+        val error = (result as ForageApiResponse.Failure).error
         assertEquals(
             "Failed to send request to Forage Vault.",
             mockLogger.errorLogs.last().getMessage()
         )
-        assertEquals("Unknown Server Error", firstError.message)
-        assertEquals(500, firstError.httpStatusCode)
-        assertEquals("unknown_server_error", firstError.code)
+        assertEquals("Unknown Server Error", error.message)
+        assertEquals(500, error.httpStatusCode)
+        assertEquals("unknown_server_error", error.code)
     }
 
     // The paths dictate which mock server response to expect

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/balance/FlowBalanceViewModel.kt
@@ -75,10 +75,10 @@ class FlowBalanceViewModel @Inject constructor(
                     }
                 }
                 is ForageApiResponse.Failure -> {
-                    Log.d(TAG, "Check Balance Response: ${response.errors[0].message}")
+                    Log.d(TAG, "Check Balance Response: ${response.error.message}")
 
                     _isLoading.value = false
-                    _error.value = response.errors[0].message
+                    _error.value = response.error.message
                 }
             }
         }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/payment/capture/FlowCapturePaymentViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/payment/capture/FlowCapturePaymentViewModel.kt
@@ -60,12 +60,12 @@ class FlowCapturePaymentViewModel @Inject constructor(
                     )
                 }
                 is ForageApiResponse.Failure -> {
-                    Log.d(TAG, "Capture Snap Payment Response: ${response.errors[0].message} Payment: $snapPaymentRef")
+                    Log.d(TAG, "Capture Snap Payment Response: ${response.error.message} Payment: $snapPaymentRef")
 
                     _uiState.value = _uiState.value!!.copy(
                         isLoading = false,
-                        snapResponse = response.errors[0].message,
-                        snapResponseError = response.errors[0].toString()
+                        snapResponse = response.error.message,
+                        snapResponseError = response.error.toString()
                     )
                 }
             }
@@ -92,12 +92,12 @@ class FlowCapturePaymentViewModel @Inject constructor(
                     )
                 }
                 is ForageApiResponse.Failure -> {
-                    Log.d(TAG, "Defer Capture Snap Response: ${response.errors[0].message}")
+                    Log.d(TAG, "Defer Capture Snap Response: ${response.error.message}")
 
                     _uiState.value = _uiState.value!!.copy(
                         isLoading = false,
-                        snapResponse = response.errors[0].message,
-                        snapResponseError = response.errors[0].toString()
+                        snapResponse = response.error.message,
+                        snapResponseError = response.error.toString()
                     )
                 }
             }
@@ -127,12 +127,12 @@ class FlowCapturePaymentViewModel @Inject constructor(
                     )
                 }
                 is ForageApiResponse.Failure -> {
-                    Log.d(TAG, "Capture Cash Payment Response: ${response.errors[0].message}")
+                    Log.d(TAG, "Capture Cash Payment Response: ${response.error.message}")
 
                     _uiState.value = _uiState.value!!.copy(
                         isLoading = false,
-                        cashResponse = response.errors[0].message,
-                        cashResponseError = response.errors[0].toString()
+                        cashResponse = response.error.message,
+                        cashResponseError = response.error.toString()
                     )
                 }
             }
@@ -159,12 +159,12 @@ class FlowCapturePaymentViewModel @Inject constructor(
                     )
                 }
                 is ForageApiResponse.Failure -> {
-                    Log.d(TAG, "Defer Capture Cash Response: ${response.errors[0].message}")
+                    Log.d(TAG, "Defer Capture Cash Response: ${response.error.message}")
 
                     _uiState.value = _uiState.value!!.copy(
                         isLoading = false,
-                        cashResponse = response.errors[0].message,
-                        cashResponseError = response.errors[0].toString()
+                        cashResponse = response.error.message,
+                        cashResponseError = response.error.toString()
                     )
                 }
             }

--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeViewModel.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizeViewModel.kt
@@ -77,7 +77,7 @@ class FlowTokenizeViewModel @Inject constructor(
                 _paymentMethod.value = paymentMethod
             }
             is ForageApiResponse.Failure -> {
-                _error.value = response.errors[0].message
+                _error.value = response.error.message
             }
         }
 


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
We got single-error objects for free from the work in #290. This PR applies that benefit to the rest of our codebase 
<!-- Please include a summary of the change. List any dependencies that are required for this change. -->

## Why
`.error` is less verbose than `.errors[0]`. It also allows the compiler to make stronger type safety guarantees. Before, the compiler would require merchants to handle cases where `.errors[0]` could be thrown or otherwise did not exist. This gets the Android SDK to parity with the iOS and JS SDKs
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- ✅ I've modified unit tests for this change. <!-- If not, why? -->
- ❌ No need to manually test the changes in this PR because the automated and CI tests pass. <!-- If so, please describe how to test below. -->

## Demo
Check out the code changes in the sample app files!
<!-- If applicable, please include a screenshot to this PR description -->
<!-- If applicable, please include a screen recording and post it in #feature-recordings -->

## How
Must be rolled out after #290, but it's planned to be released after the #289 
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond reverting this PR -->
