### PR TITLE
[TW-700] Remove mid/ from Android online-only SDK docs 

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/ForageConfig.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/ForageConfig.kt
@@ -7,8 +7,8 @@ package com.joinforage.forage.android.core.services
  * [setForageConfig][com.joinforage.forage.android.core.ui.element.ForagePanElement.setForageConfig] to
  * configure an Element.
  *
- * @property merchantId A unique Merchant ID that Forage provides during onboarding
- * onboarding preceded by "mid/". For example, `mid/123ab45c67`.
+ * @property merchantId A unique Merchant ID that Forage provides during onboarding, as in
+ * `123ab45c67`.
  * The Merchant ID can be found in the Forage [Sandbox](https://dashboard.sandbox.joinforage.app/login/)
  * or [Production](https://dashboard.joinforage.app/login/) Dashboard.
  *

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForageElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForageElement.kt
@@ -16,7 +16,7 @@ internal interface DynamicEnvElement {
      * )
      * foragePanEditText.setForageConfig(
      *     ForageConfig(
-     *         merchantId = "mid/<merchant_id>",
+     *         merchantId = "<merchant_id>",
      *         sessionToken = "<session_token>"
      *     )
      * )

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePanElement.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/ForagePanElement.kt
@@ -204,7 +204,7 @@ abstract class ForagePanElement @JvmOverloads constructor(
      * )
      * foragePanEditText.setForageConfig(
      *     ForageConfig(
-     *         merchantId = "mid/<merchant_id>",
+     *         merchantId = "<merchant_id>",
      *         sessionToken = "<session_token>"
      *     )
      * )

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/services/ForageSDK.kt
@@ -76,7 +76,7 @@ class ForageSDK {
      * ```kotlin
      * // Example tokenizeEBTCard call in a TokenizeViewModel.kt
      * class TokenizeViewModel : ViewModel() {
-     *     val merchantId = "mid/<merchant_id>"
+     *     val merchantId = "<merchant_id>"
      *     val sessionToken = "<session_token>"
      *
      *     fun tokenizeEBTCard(foragePanEditText: ForagePANEditText) = viewModelScope.launch {
@@ -243,7 +243,7 @@ class ForageSDK {
      * // Example capturePayment call in a PaymentCaptureViewModel.kt
      * class PaymentCaptureViewModel : ViewModel() {
      *     val snapPaymentRef = "s0alzle0fal"
-     *     val merchantId = "mid/<merchant_id>"
+     *     val merchantId = "<merchant_id>"
      *     val sessionToken = "<session_token>"
      *
      *     fun capturePayment(foragePinEditText: ForagePINEditText, paymentRef: String) =
@@ -337,7 +337,7 @@ class ForageSDK {
      * // Example deferPaymentCapture call in a DeferPaymentCaptureViewModel.kt
      * class DeferPaymentCaptureViewModel  : ViewModel() {
      *     val snapPaymentRef = "s0alzle0fal"
-     *     val merchantId = "mid/<merchant_id>"
+     *     val merchantId = "<merchant_id>"
      *     val sessionToken = "<session_token>"
      *
      *     fun deferPaymentCapture(foragePinEditText: ForagePINEditText, paymentRef: String) =

--- a/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePINEditText.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/ecom/ui/element/ForagePINEditText.kt
@@ -171,7 +171,7 @@ class ForagePINEditText @JvmOverloads constructor(
      * )
      * foragePinEditText.setForageConfig(
      *     ForageConfig(
-     *         merchantId = "mid/<merchant_id>",
+     *         merchantId = "<merchant_id>",
      *         sessionToken = "<session_token>"
      *     )
      * )


### PR DESCRIPTION
This PR updates the `merchantId` description and code snippets to reflect the new best practices after PAID-1227 (to no longer use `mid/`). 