### PR TITLE
[SEC-42] Send android logs to PCI compliant datadog endpoints

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/telemetry/Log.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/telemetry/Log.kt
@@ -48,7 +48,9 @@ internal interface Log {
                     clientToken = envConfig.ddClientToken,
                     env = envConfig.FLAVOR.value,
                     variant = envConfig.FLAVOR.value
-                ).build()
+                )
+                    .setProxy("https://pci.browser-intake-datadoghq.com")
+                    .build()
                 Datadog.initialize(context, configuration, TrackingConsent.GRANTED)
                 val logsConfig = LogsConfiguration.Builder().build()
                 Logs.enable(logsConfig)


### PR DESCRIPTION
## What
Title

## Why
We want to send logs to a different server of Datadog's, which has a better compliance posture.

## Helpful research links
- [Datadog Kotlin SDK advanced config](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android/?tab=kotlin#initialization-parameters)
- [PCI compliant log management docs](https://docs.datadoghq.com/data_security/logs/#pci-dss-compliance-for-log-management)