### PR TITLE
Support 16 and 19 Digit Maine PANs

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/pan/PanInputState.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/pan/PanInputState.kt
@@ -20,7 +20,11 @@ internal class PanInputState(
     val validationError: ElementValidationError? = validators
         .map { it.checkForValidationError(normalizedPanText) }
         .firstOrNull { it != null }
-    val usState: USState? = queryForStateIIN(normalizedPanText)?.publicEnum
+
+    // Some states, like Maine, issue PANs with differing
+    // lengths (e.g. 16 and 19). It's Maine in both cases so
+    // doing .firstOrNull supports() is sufficient
+    val usState: USState? = queryForStateIIN(normalizedPanText).firstOrNull()?.publicEnum
 
     fun handleChangeEvent(newPanText: String) = PanInputState(
         newPanText,

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/pan/StateIIN.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/pan/StateIIN.kt
@@ -96,7 +96,9 @@ internal enum class StateIIN(
     KANSAS("601413", 16, USState.KANSAS),
     KENTUCKY("507709", 16, USState.KENTUCKY),
     LOUISIANA("504476", 16, USState.LOUISIANA),
-    MAINE("507703", 19, USState.MAINE),
+    // we found out that Maine has 16 and 19 digit PANs 🤷
+    MAINE16("507703", 16, USState.MAINE),
+    MAINE19("507703", 19, USState.MAINE),
     MARYLAND("600528", 16, USState.MARYLAND),
     MASSACHUSETTS("600875", 18, USState.MASSACHUSETTS),
     MICHIGAN("507711", 16, USState.MICHIGAN),
@@ -133,20 +135,34 @@ internal enum class StateIIN(
 internal fun missingStateIIN(cardNumber: String): Boolean {
     return cardNumber.length < STATE_INN_LENGTH
 }
-internal fun queryForStateIIN(cardNumber: String): StateIIN? {
-    return StateIIN.values().find { cardNumber.startsWith(it.iin) }
+internal fun queryForStateIIN(cardNumber: String): List<StateIIN> {
+    return StateIIN.values().filter { cardNumber.startsWith(it.iin) }
 }
 internal fun hasInvalidStateIIN(cardNumber: String): Boolean {
-    return queryForStateIIN(cardNumber) == null
+    return queryForStateIIN(cardNumber) == listOf<StateIIN>()
 }
 internal fun tooShortForStateIIN(cardNumber: String): Boolean {
-    val iin = queryForStateIIN(cardNumber) ?: return true
-    return cardNumber.length < iin.panLength
+    val matchingIINs = queryForStateIIN(cardNumber)
+    if (matchingIINs.isEmpty()) return true
+
+    val maxPanLength = matchingIINs.maxOf { it.panLength }
+    val matchesAnyLength = matchingIINs.any { cardNumber.length == it.panLength }
+    return cardNumber.length < maxPanLength && !matchesAnyLength
 }
+
 internal fun tooLongForStateIIN(cardNumber: String): Boolean {
-    val iin = queryForStateIIN(cardNumber) ?: return true
-    return cardNumber.length > iin.panLength
+    val matchingIINs = queryForStateIIN(cardNumber)
+    if (matchingIINs.isEmpty()) return true
+
+    // if the card number is not at least as short as of any StateIINs' length
+    // then the card must be longer than all of them and is thus too long
+    return matchingIINs.none { cardNumber.length <= it.panLength }
 }
 internal fun isCorrectLength(cardNumber: String): Boolean {
-    return !tooShortForStateIIN(cardNumber) && !tooLongForStateIIN(cardNumber)
+    val matchingIINs = queryForStateIIN(cardNumber)
+    if (matchingIINs.isEmpty()) return false
+
+    // the card number needs the same length of at least 1 of
+    // allowed StateIINs
+    return matchingIINs.any { cardNumber.length == it.panLength }
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/pan/StateIIN.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/ui/element/state/pan/StateIIN.kt
@@ -96,6 +96,7 @@ internal enum class StateIIN(
     KANSAS("601413", 16, USState.KANSAS),
     KENTUCKY("507709", 16, USState.KENTUCKY),
     LOUISIANA("504476", 16, USState.LOUISIANA),
+
     // we found out that Maine has 16 and 19 digit PANs 🤷
     MAINE16("507703", 16, USState.MAINE),
     MAINE19("507703", 19, USState.MAINE),

--- a/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/pan/PanInputStateTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/pan/PanInputStateTest.kt
@@ -91,6 +91,50 @@ class StrictForEmptyInputTest {
         assertThat(state.validationError).isNull()
         assertThat(state.usState).isEqualTo(USState.SOUTH_DAKOTA)
     }
+
+    @Test
+    fun `16  digit Maine cards numbers are OK `() {
+        val maine16Ok: String = "507703 1111 1111 11" // Maine is 507703
+        val state = PanInputState.forEmptyInput().handleChangeEvent(maine16Ok)
+
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isTrue
+        assertThat(state.validationError).isNull()
+        assertThat(state.usState).isEqualTo(USState.MAINE)
+    }
+
+    @Test
+    fun `17 digit Maine cards numbers are NOT ok `() {
+        val maine17Bad: String = "507703 1111 1111 111" // Maine is 507703
+        val state = PanInputState.forEmptyInput().handleChangeEvent(maine17Bad)
+
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isFalse
+        assertThat(state.validationError).isEqualTo(IncompleteEbtPanError)
+        assertThat(state.usState).isEqualTo(USState.MAINE)
+    }
+
+    @Test
+    fun `18 digit Maine cards numbers are NOT ok `() {
+        val maine18Bad: String = "507703 1111 1111 111 1" // Maine is 507703
+        val state = PanInputState.forEmptyInput().handleChangeEvent(maine18Bad)
+
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isFalse
+        assertThat(state.validationError).isEqualTo(IncompleteEbtPanError)
+        assertThat(state.usState).isEqualTo(USState.MAINE)
+    }
+
+    @Test
+    fun `19 digit Maine cards numbers are OK `() {
+        val maine19Ok: String = "507703 1111 1111 111 11" // Maine is 507703
+        val state = PanInputState.forEmptyInput().handleChangeEvent(maine19Ok)
+
+        assertThat(state.isValid).isTrue
+        assertThat(state.isComplete).isTrue
+        assertThat(state.validationError).isNull()
+        assertThat(state.usState).isEqualTo(USState.MAINE)
+    }
 }
 
 class DEV_ONLY_IntegrationTests {

--- a/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/pan/PanInputStateTest.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/core/element/state/pan/PanInputStateTest.kt
@@ -83,8 +83,8 @@ class StrictForEmptyInputTest {
 
     @Test
     fun `cardNumber is the shared ND-SD card number`() {
-        val longMaineNumber: String = "5081321111111111" // North Dakota/South Dakota is 508132
-        val state = PanInputState.forEmptyInput().handleChangeEvent(longMaineNumber)
+        val longDakotaNumber: String = "5081321111111111" // North Dakota/South Dakota is 508132
+        val state = PanInputState.forEmptyInput().handleChangeEvent(longDakotaNumber)
 
         assertThat(state.isValid).isTrue
         assertThat(state.isComplete).isTrue


### PR DESCRIPTION
## What

Added support for Maine's 16-digit and 19-digit PAN numbers by updating the state IIN validation logic to handle multiple valid PAN lengths for a single state.

## Why

Maine issues EBT cards with both 16 and 19-digit PAN numbers, but our system previously only supported 19-digit PANs. This change ensures we can properly validate and format both PAN lengths.

## Test Plan

- ✅ Added comprehensive unit tests for both 16 and 19-digit Maine PAN validation
- ✅  Manual testing not required as this is covered by unit tests

## Demo
Here's a visual of `ForagePANEditText` playing nicely with Maine's (BIN `507703`) 16 and 19 digit PANs

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/IfyQmT9sZxXL1kIgYI4y/4a5a9f8d-de6b-4faf-adb6-f4a7317d64c5.webm">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/IfyQmT9sZxXL1kIgYI4y/4a5a9f8d-de6b-4faf-adb6-f4a7317d64c5.webm">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/IfyQmT9sZxXL1kIgYI4y/4a5a9f8d-de6b-4faf-adb6-f4a7317d64c5.webm">Maine16and19Pan.webm</video>

## How

This change is self-contained and can be reverted directly if needed. The updates maintain backward compatibility with existing PAN validation for other states.