### PR TITLE
Bump to 4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Forage Android SDK (`v4.0.1`)
+# Forage Android SDK (`v4.2.0`)
 
 You can use the Forage Android SDK to process online-only and/or Terminal POS EBT payments. The SDK provides UI components known as Forage Elements and associated methods that perform payment operations.
 

--- a/forage-android/build.gradle
+++ b/forage-android/build.gradle
@@ -10,7 +10,7 @@ apply plugin: ShadowAarDependenciesPlugin
 
 ext {
     PUBLISH_GROUP_ID = 'com.joinforage'
-    PUBLISH_VERSION = '4.1.0'
+    PUBLISH_VERSION = '4.2.0'
     PUBLISH_ARTIFACT_ID = 'forage-android'
     PUBLISH_DESCRIPTION = 'Forage Android SDK'
     PUBLISH_URL = 'https://github.com/teamforage/forage-android-sdk'


### PR DESCRIPTION
## What

Bump SDK version to 4.2.0 

## Why

We're calling the Maine PAN fix a MINOR not a PATCH


## How

Simple version update that can be reverted if needed.