### PR TITLE
[EXPA-206] Better tolerate defective session tokens

### DIFF
--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/telemetry/LogLogger.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/telemetry/LogLogger.kt
@@ -2,17 +2,23 @@ package com.joinforage.forage.android.core.services.telemetry
 
 import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.core.services.forageapi.network.error.ForageError
+import org.json.JSONException
 import org.json.JSONObject
 
 internal fun extractTenantIdFromToken(
     base64Util: IBase64Util,
     forageConfig: ForageConfig
-): String {
+): String? {
     val token = forageConfig.sessionToken
     val parts = token.split(".")
     val firstPart = parts[0].substringAfter("_")
     val decodedFirstPart = String(base64Util.decode(firstPart))
-    val jsonObject = JSONObject(decodedFirstPart)
+    val jsonObject: JSONObject
+    try {
+        jsonObject = JSONObject(decodedFirstPart)
+    } catch (e: JSONException) {
+        return null
+    }
     return jsonObject.getInt("t").toString() // the "t" key is the tenant id
 }
 


### PR DESCRIPTION
## What
Better tolerate defective session tokens.

Using an access token or a defective session token (like dev_sessionToken1234) would crash the app.

## Why

HSA/FSA for GoPuff

## Test Plan
No new test coverage required.