### PR TITLE
[EXPA-213] Extend payment method models for HSA/FSA

### DIFF
--- a/forage-android/build.gradle
+++ b/forage-android/build.gradle
@@ -132,6 +132,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.18.0'
     testImplementation 'org.json:json:20220924'
     testImplementation 'org.robolectric:robolectric:4.10.3'
+    testImplementation "org.jetbrains.kotlin:kotlin-test:1.8.10"
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
     testImplementation 'com.squareup.moshi:moshi:1.14.0'
     testImplementation 'com.squareup.moshi:moshi-adapters:1.14.0'

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/forageapi/paymentmethod/CreditDebitCard.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/forageapi/paymentmethod/CreditDebitCard.kt
@@ -1,0 +1,16 @@
+package com.joinforage.forage.android.core.services.forageapi.paymentmethod
+
+/**
+ * @property last4 The last 4 digits of the card number.
+ * @property brand
+ * @property expMonth
+ * @property expYear
+ * @property isHsaFsa
+ */
+interface CreditDebitCard : Card {
+    override val last4: String
+    val brand: String
+    val expMonth: Int
+    val expYear: Int
+    val isHsaFsa: Boolean
+}

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/forageapi/paymentmethod/PaymentMethod.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/forageapi/paymentmethod/PaymentMethod.kt
@@ -29,7 +29,15 @@ data class PaymentMethod(
         } else {
             null
         },
-        card = EbtCard(jsonObject.getJSONObject("card")),
+        card = jsonObject.getString("type").let { type ->
+            jsonObject.getJSONObject("card").let { cardJson ->
+                when (type) {
+                    "ebt" -> EbtCard(cardJson)
+                    "credit" -> StripeCreditDebitCard(cardJson)
+                    else -> throw IllegalStateException(type)
+                }
+            }
+        },
         reusable = jsonObject.optBoolean("reusable", true)
     )
 }

--- a/forage-android/src/main/java/com/joinforage/forage/android/core/services/forageapi/paymentmethod/StripeCreditDebitCard.kt
+++ b/forage-android/src/main/java/com/joinforage/forage/android/core/services/forageapi/paymentmethod/StripeCreditDebitCard.kt
@@ -1,0 +1,33 @@
+package com.joinforage.forage.android.core.services.forageapi.paymentmethod
+
+import org.json.JSONObject
+
+/**
+ * @property last4 The last 4 digits of the card number.
+ * @property brand
+ * @property expMonth
+ * @property expYear
+ * @property bin
+ * @property isHsaFsa
+ * @property pspCustomerId
+ * @property paymentMethodId
+ */
+data class StripeCreditDebitCard(
+    override val last4: String,
+    override val brand: String,
+    override val expMonth: Int,
+    override val expYear: Int,
+    override val isHsaFsa: Boolean,
+    val pspCustomerId: String,
+    val paymentMethodId: String
+) : CreditDebitCard {
+    internal constructor(jsonObject: JSONObject) : this(
+        last4 = jsonObject.getString("last_4"),
+        brand = jsonObject.getString("brand"),
+        expMonth = jsonObject.getInt("exp_month"),
+        expYear = jsonObject.getInt("exp_year"),
+        isHsaFsa = jsonObject.getBoolean("is_hsa_fsa"),
+        pspCustomerId = jsonObject.getString("psp_customer_id"),
+        paymentMethodId = jsonObject.getString("payment_method_id")
+    )
+}

--- a/forage-android/src/test/java/com/joinforage/forage/android/model/PaymentMethodModelTests.kt
+++ b/forage-android/src/test/java/com/joinforage/forage/android/model/PaymentMethodModelTests.kt
@@ -3,45 +3,81 @@ package com.joinforage.forage.android.model
 import com.joinforage.forage.android.core.services.forageapi.paymentmethod.EbtBalance
 import com.joinforage.forage.android.core.services.forageapi.paymentmethod.EbtCard
 import com.joinforage.forage.android.core.services.forageapi.paymentmethod.PaymentMethod
+import com.joinforage.forage.android.core.services.forageapi.paymentmethod.StripeCreditDebitCard
 import com.joinforage.forage.android.core.ui.element.state.pan.USState
 import junit.framework.TestCase.assertEquals
 import org.json.JSONObject
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class PaymentMethodModelTests {
     companion object {
         val ref = "abce123"
-        val type = "ebt"
-        val card = EbtCard(
+
+        val ebtType = "ebt"
+        val ebtCard = EbtCard(
             last4 = "4201",
             number = null,
             token = "moss123",
             fingerprint = "fingerprint1234",
             usState = null
         )
-
-        val baseJsonString = """
+        val ebtBaseJsonString = """
             {
                 "ref": "$ref",
-                "type": "$type",
+                "type": "$ebtType",
                 "card": {
-                    "last_4": "${card.last4}",
-                    "token": "${card.token}",
-                    "fingerprint": "${card.fingerprint}"
+                    "last_4": "${ebtCard.last4}",
+                    "token": "${ebtCard.token}",
+                    "fingerprint": "${ebtCard.fingerprint}"
                 }
+            }
+        """.trimIndent()
+
+        val creditType = "credit"
+        val creditCard = StripeCreditDebitCard(
+            last4 = "4201",
+            brand = "visa",
+            expMonth = 12,
+            expYear = 2050,
+            isHsaFsa = true,
+            pspCustomerId = "cus_12345678901234",
+            paymentMethodId = "pm_123456789012345678901234"
+        )
+        val creditBaseJsonString = """
+            {
+                "ref": "$ref",
+                "type": "$creditType",
+                "card": {
+                    "last_4": "${creditCard.last4}",
+                    "brand": "${creditCard.brand}",
+                    "exp_month": ${creditCard.expMonth},
+                    "exp_year": ${creditCard.expYear},
+                    "is_hsa_fsa": ${creditCard.isHsaFsa},
+                    "psp_customer_id": "${creditCard.pspCustomerId}",
+                    "payment_method_id": "${creditCard.paymentMethodId}",
+                }
+            }
+        """.trimIndent()
+
+        val benefitBaseJsonString = """
+            {
+                "ref": "$ref",
+                "type": "benefit",
+                "card": {}
             }
         """.trimIndent()
     }
 
     @Test
-    fun `Without optional fields`() {
-        val paymentMethod = PaymentMethod(baseJsonString)
+    fun `EBT card type without optional fields`() {
+        val paymentMethod = PaymentMethod(ebtBaseJsonString)
 
         assertEquals(
             PaymentMethod(
-                card = card,
+                card = ebtCard,
                 ref = ref,
-                type = type,
+                type = ebtType,
                 balance = null,
                 customerId = null,
                 reusable = true // should default to true
@@ -51,8 +87,30 @@ class PaymentMethodModelTests {
     }
 
     @Test
+    fun `Credit card type without optional fields`() {
+        val paymentMethod = PaymentMethod(creditBaseJsonString)
+
+        assertEquals(
+            PaymentMethod(
+                card = creditCard,
+                ref = ref,
+                type = creditType,
+                balance = null,
+                customerId = null,
+                reusable = true // should default to true
+            ),
+            paymentMethod
+        )
+    }
+
+    @Test
+    fun `Unknown card type without optional fields`() {
+        assertFailsWith<IllegalStateException> { PaymentMethod(benefitBaseJsonString) }
+    }
+
+    @Test
     fun `With null fields`() {
-        val baseJsonObject = JSONObject(baseJsonString)
+        val baseJsonObject = JSONObject(ebtBaseJsonString)
         baseJsonObject.put("balance", JSONObject.NULL)
         baseJsonObject.put("customer_id", JSONObject.NULL)
         baseJsonObject.put("reusable", JSONObject.NULL)
@@ -60,9 +118,9 @@ class PaymentMethodModelTests {
         val paymentMethod = PaymentMethod(baseJsonObject)
         assertEquals(
             PaymentMethod(
-                card = card,
+                card = ebtCard,
                 ref = ref,
-                type = type,
+                type = ebtType,
                 balance = null,
                 customerId = null,
                 reusable = true // should default to true
@@ -82,15 +140,15 @@ class PaymentMethodModelTests {
             """.trimIndent()
         )
 
-        val baseJsonObject = JSONObject(baseJsonString)
+        val baseJsonObject = JSONObject(ebtBaseJsonString)
         baseJsonObject.put("balance", balanceJsonObject)
 
         val paymentMethod = PaymentMethod(baseJsonObject)
         assertEquals(
             PaymentMethod(
-                card = card,
+                card = ebtCard,
                 ref = ref,
-                type = type,
+                type = ebtType,
                 balance = EbtBalance(balanceJsonObject),
                 customerId = null,
                 reusable = true
@@ -103,15 +161,15 @@ class PaymentMethodModelTests {
     fun `With customer id`() {
         val customerId = "customer123"
 
-        val baseJsonObject = JSONObject(baseJsonString)
+        val baseJsonObject = JSONObject(ebtBaseJsonString)
         baseJsonObject.put("customer_id", customerId)
 
         val paymentMethod = PaymentMethod(baseJsonObject)
         assertEquals(
             PaymentMethod(
-                card = card,
+                card = ebtCard,
                 ref = ref,
-                type = type,
+                type = ebtType,
                 balance = null,
                 customerId = customerId,
                 reusable = true
@@ -122,15 +180,15 @@ class PaymentMethodModelTests {
 
     @Test
     fun `With reusable false`() {
-        val baseJsonObject = JSONObject(baseJsonString)
+        val baseJsonObject = JSONObject(ebtBaseJsonString)
         baseJsonObject.put("reusable", false)
 
         val paymentMethod = PaymentMethod(baseJsonObject)
         assertEquals(
             PaymentMethod(
-                card = card,
+                card = ebtCard,
                 ref = ref,
-                type = type,
+                type = ebtType,
                 balance = null,
                 customerId = null,
                 reusable = false
@@ -142,12 +200,12 @@ class PaymentMethodModelTests {
     @Test
     fun `With card (US) state`() {
         val state = "CA"
-        val cardWithState = card.copy(usState = USState.CALIFORNIA)
+        val cardWithState = ebtCard.copy(usState = USState.CALIFORNIA)
 
-        val cardJsonObject = JSONObject(baseJsonString).getJSONObject("card")
+        val cardJsonObject = JSONObject(ebtBaseJsonString).getJSONObject("card")
         cardJsonObject.put("state", state)
 
-        val baseJsonObject = JSONObject(baseJsonString)
+        val baseJsonObject = JSONObject(ebtBaseJsonString)
         baseJsonObject.put("card", cardJsonObject)
 
         val paymentMethod = PaymentMethod(baseJsonObject)
@@ -155,7 +213,7 @@ class PaymentMethodModelTests {
             PaymentMethod(
                 card = cardWithState,
                 ref = ref,
-                type = type,
+                type = ebtType,
                 balance = null,
                 customerId = null,
                 reusable = true


### PR DESCRIPTION
## What
Extend payment method models for HSA/FSA.

Add CreditDebitCard and StripeCreditDebitCard.

## Why
HSA/FSA for GoPuff

## Test Plan
Unit testing