### PR TITLE
[EXPA-265] Hide soft keyboard on submit in sample-app

### DIFF
--- a/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizePaymentSheetFragment.kt
+++ b/sample-app/src/main/java/com/joinforage/android/example/ui/complete/flow/tokenize/FlowTokenizePaymentSheetFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.joinforage.android.example.R
 import com.joinforage.android.example.databinding.FragmentFlowTokenizeCreditBinding
+import com.joinforage.android.example.ext.hideKeyboard
 import com.joinforage.forage.android.core.services.ForageConfig
 import com.joinforage.forage.android.core.services.forageapi.paymentmethod.PaymentMethod
 import com.joinforage.forage.android.ecom.ui.element.ForagePaymentSheet.CombinedElementState
@@ -63,6 +64,7 @@ class FlowTokenizePaymentSheetFragment : Fragment() {
         viewModel.error.observe(viewLifecycleOwner, ::handleErrorChange)
 
         binding.submitButton.setOnClickListener {
+            it.context.hideKeyboard(it)
             viewModel.onSubmit(binding.tokenizeForagePaymentSheet)
         }
 


### PR DESCRIPTION
## What
Hide soft keyboard on submit in sample-app.

## Why
So mobile QA tests can find the element with the result.

## Test Plan
Mobile QA tests