### PR TITLE
[EXPA-582] Update Android Gradle plugin to 8.13.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-android = "8.1.0"
-hiltAndroid = "2.44"
+android = "8.13.2"
+hiltAndroid = "2.58"
 junit = "4.13.2"
-kotlin = "1.8.10"
+kotlin = "2.3.20"
 kotlinxCoroutinesAndroid = "1.6.4"
 lifecycleLivedataKtx = "2.5.1"
 moshi = "1.14.0"
@@ -60,7 +60,8 @@ androidx-navigation-safeargs-kotlin = { id = 'androidx.navigation.safeargs.kotli
 gradle-nexus-publish-plugin = { id = 'io.github.gradle-nexus.publish-plugin', version = '2.0.0' }
 jetbrains-kotlinx-kover = { id = 'org.jetbrains.kotlinx.kover', version = '0.6.1' }
 jetbrains-dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
-com-google-devtools-ksp = { id = "com.google.devtools.ksp", version = "1.8.10-1.0.9" }
-dagger-hilt-android = { id = 'com.google.dagger.hilt.android', version = '2.44' }
+com-google-devtools-ksp = { id = "com.google.devtools.ksp", version = "2.2.21-2.0.4" }
+dagger-hilt-android = { id = 'com.google.dagger.hilt.android', version.ref = "hiltAndroid" }
 org-jetbrains-kotlin-plugin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 org-jetbrains-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.org.jetbrains.kotlin.kapt)
     alias(libs.plugins.com.google.devtools.ksp)
     alias(libs.plugins.org.jetbrains.kotlin.plugin.serialization)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {


### PR DESCRIPTION
## What
Update Android Gradle plugin to 8.13.2. Fix associated fallout.

## Why
Best practices.

## Test Plan

- ❌ I've added unit tests for this change. No code changes.
- ❌ The reviewer should manually test the changes in this PR. Library and ppp builds and runs.