### PR TITLE
PLT-1236 Upgrade and pin actions/checkout to latest

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,7 +21,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v3
@@ -49,7 +50,8 @@ jobs:
           -F "custom_id=${{ env.BROWSERSTACK_CUSTOM_ID }}"
 
       - name: Checkout Integration Test Repo
-        uses: actions/checkout@v3
+        # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: teamforage/mobile-qa-tests
           ref: main

--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -10,7 +10,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/Lint.yaml
+++ b/.github/workflows/Lint.yaml
@@ -13,7 +13,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v3

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
## What
* Upgrade and pin actions/checkout to latest.

## Why
To handle node.js:20 EOL in GitHub Actions.
Latest release: https://github.com/actions/checkout/releases/tag/v6.0.2

## Test Plan
See all GitHub Action workflows run without issue.