### PR TITLE
[PLT-1690, PLT-1692, PLT-1693] Upgrade multiple github actions to latest and pin them

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,13 +22,13 @@ jobs:
     steps:
       - name: Checkout
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
           distribution: 'zulu'
           java-version: 17
@@ -51,7 +51,7 @@ jobs:
 
       - name: Checkout Integration Test Repo
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: teamforage/mobile-qa-tests
           ref: main

--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Checkout
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
@@ -20,13 +20,13 @@ jobs:
         uses: gradle/wrapper-validation-action@v3
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
           distribution: 'zulu'
           java-version: 17
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.9'
           cache: 'pip'

--- a/.github/workflows/Lint.yaml
+++ b/.github/workflows/Lint.yaml
@@ -14,13 +14,13 @@ jobs:
     steps:
       - name: Checkout
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
           distribution: 'zulu'
           java-version: 17

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout repository
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
           java-version: "17"
           distribution: "zulu"
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup NodeJS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 24
 


### PR DESCRIPTION
## What
* Upgrade and pin actions/setup-node to latest.
* Upgrade and pin actions/setup-python to latest.
* Upgrade and pin actions/setup-java to latest.

## Why
To handle node.js:20 EOL in GitHub Actions.
Latest releases:
* https://github.com/actions/setup-node/releases/tag/v6.4.0
* https://github.com/actions/setup-python/releases/tag/v6.2.0
* https://github.com/actions/setup-java/releases/tag/v5.2.0

## Test Plan
See all GitHub Action workflows run without issue.