### PR TITLE
PLT-1695 Move to latest gradle GitHub actions + pinning

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,9 +24,6 @@ jobs:
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v3
-
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
@@ -34,7 +31,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e  # v6.1.0
 
       - name: Run unit tests for the debug build
         run: ./gradlew testDebugUnitTest --stacktrace

--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -16,9 +16,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
-
       - name: Setup JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
@@ -35,7 +32,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e  # v6.1.0
 
       - name: Generate XML coverage report (JaCoCo)
         run: ./gradlew forage-android:koverXmlReport

--- a/.github/workflows/Lint.yaml
+++ b/.github/workflows/Lint.yaml
@@ -16,9 +16,6 @@ jobs:
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v3
-
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
@@ -26,7 +23,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e  # v6.1.0
         with:
           arguments: forage-android:lint
 

--- a/.github/workflows/Lint.yaml
+++ b/.github/workflows/Lint.yaml
@@ -24,8 +24,9 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e  # v6.1.0
-        with:
-          arguments: forage-android:lint
+
+      - name: Run Lint
+        run: ./gradlew forage-android:lint
 
       - uses: github/codeql-action/upload-sarif@v2
         with:

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -21,7 +21,7 @@ jobs:
           cache: "gradle"
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e  # v6.1.0
 
       - name: Generate Dokka documentation
         run: ./gradlew dokkaHtml


### PR DESCRIPTION
## What
* Switch from the deprecated `gradle/gradle-build-action` -> `gradle/actions/setup-gradle` ([docs](https://github.com/gradle/gradle-build-action))
* Pin to latest version
* Drop use of `gradle/wrapper-validation-action` as it's now baked into `setup-gradle` ([docs](https://github.com/gradle/actions/tree/main/wrapper-validation))
* Replace usage of the old `arguments` parameter on the `setup-gradle` action ([docs](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated))

## Why
To handle node.js:20 EOL in GitHub Actions.
Latest releases:
* https://github.com/gradle/actions/releases/tag/v6.1.0

## Test Plan
See all GitHub Action workflows run without issue.